### PR TITLE
followup: remove BullXBrain.Supervisor from application.ex

### DIFF
--- a/lib/bullx/application.ex
+++ b/lib/bullx/application.ex
@@ -21,7 +21,6 @@ defmodule BullX.Application do
       BullXAIAgent.Supervisor,
       BullXGateway.CoreSupervisor,
       BullX.Skills.Supervisor,
-      BullXBrain.Supervisor,
       BullX.Runtime.Supervisor,
       BullXGateway.AdapterSupervisor,
       BullXWeb.Endpoint


### PR DESCRIPTION
## Summary
- Completes #4. Unit 4 worker landed the `bullx_brain/` and `lib/bullx_brain.ex` deletions but hit Edit denial on `lib/bullx/application.ex`, so the `BullXBrain.Supervisor` child reference was left dangling.
- This PR removes the single dangling line.

## Test plan
- [ ] After this PR + #4 merge, `grep BullXBrain lib/bullx/application.ex` returns empty
- [ ] After all 13 deletion PRs land, `mix compile --warnings-as-errors` is clean on feat/reborn

🤖 Generated with [Claude Code](https://claude.com/claude-code)