### PR TITLE
refactor(db): squash migrations to represent current final schema

### DIFF
--- a/app/db/20260611111903_ambitious_pyro.sql
+++ b/app/db/20260611111903_ambitious_pyro.sql
@@ -1,70 +1,84 @@
 CREATE EXTENSION IF NOT EXISTS vector;--> statement-breakpoint
-CREATE TYPE "public"."principal_group_kind" AS ENUM('static', 'computed');--> statement-breakpoint
 CREATE TYPE "public"."agent_type" AS ENUM('llm_agentic_loop');--> statement-breakpoint
 CREATE TYPE "public"."principal_external_identity_kind" AS ENUM('platform_subject', 'channel_actor', 'login_subject', 'outbound_actor');--> statement-breakpoint
+CREATE TYPE "public"."principal_group_kind" AS ENUM('static', 'computed');--> statement-breakpoint
 CREATE TYPE "public"."principal_status" AS ENUM('active', 'disabled');--> statement-breakpoint
 CREATE TYPE "public"."principal_type" AS ENUM('human', 'agent');--> statement-breakpoint
-CREATE TABLE "app_configure" (
-	"key" text NOT NULL,
-	"value" jsonb NOT NULL,
-	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-	CONSTRAINT "key_unique" UNIQUE("key"),
-	CONSTRAINT "app_configure_value_envelope" CHECK (jsonb_typeof("app_configure"."value") = 'object' AND "app_configure"."value" ? 'type' AND "app_configure"."value" ? 'value')
-);
---> statement-breakpoint
-CREATE TABLE "permission_grants" (
+CREATE TABLE "agent_library_container_entries" (
 	"id" uuid PRIMARY KEY NOT NULL,
-	"principal_uid" text,
-	"group_id" uuid,
-	"resource_pattern" text NOT NULL,
-	"action" text NOT NULL,
-	"condition" text DEFAULT 'true' NOT NULL,
-	"description" text,
+	"agent_uid" text NOT NULL,
+	"virtual_path" text NOT NULL,
+	"entry_kind" text DEFAULT 'file' NOT NULL,
+	"source_kind" text NOT NULL,
+	"source_ref" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"content_text" text,
+	"content_bytes" text,
+	"content_media_type" text DEFAULT 'text/plain' NOT NULL,
+	"content_blake3" text NOT NULL,
 	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
-	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-	CONSTRAINT "permission_grants_principal_exclusive" CHECK (("permission_grants"."principal_uid" IS NOT NULL AND "permission_grants"."group_id" IS NULL) OR ("permission_grants"."principal_uid" IS NULL AND "permission_grants"."group_id" IS NOT NULL)),
-	CONSTRAINT "permission_grants_action_no_colon" CHECK (position(':' in "permission_grants"."action") = 0),
-	CONSTRAINT "permission_grants_resource_pattern_present" CHECK (length("permission_grants"."resource_pattern") > 0),
-	CONSTRAINT "permission_grants_action_present" CHECK (length("permission_grants"."action") > 0),
-	CONSTRAINT "permission_grants_metadata_object" CHECK (jsonb_typeof("permission_grants"."metadata") = 'object')
+	"enabled" boolean DEFAULT true NOT NULL,
+	"version" text DEFAULT '1' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone,
+	CONSTRAINT "agent_library_entries_virtual_path_relative" CHECK ("agent_library_container_entries"."virtual_path" !~ '(^/|(^|/)..(/|$)|//)'),
+	CONSTRAINT "agent_library_entries_kind_check" CHECK ("agent_library_container_entries"."entry_kind" in ('file', 'directory')),
+	CONSTRAINT "agent_library_entries_source_check" CHECK ("agent_library_container_entries"."source_kind" in ('soul', 'mission', 'skill_append', 'setting', 'memory', 'system', 'user', 'computer')),
+	CONSTRAINT "agent_library_entries_one_content" CHECK (not ("agent_library_container_entries"."content_text" is not null and "agent_library_container_entries"."content_bytes" is not null)),
+	CONSTRAINT "agent_library_entries_metadata_object" CHECK (jsonb_typeof("agent_library_container_entries"."metadata") = 'object'),
+	CONSTRAINT "agent_library_entries_source_ref_object" CHECK (jsonb_typeof("agent_library_container_entries"."source_ref") = 'object')
 );
 --> statement-breakpoint
-CREATE TABLE "principal_group_external_bindings" (
-	"provider" text NOT NULL,
-	"external_id" text NOT NULL,
-	"group_id" uuid NOT NULL,
+CREATE TABLE "agent_skill_assignments" (
+	"agent_uid" text NOT NULL,
+	"skill_id" uuid NOT NULL,
+	"enabled" boolean NOT NULL,
+	"reason" text,
 	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
-	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-	CONSTRAINT "principal_group_external_bindings_provider_external_id_pk" PRIMARY KEY("provider","external_id"),
-	CONSTRAINT "principal_group_external_bindings_provider_present" CHECK (length(btrim("principal_group_external_bindings"."provider")) > 0),
-	CONSTRAINT "principal_group_external_bindings_provider_format" CHECK ("principal_group_external_bindings"."provider" ~ '^[a-z][a-z0-9_-]*$'),
-	CONSTRAINT "principal_group_external_bindings_external_id_present" CHECK (length(btrim("principal_group_external_bindings"."external_id")) > 0),
-	CONSTRAINT "principal_group_external_bindings_metadata_object" CHECK (jsonb_typeof("principal_group_external_bindings"."metadata") = 'object')
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "agent_skill_assignments_agent_uid_skill_id_pk" PRIMARY KEY("agent_uid","skill_id"),
+	CONSTRAINT "agent_skill_assignments_metadata_object" CHECK (jsonb_typeof("agent_skill_assignments"."metadata") = 'object')
 );
 --> statement-breakpoint
-CREATE TABLE "principal_group_memberships" (
-	"principal_uid" text NOT NULL,
-	"group_id" uuid NOT NULL,
+CREATE TABLE "agents" (
+	"uid" text PRIMARY KEY NOT NULL,
+	"type" "agent_type" DEFAULT 'llm_agentic_loop' NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_by_principal_uid" text,
 	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
 	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-	CONSTRAINT "principal_group_memberships_principal_uid_group_id_pk" PRIMARY KEY("principal_uid","group_id")
+	CONSTRAINT "agents_metadata_object" CHECK (jsonb_typeof("agents"."metadata") = 'object')
 );
 --> statement-breakpoint
-CREATE TABLE "principal_groups" (
+CREATE TABLE "ai_agent_checkbacks" (
 	"id" uuid PRIMARY KEY NOT NULL,
-	"name" text NOT NULL,
-	"kind" "principal_group_kind" DEFAULT 'static' NOT NULL,
-	"description" text,
-	"computed_condition" text,
-	"built_in" boolean DEFAULT false NOT NULL,
-	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-	CONSTRAINT "principal_groups_name_present" CHECK (length(btrim("principal_groups"."name")) > 0),
-	CONSTRAINT "principal_groups_name_lowercase" CHECK ("principal_groups"."name" = lower("principal_groups"."name")),
-	CONSTRAINT "principal_groups_computed_condition_by_kind" CHECK (("principal_groups"."kind" = 'static' AND "principal_groups"."computed_condition" IS NULL) OR ("principal_groups"."kind" = 'computed' AND length(btrim("principal_groups"."computed_condition")) > 0))
+	"agent_uid" text NOT NULL,
+	"due_at" timestamp with time zone NOT NULL,
+	"timezone" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"reason" text NOT NULL,
+	"check" text NOT NULL,
+	"context_summary" text,
+	"source" jsonb NOT NULL,
+	"wake_message" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"conversation_id" uuid,
+	"trigger_message_id" uuid,
+	"completed_at" timestamp with time zone,
+	"claimed_by" text,
+	"claimed_at" timestamp with time zone,
+	"lease_expires_at" timestamp with time zone,
+	"error" text,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "ai_agent_checkbacks_status_check" CHECK ("ai_agent_checkbacks"."status" in ('pending', 'running', 'succeeded', 'failed', 'cancelled')),
+	CONSTRAINT "ai_agent_checkbacks_timezone_nonempty" CHECK ("ai_agent_checkbacks"."timezone" <> ''),
+	CONSTRAINT "ai_agent_checkbacks_reason_nonempty" CHECK ("ai_agent_checkbacks"."reason" <> ''),
+	CONSTRAINT "ai_agent_checkbacks_check_nonempty" CHECK ("ai_agent_checkbacks"."check" <> ''),
+	CONSTRAINT "ai_agent_checkbacks_source_object" CHECK (jsonb_typeof("ai_agent_checkbacks"."source") = 'object'),
+	CONSTRAINT "ai_agent_checkbacks_wake_message_array" CHECK (jsonb_typeof("ai_agent_checkbacks"."wake_message") = 'array'),
+	CONSTRAINT "ai_agent_checkbacks_metadata_object" CHECK (jsonb_typeof("ai_agent_checkbacks"."metadata") = 'object')
 );
 --> statement-breakpoint
 CREATE TABLE "ai_agent_conversations" (
@@ -149,6 +163,15 @@ CREATE TABLE "ai_agent_messages" (
 	CONSTRAINT "ai_agent_messages_metadata_object" CHECK (jsonb_typeof("ai_agent_messages"."metadata") = 'object')
 );
 --> statement-breakpoint
+CREATE TABLE "app_configure" (
+	"key" text NOT NULL,
+	"value" jsonb NOT NULL,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	CONSTRAINT "key_unique" UNIQUE("key"),
+	CONSTRAINT "app_configure_value_envelope" CHECK (jsonb_typeof("app_configure"."value") = 'object' AND "app_configure"."value" ? 'type' AND "app_configure"."value" ? 'value')
+);
+--> statement-breakpoint
 CREATE TABLE "chat_recall_embeddings" (
 	"document_id" uuid NOT NULL,
 	"profile_id" text NOT NULL,
@@ -170,6 +193,41 @@ CREATE TABLE "chat_recall_embeddings" (
 	CONSTRAINT "chat_recall_embeddings_status_check" CHECK ("chat_recall_embeddings"."status" in ('pending', 'processing', 'synced', 'failed'))
 );
 --> statement-breakpoint
+CREATE TABLE "computer_agent_worker_bindings" (
+	"agent_uid" text PRIMARY KEY NOT NULL,
+	"worker_id" text NOT NULL,
+	"binding_kind" text NOT NULL,
+	"binding_reason" text,
+	"instance_id" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_resolved_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "computer_agent_worker_pins" (
+	"agent_uid" text PRIMARY KEY NOT NULL,
+	"worker_id" text NOT NULL,
+	"reason" text,
+	"created_by_principal_uid" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "computer_workers" (
+	"worker_id" text PRIMARY KEY NOT NULL,
+	"instance_id" text NOT NULL,
+	"base_url" text NOT NULL,
+	"status" text DEFAULT 'starting' NOT NULL,
+	"version" text,
+	"features" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"capacity" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"load" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"registered_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_heartbeat_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
 CREATE TABLE "external_agent_room_observations" (
 	"agent_uid" text NOT NULL,
 	"binding_name" text NOT NULL,
@@ -182,7 +240,7 @@ CREATE TABLE "external_agent_room_observations" (
 	CONSTRAINT "external_agent_room_observations_metadata_object" CHECK (jsonb_typeof("external_agent_room_observations"."metadata") = 'object')
 );
 --> statement-breakpoint
-CREATE UNLOGGED TABLE "external_gateway_agent_events" (
+CREATE TABLE "external_gateway_agent_events" (
 	"agent_uid" text NOT NULL,
 	"binding_name" text NOT NULL,
 	"provider_room_id" text NOT NULL,
@@ -204,7 +262,7 @@ CREATE UNLOGGED TABLE "external_gateway_agent_events" (
 	CONSTRAINT "external_gateway_agent_events_delivery_mode_check" CHECK ("external_gateway_agent_events"."delivery_mode" in ('addressed', 'ambient', 'command', 'action', 'lifecycle'))
 );
 --> statement-breakpoint
-CREATE UNLOGGED TABLE "external_gateway_input_tombstones" (
+CREATE TABLE "external_gateway_input_tombstones" (
 	"agent_uid" text NOT NULL,
 	"binding_name" text NOT NULL,
 	"provider_room_id" text NOT NULL,
@@ -299,41 +357,12 @@ CREATE TABLE "external_rooms" (
 	CONSTRAINT "external_rooms_metadata_object" CHECK (jsonb_typeof("external_rooms"."metadata") = 'object')
 );
 --> statement-breakpoint
-CREATE TABLE "agent_library_container_entries" (
-	"id" uuid PRIMARY KEY NOT NULL,
-	"agent_uid" text NOT NULL,
-	"virtual_path" text NOT NULL,
-	"entry_kind" text DEFAULT 'file' NOT NULL,
-	"source_kind" text NOT NULL,
-	"source_ref" jsonb DEFAULT '{}'::jsonb NOT NULL,
-	"content_text" text,
-	"content_bytes" text,
-	"content_media_type" text DEFAULT 'text/plain' NOT NULL,
-	"content_blake3" text NOT NULL,
-	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
-	"enabled" boolean DEFAULT true NOT NULL,
-	"version" text DEFAULT '1' NOT NULL,
-	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"deleted_at" timestamp with time zone,
-	CONSTRAINT "agent_library_entries_virtual_path_relative" CHECK ("agent_library_container_entries"."virtual_path" !~ '(^/|(^|/)..(/|$)|//)'),
-	CONSTRAINT "agent_library_entries_kind_check" CHECK ("agent_library_container_entries"."entry_kind" in ('file', 'directory')),
-	CONSTRAINT "agent_library_entries_source_check" CHECK ("agent_library_container_entries"."source_kind" in ('soul', 'mission', 'skill_append', 'setting', 'memory', 'system', 'user', 'computer')),
-	CONSTRAINT "agent_library_entries_one_content" CHECK (not ("agent_library_container_entries"."content_text" is not null and "agent_library_container_entries"."content_bytes" is not null)),
-	CONSTRAINT "agent_library_entries_metadata_object" CHECK (jsonb_typeof("agent_library_container_entries"."metadata") = 'object'),
-	CONSTRAINT "agent_library_entries_source_ref_object" CHECK (jsonb_typeof("agent_library_container_entries"."source_ref") = 'object')
-);
---> statement-breakpoint
-CREATE TABLE "agent_skill_assignments" (
-	"agent_uid" text NOT NULL,
-	"skill_id" uuid NOT NULL,
-	"enabled" boolean NOT NULL,
-	"reason" text,
-	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
-	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	CONSTRAINT "agent_skill_assignments_agent_uid_skill_id_pk" PRIMARY KEY("agent_uid","skill_id"),
-	CONSTRAINT "agent_skill_assignments_metadata_object" CHECK (jsonb_typeof("agent_skill_assignments"."metadata") = 'object')
+CREATE TABLE "human_users" (
+	"principal_uid" text PRIMARY KEY NOT NULL,
+	"email" text,
+	"phone" text,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "library_builtin_sync_state" (
@@ -391,22 +420,22 @@ CREATE TABLE "llm_providers" (
 	CONSTRAINT "llm_providers_provider_options_object" CHECK (jsonb_typeof("llm_providers"."provider_options") = 'object')
 );
 --> statement-breakpoint
-CREATE TABLE "agents" (
-	"uid" text PRIMARY KEY NOT NULL,
-	"type" "agent_type" DEFAULT 'llm_agentic_loop' NOT NULL,
+CREATE TABLE "permission_grants" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"principal_uid" text,
+	"group_id" uuid,
+	"resource_pattern" text NOT NULL,
+	"action" text NOT NULL,
+	"condition" text DEFAULT 'true' NOT NULL,
+	"description" text,
 	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
-	"created_by_principal_uid" text,
 	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
 	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-	CONSTRAINT "agents_metadata_object" CHECK (jsonb_typeof("agents"."metadata") = 'object')
-);
---> statement-breakpoint
-CREATE TABLE "human_users" (
-	"principal_uid" text PRIMARY KEY NOT NULL,
-	"email" text,
-	"phone" text,
-	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+	CONSTRAINT "permission_grants_principal_exclusive" CHECK (("permission_grants"."principal_uid" IS NOT NULL AND "permission_grants"."group_id" IS NULL) OR ("permission_grants"."principal_uid" IS NULL AND "permission_grants"."group_id" IS NOT NULL)),
+	CONSTRAINT "permission_grants_action_no_colon" CHECK (position(':' in "permission_grants"."action") = 0),
+	CONSTRAINT "permission_grants_resource_pattern_present" CHECK (length("permission_grants"."resource_pattern") > 0),
+	CONSTRAINT "permission_grants_action_present" CHECK (length("permission_grants"."action") > 0),
+	CONSTRAINT "permission_grants_metadata_object" CHECK (jsonb_typeof("permission_grants"."metadata") = 'object')
 );
 --> statement-breakpoint
 CREATE TABLE "principal_external_identities" (
@@ -427,6 +456,42 @@ CREATE TABLE "principal_external_identities" (
 	CONSTRAINT "principal_external_identities_metadata_object" CHECK (jsonb_typeof("principal_external_identities"."metadata") = 'object')
 );
 --> statement-breakpoint
+CREATE TABLE "principal_group_external_bindings" (
+	"provider" text NOT NULL,
+	"external_id" text NOT NULL,
+	"group_id" uuid NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	CONSTRAINT "principal_group_external_bindings_provider_external_id_pk" PRIMARY KEY("provider","external_id"),
+	CONSTRAINT "principal_group_external_bindings_provider_present" CHECK (length(btrim("principal_group_external_bindings"."provider")) > 0),
+	CONSTRAINT "principal_group_external_bindings_provider_format" CHECK ("principal_group_external_bindings"."provider" ~ '^[a-z][a-z0-9_-]*$'),
+	CONSTRAINT "principal_group_external_bindings_external_id_present" CHECK (length(btrim("principal_group_external_bindings"."external_id")) > 0),
+	CONSTRAINT "principal_group_external_bindings_metadata_object" CHECK (jsonb_typeof("principal_group_external_bindings"."metadata") = 'object')
+);
+--> statement-breakpoint
+CREATE TABLE "principal_group_memberships" (
+	"principal_uid" text NOT NULL,
+	"group_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	CONSTRAINT "principal_group_memberships_principal_uid_group_id_pk" PRIMARY KEY("principal_uid","group_id")
+);
+--> statement-breakpoint
+CREATE TABLE "principal_groups" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"kind" "principal_group_kind" DEFAULT 'static' NOT NULL,
+	"description" text,
+	"computed_condition" text,
+	"built_in" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	CONSTRAINT "principal_groups_name_present" CHECK (length(btrim("principal_groups"."name")) > 0),
+	CONSTRAINT "principal_groups_name_lowercase" CHECK ("principal_groups"."name" = lower("principal_groups"."name")),
+	CONSTRAINT "principal_groups_computed_condition_by_kind" CHECK (("principal_groups"."kind" = 'static' AND "principal_groups"."computed_condition" IS NULL) OR ("principal_groups"."kind" = 'computed' AND length(btrim("principal_groups"."computed_condition")) > 0))
+);
+--> statement-breakpoint
 CREATE TABLE "principals" (
 	"uid" text PRIMARY KEY NOT NULL,
 	"type" "principal_type" NOT NULL,
@@ -438,69 +503,28 @@ CREATE TABLE "principals" (
 	CONSTRAINT "principals_uid_lowercase" CHECK ("principals"."uid" = lower("principals"."uid"))
 );
 --> statement-breakpoint
-CREATE TABLE "computer_agent_worker_bindings" (
-	"agent_uid" text PRIMARY KEY NOT NULL,
-	"worker_id" text NOT NULL,
-	"binding_kind" text NOT NULL,
-	"binding_reason" text,
-	"instance_id" text,
-	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"last_resolved_at" timestamp with time zone DEFAULT now() NOT NULL
-);
---> statement-breakpoint
-CREATE TABLE "computer_agent_worker_pins" (
-	"agent_uid" text PRIMARY KEY NOT NULL,
-	"worker_id" text NOT NULL,
-	"reason" text,
-	"created_by_principal_uid" text,
-	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
-);
---> statement-breakpoint
-CREATE TABLE "computer_workers" (
-	"worker_id" text PRIMARY KEY NOT NULL,
-	"instance_id" text NOT NULL,
-	"base_url" text NOT NULL,
-	"status" text DEFAULT 'starting' NOT NULL,
-	"version" text,
-	"features" jsonb DEFAULT '[]'::jsonb NOT NULL,
-	"capacity" jsonb DEFAULT '{}'::jsonb NOT NULL,
-	"load" jsonb DEFAULT '{}'::jsonb NOT NULL,
-	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
-	"registered_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"last_heartbeat_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
-);
---> statement-breakpoint
-CREATE TABLE "ai_agent_checkbacks" (
+CREATE TABLE "runtime_credentials" (
 	"id" uuid PRIMARY KEY NOT NULL,
-	"agent_uid" text NOT NULL,
-	"due_at" timestamp with time zone NOT NULL,
-	"timezone" text NOT NULL,
-	"status" text DEFAULT 'pending' NOT NULL,
-	"reason" text NOT NULL,
-	"check" text NOT NULL,
-	"context_summary" text,
-	"source" jsonb NOT NULL,
-	"wake_message" jsonb DEFAULT '[]'::jsonb NOT NULL,
-	"conversation_id" uuid,
-	"trigger_message_id" uuid,
-	"completed_at" timestamp with time zone,
-	"claimed_by" text,
-	"claimed_at" timestamp with time zone,
-	"lease_expires_at" timestamp with time zone,
-	"error" text,
+	"consumer_kind" text NOT NULL,
+	"consumer_name" text NOT NULL,
+	"credential_name" text NOT NULL,
+	"scope_kind" text NOT NULL,
+	"agent_uid" text,
+	"encrypted_payload" text NOT NULL,
+	"payload_media_type" text DEFAULT 'text/plain' NOT NULL,
+	"payload_blake3" text NOT NULL,
 	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	CONSTRAINT "ai_agent_checkbacks_status_check" CHECK ("ai_agent_checkbacks"."status" in ('pending', 'running', 'succeeded', 'failed', 'cancelled')),
-	CONSTRAINT "ai_agent_checkbacks_timezone_nonempty" CHECK ("ai_agent_checkbacks"."timezone" <> ''),
-	CONSTRAINT "ai_agent_checkbacks_reason_nonempty" CHECK ("ai_agent_checkbacks"."reason" <> ''),
-	CONSTRAINT "ai_agent_checkbacks_check_nonempty" CHECK ("ai_agent_checkbacks"."check" <> ''),
-	CONSTRAINT "ai_agent_checkbacks_source_object" CHECK (jsonb_typeof("ai_agent_checkbacks"."source") = 'object'),
-	CONSTRAINT "ai_agent_checkbacks_wake_message_array" CHECK (jsonb_typeof("ai_agent_checkbacks"."wake_message") = 'array'),
-	CONSTRAINT "ai_agent_checkbacks_metadata_object" CHECK (jsonb_typeof("ai_agent_checkbacks"."metadata") = 'object')
+	CONSTRAINT "runtime_credentials_consumer_kind_check" CHECK ("runtime_credentials"."consumer_kind" in ('skill', 'tool', 'runtime')),
+	CONSTRAINT "runtime_credentials_scope_kind_check" CHECK ("runtime_credentials"."scope_kind" in ('default', 'agent')),
+	CONSTRAINT "runtime_credentials_scope_agent_shape" CHECK (("runtime_credentials"."scope_kind" = 'default' AND "runtime_credentials"."agent_uid" IS NULL) OR ("runtime_credentials"."scope_kind" = 'agent' AND "runtime_credentials"."agent_uid" IS NOT NULL)),
+	CONSTRAINT "runtime_credentials_consumer_name_format" CHECK ("runtime_credentials"."consumer_name" ~ '^[a-z][a-z0-9_-]{0,63}$'),
+	CONSTRAINT "runtime_credentials_name_format" CHECK ("runtime_credentials"."credential_name" ~ '^[a-z][a-z0-9_-]{0,63}$'),
+	CONSTRAINT "runtime_credentials_payload_nonempty" CHECK (length("runtime_credentials"."encrypted_payload") > 0),
+	CONSTRAINT "runtime_credentials_payload_media_type_nonempty" CHECK (length(trim("runtime_credentials"."payload_media_type")) > 0),
+	CONSTRAINT "runtime_credentials_metadata_object" CHECK (jsonb_typeof("runtime_credentials"."metadata") = 'object')
 );
 --> statement-breakpoint
 CREATE TABLE "scheduled_task_runs" (
@@ -554,71 +578,47 @@ CREATE TABLE "scheduled_tasks" (
 	CONSTRAINT "scheduled_tasks_last_status_check" CHECK ("scheduled_tasks"."last_status" is null or "scheduled_tasks"."last_status" in ('succeeded', 'failed', 'cancelled'))
 );
 --> statement-breakpoint
-CREATE TABLE "runtime_credentials" (
-	"id" uuid PRIMARY KEY NOT NULL,
-	"consumer_kind" text NOT NULL,
-	"consumer_name" text NOT NULL,
-	"credential_name" text NOT NULL,
-	"scope_kind" text NOT NULL,
-	"agent_uid" text,
-	"encrypted_payload" text NOT NULL,
-	"payload_media_type" text DEFAULT 'text/plain' NOT NULL,
-	"payload_blake3" text NOT NULL,
-	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
-	"enabled" boolean DEFAULT true NOT NULL,
-	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	CONSTRAINT "runtime_credentials_consumer_kind_check" CHECK ("runtime_credentials"."consumer_kind" in ('skill', 'tool', 'runtime')),
-	CONSTRAINT "runtime_credentials_scope_kind_check" CHECK ("runtime_credentials"."scope_kind" in ('default', 'agent')),
-	CONSTRAINT "runtime_credentials_scope_agent_shape" CHECK (("runtime_credentials"."scope_kind" = 'default' AND "runtime_credentials"."agent_uid" IS NULL) OR ("runtime_credentials"."scope_kind" = 'agent' AND "runtime_credentials"."agent_uid" IS NOT NULL)),
-	CONSTRAINT "runtime_credentials_consumer_name_format" CHECK ("runtime_credentials"."consumer_name" ~ '^[a-z][a-z0-9_-]{0,63}$'),
-	CONSTRAINT "runtime_credentials_name_format" CHECK ("runtime_credentials"."credential_name" ~ '^[a-z][a-z0-9_-]{0,63}$'),
-	CONSTRAINT "runtime_credentials_payload_nonempty" CHECK (length("runtime_credentials"."encrypted_payload") > 0),
-	CONSTRAINT "runtime_credentials_payload_media_type_nonempty" CHECK (length(trim("runtime_credentials"."payload_media_type")) > 0),
-	CONSTRAINT "runtime_credentials_metadata_object" CHECK (jsonb_typeof("runtime_credentials"."metadata") = 'object')
-);
---> statement-breakpoint
-ALTER TABLE "permission_grants" ADD CONSTRAINT "permission_grants_principal_uid_principals_uid_fk" FOREIGN KEY ("principal_uid") REFERENCES "public"."principals"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "permission_grants" ADD CONSTRAINT "permission_grants_group_id_principal_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."principal_groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "principal_group_external_bindings" ADD CONSTRAINT "principal_group_external_bindings_group_id_principal_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."principal_groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "principal_group_memberships" ADD CONSTRAINT "principal_group_memberships_principal_uid_principals_uid_fk" FOREIGN KEY ("principal_uid") REFERENCES "public"."principals"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "principal_group_memberships" ADD CONSTRAINT "principal_group_memberships_group_id_principal_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."principal_groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "agent_library_container_entries" ADD CONSTRAINT "agent_library_container_entries_agent_uid_agents_uid_fk" FOREIGN KEY ("agent_uid") REFERENCES "public"."agents"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "agent_skill_assignments" ADD CONSTRAINT "agent_skill_assignments_agent_uid_agents_uid_fk" FOREIGN KEY ("agent_uid") REFERENCES "public"."agents"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "agent_skill_assignments" ADD CONSTRAINT "agent_skill_assignments_skill_id_library_skills_id_fk" FOREIGN KEY ("skill_id") REFERENCES "public"."library_skills"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "agents" ADD CONSTRAINT "agents_uid_principals_uid_fk" FOREIGN KEY ("uid") REFERENCES "public"."principals"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "agents" ADD CONSTRAINT "agents_created_by_principal_uid_principals_uid_fk" FOREIGN KEY ("created_by_principal_uid") REFERENCES "public"."principals"("uid") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "ai_agent_checkbacks" ADD CONSTRAINT "ai_agent_checkbacks_agent_uid_agents_uid_fk" FOREIGN KEY ("agent_uid") REFERENCES "public"."agents"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "ai_agent_checkbacks" ADD CONSTRAINT "ai_agent_checkbacks_conversation_id_ai_agent_conversations_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."ai_agent_conversations"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "ai_agent_checkbacks" ADD CONSTRAINT "ai_agent_checkbacks_trigger_message_id_ai_agent_messages_id_fk" FOREIGN KEY ("trigger_message_id") REFERENCES "public"."ai_agent_messages"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "ai_agent_conversations" ADD CONSTRAINT "ai_agent_conversations_agent_uid_agents_uid_fk" FOREIGN KEY ("agent_uid") REFERENCES "public"."agents"("uid") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "ai_agent_llm_turns" ADD CONSTRAINT "ai_agent_llm_turns_conversation_id_ai_agent_conversations_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."ai_agent_conversations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "ai_agent_messages" ADD CONSTRAINT "ai_agent_messages_conversation_id_ai_agent_conversations_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."ai_agent_conversations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-CREATE UNIQUE INDEX "external_messages_document_id_index" ON "external_messages" USING btree ("document_id");--> statement-breakpoint
 ALTER TABLE "chat_recall_embeddings" ADD CONSTRAINT "chat_recall_embeddings_document_id_external_messages_document_id_fk" FOREIGN KEY ("document_id") REFERENCES "public"."external_messages"("document_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "computer_agent_worker_bindings" ADD CONSTRAINT "computer_agent_worker_bindings_worker_id_computer_workers_worker_id_fk" FOREIGN KEY ("worker_id") REFERENCES "public"."computer_workers"("worker_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "computer_agent_worker_pins" ADD CONSTRAINT "computer_agent_worker_pins_worker_id_computer_workers_worker_id_fk" FOREIGN KEY ("worker_id") REFERENCES "public"."computer_workers"("worker_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "external_agent_room_observations" ADD CONSTRAINT "external_agent_room_observations_agent_uid_agents_uid_fk" FOREIGN KEY ("agent_uid") REFERENCES "public"."agents"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "external_agent_room_observations" ADD CONSTRAINT "external_agent_room_observations_room_id_external_rooms_id_fk" FOREIGN KEY ("room_id") REFERENCES "public"."external_rooms"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "external_messages" ADD CONSTRAINT "external_messages_room_id_external_rooms_id_fk" FOREIGN KEY ("room_id") REFERENCES "public"."external_rooms"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "external_room_memberships" ADD CONSTRAINT "external_room_memberships_room_id_external_rooms_id_fk" FOREIGN KEY ("room_id") REFERENCES "public"."external_rooms"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "external_room_memberships" ADD CONSTRAINT "external_room_memberships_principal_uid_principals_uid_fk" FOREIGN KEY ("principal_uid") REFERENCES "public"."principals"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "agent_library_container_entries" ADD CONSTRAINT "agent_library_container_entries_agent_uid_agents_uid_fk" FOREIGN KEY ("agent_uid") REFERENCES "public"."agents"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "agent_skill_assignments" ADD CONSTRAINT "agent_skill_assignments_agent_uid_agents_uid_fk" FOREIGN KEY ("agent_uid") REFERENCES "public"."agents"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "agent_skill_assignments" ADD CONSTRAINT "agent_skill_assignments_skill_id_library_skills_id_fk" FOREIGN KEY ("skill_id") REFERENCES "public"."library_skills"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "library_skill_files" ADD CONSTRAINT "library_skill_files_skill_id_library_skills_id_fk" FOREIGN KEY ("skill_id") REFERENCES "public"."library_skills"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "agents" ADD CONSTRAINT "agents_uid_principals_uid_fk" FOREIGN KEY ("uid") REFERENCES "public"."principals"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "agents" ADD CONSTRAINT "agents_created_by_principal_uid_principals_uid_fk" FOREIGN KEY ("created_by_principal_uid") REFERENCES "public"."principals"("uid") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "human_users" ADD CONSTRAINT "human_users_principal_uid_principals_uid_fk" FOREIGN KEY ("principal_uid") REFERENCES "public"."principals"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "library_skill_files" ADD CONSTRAINT "library_skill_files_skill_id_library_skills_id_fk" FOREIGN KEY ("skill_id") REFERENCES "public"."library_skills"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "permission_grants" ADD CONSTRAINT "permission_grants_principal_uid_principals_uid_fk" FOREIGN KEY ("principal_uid") REFERENCES "public"."principals"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "permission_grants" ADD CONSTRAINT "permission_grants_group_id_principal_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."principal_groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "principal_external_identities" ADD CONSTRAINT "principal_external_identities_principal_uid_principals_uid_fk" FOREIGN KEY ("principal_uid") REFERENCES "public"."principals"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "computer_agent_worker_bindings" ADD CONSTRAINT "computer_agent_worker_bindings_worker_id_computer_workers_worker_id_fk" FOREIGN KEY ("worker_id") REFERENCES "public"."computer_workers"("worker_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "computer_agent_worker_pins" ADD CONSTRAINT "computer_agent_worker_pins_worker_id_computer_workers_worker_id_fk" FOREIGN KEY ("worker_id") REFERENCES "public"."computer_workers"("worker_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "ai_agent_checkbacks" ADD CONSTRAINT "ai_agent_checkbacks_agent_uid_agents_uid_fk" FOREIGN KEY ("agent_uid") REFERENCES "public"."agents"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "ai_agent_checkbacks" ADD CONSTRAINT "ai_agent_checkbacks_conversation_id_ai_agent_conversations_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."ai_agent_conversations"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "ai_agent_checkbacks" ADD CONSTRAINT "ai_agent_checkbacks_trigger_message_id_ai_agent_messages_id_fk" FOREIGN KEY ("trigger_message_id") REFERENCES "public"."ai_agent_messages"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "principal_group_external_bindings" ADD CONSTRAINT "principal_group_external_bindings_group_id_principal_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."principal_groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "principal_group_memberships" ADD CONSTRAINT "principal_group_memberships_principal_uid_principals_uid_fk" FOREIGN KEY ("principal_uid") REFERENCES "public"."principals"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "principal_group_memberships" ADD CONSTRAINT "principal_group_memberships_group_id_principal_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."principal_groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "runtime_credentials" ADD CONSTRAINT "runtime_credentials_agent_uid_agents_uid_fk" FOREIGN KEY ("agent_uid") REFERENCES "public"."agents"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "scheduled_task_runs" ADD CONSTRAINT "scheduled_task_runs_task_id_scheduled_tasks_id_fk" FOREIGN KEY ("task_id") REFERENCES "public"."scheduled_tasks"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "scheduled_task_runs" ADD CONSTRAINT "scheduled_task_runs_conversation_id_ai_agent_conversations_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."ai_agent_conversations"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "scheduled_task_runs" ADD CONSTRAINT "scheduled_task_runs_trigger_message_id_ai_agent_messages_id_fk" FOREIGN KEY ("trigger_message_id") REFERENCES "public"."ai_agent_messages"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "scheduled_tasks" ADD CONSTRAINT "scheduled_tasks_agent_uid_agents_uid_fk" FOREIGN KEY ("agent_uid") REFERENCES "public"."agents"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "runtime_credentials" ADD CONSTRAINT "runtime_credentials_agent_uid_agents_uid_fk" FOREIGN KEY ("agent_uid") REFERENCES "public"."agents"("uid") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-CREATE INDEX "permission_grants_principal_uid_index" ON "permission_grants" USING btree ("principal_uid");--> statement-breakpoint
-CREATE INDEX "permission_grants_group_id_index" ON "permission_grants" USING btree ("group_id");--> statement-breakpoint
-CREATE INDEX "permission_grants_action_index" ON "permission_grants" USING btree ("action");--> statement-breakpoint
-CREATE UNIQUE INDEX "permission_grants_principal_upsert_index" ON "permission_grants" USING btree ("principal_uid","resource_pattern","action","condition") WHERE "permission_grants"."principal_uid" IS NOT NULL;--> statement-breakpoint
-CREATE UNIQUE INDEX "permission_grants_group_upsert_index" ON "permission_grants" USING btree ("group_id","resource_pattern","action","condition") WHERE "permission_grants"."group_id" IS NOT NULL;--> statement-breakpoint
-CREATE INDEX "principal_group_external_bindings_group_id_index" ON "principal_group_external_bindings" USING btree ("group_id");--> statement-breakpoint
-CREATE INDEX "principal_group_memberships_group_id_index" ON "principal_group_memberships" USING btree ("group_id");--> statement-breakpoint
-CREATE UNIQUE INDEX "principal_groups_name_index" ON "principal_groups" USING btree ("name");--> statement-breakpoint
+CREATE UNIQUE INDEX "agent_library_entries_active_path_index" ON "agent_library_container_entries" USING btree ("agent_uid","virtual_path") WHERE "agent_library_container_entries"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "agent_library_entries_agent_index" ON "agent_library_container_entries" USING btree ("agent_uid","enabled","virtual_path");--> statement-breakpoint
+CREATE INDEX "agent_skill_assignments_agent_index" ON "agent_skill_assignments" USING btree ("agent_uid");--> statement-breakpoint
+CREATE INDEX "agents_created_by_principal_uid_index" ON "agents" USING btree ("created_by_principal_uid");--> statement-breakpoint
+CREATE INDEX "ai_agent_checkbacks_due_index" ON "ai_agent_checkbacks" USING btree ("status","due_at");--> statement-breakpoint
+CREATE INDEX "ai_agent_checkbacks_agent_index" ON "ai_agent_checkbacks" USING btree ("agent_uid","created_at");--> statement-breakpoint
+CREATE INDEX "ai_agent_checkbacks_conversation_index" ON "ai_agent_checkbacks" USING btree ("conversation_id");--> statement-breakpoint
+CREATE INDEX "ai_agent_checkbacks_trigger_message_index" ON "ai_agent_checkbacks" USING btree ("trigger_message_id");--> statement-breakpoint
+CREATE INDEX "ai_agent_checkbacks_lease_index" ON "ai_agent_checkbacks" USING btree ("lease_expires_at");--> statement-breakpoint
 CREATE UNIQUE INDEX "ai_agent_conversations_active_key_index" ON "ai_agent_conversations" USING btree ("agent_uid","conversation_key") WHERE "ai_agent_conversations"."ended_at" IS NULL;--> statement-breakpoint
 CREATE INDEX "ai_agent_conversations_stale_generation_index" ON "ai_agent_conversations" USING btree ("ended_at","updated_at");--> statement-breakpoint
 CREATE INDEX "ai_agent_llm_turns_conversation_index" ON "ai_agent_llm_turns" USING btree ("conversation_id","started_at","id");--> statement-breakpoint
@@ -629,46 +629,46 @@ CREATE INDEX "ai_agent_messages_conversation_order_index" ON "ai_agent_messages"
 CREATE UNIQUE INDEX "ai_agent_messages_inbound_event_index" ON "ai_agent_messages" USING btree ("conversation_id","event_source","event_id") WHERE "ai_agent_messages"."role" in ('user', 'im_ambient') and "ai_agent_messages"."kind" = 'normal' and "ai_agent_messages"."event_source" is not null and "ai_agent_messages"."event_id" is not null;--> statement-breakpoint
 CREATE INDEX "ai_agent_messages_summary_index" ON "ai_agent_messages" USING btree ("conversation_id","created_at","id") WHERE "ai_agent_messages"."kind" = 'summary' and "ai_agent_messages"."status" = 'complete';--> statement-breakpoint
 CREATE INDEX "ai_agent_messages_assistant_index" ON "ai_agent_messages" USING btree ("conversation_id","created_at","id") WHERE "ai_agent_messages"."role" = 'assistant';--> statement-breakpoint
-CREATE INDEX "ai_agent_messages_provider_message_ids_index" ON "ai_agent_messages" USING gin (("metadata"->'provider_refs'->'message_ids')) WHERE "ai_agent_messages"."role" in ('user', 'im_ambient') and "ai_agent_messages"."kind" = 'normal';--> statement-breakpoint
+CREATE INDEX "ai_agent_messages_provider_message_ids_index" ON "ai_agent_messages" USING gin ("metadata"->'provider_refs'->'message_ids') WHERE "ai_agent_messages"."role" in ('user', 'im_ambient') and "ai_agent_messages"."kind" = 'normal';--> statement-breakpoint
 CREATE INDEX "chat_recall_embeddings_ready_idx" ON "chat_recall_embeddings" USING btree ("status","next_retry_at","updated_at");--> statement-breakpoint
 CREATE INDEX "chat_recall_embeddings_profile_status_idx" ON "chat_recall_embeddings" USING btree ("profile_id","status","dimensions");--> statement-breakpoint
+CREATE INDEX "computer_agent_worker_bindings_worker_index" ON "computer_agent_worker_bindings" USING btree ("worker_id");--> statement-breakpoint
+CREATE INDEX "computer_agent_worker_pins_worker_index" ON "computer_agent_worker_pins" USING btree ("worker_id");--> statement-breakpoint
 CREATE INDEX "external_agent_room_observations_room_id_index" ON "external_agent_room_observations" USING btree ("room_id");--> statement-breakpoint
 CREATE INDEX "external_gateway_agent_events_ready_index" ON "external_gateway_agent_events" USING btree ("status","available_at");--> statement-breakpoint
 CREATE INDEX "external_gateway_agent_events_batch_index" ON "external_gateway_agent_events" USING btree ("agent_uid","batch_key","status","created_at");--> statement-breakpoint
 CREATE INDEX "external_gateway_input_tombstones_expires_at_index" ON "external_gateway_input_tombstones" USING btree ("expires_at");--> statement-breakpoint
 CREATE INDEX "external_gateway_outbox_status_index" ON "external_gateway_outbox" USING btree ("status","created_at");--> statement-breakpoint
 CREATE INDEX "external_gateway_outbox_binding_pending_index" ON "external_gateway_outbox" USING btree ("agent_uid","binding_name","status","created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "external_messages_document_id_index" ON "external_messages" USING btree ("document_id");--> statement-breakpoint
 CREATE INDEX "external_messages_room_id_sent_at_index" ON "external_messages" USING btree ("room_id","sent_at");--> statement-breakpoint
 CREATE INDEX "external_room_memberships_principal_uid_index" ON "external_room_memberships" USING btree ("principal_uid");--> statement-breakpoint
-CREATE UNIQUE INDEX "agent_library_entries_active_path_index" ON "agent_library_container_entries" USING btree ("agent_uid","virtual_path") WHERE "agent_library_container_entries"."deleted_at" IS NULL;--> statement-breakpoint
-CREATE INDEX "agent_library_entries_agent_index" ON "agent_library_container_entries" USING btree ("agent_uid","enabled","virtual_path");--> statement-breakpoint
-CREATE INDEX "agent_skill_assignments_agent_index" ON "agent_skill_assignments" USING btree ("agent_uid");--> statement-breakpoint
+CREATE UNIQUE INDEX "human_users_email_index" ON "human_users" USING btree ("email") WHERE "human_users"."email" IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "human_users_phone_index" ON "human_users" USING btree ("phone") WHERE "human_users"."phone" IS NOT NULL;--> statement-breakpoint
 CREATE UNIQUE INDEX "library_skill_files_skill_path_index" ON "library_skill_files" USING btree ("skill_id","virtual_path");--> statement-breakpoint
 CREATE INDEX "library_skill_files_skill_index" ON "library_skill_files" USING btree ("skill_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "library_skills_name_index" ON "library_skills" USING btree ("name");--> statement-breakpoint
 CREATE INDEX "library_skills_enabled_index" ON "library_skills" USING btree ("enabled","default_enabled");--> statement-breakpoint
 CREATE INDEX "llm_providers_pi_provider_index" ON "llm_providers" USING btree ("pi_provider");--> statement-breakpoint
-CREATE INDEX "agents_created_by_principal_uid_index" ON "agents" USING btree ("created_by_principal_uid");--> statement-breakpoint
-CREATE UNIQUE INDEX "human_users_email_index" ON "human_users" USING btree ("email") WHERE "human_users"."email" IS NOT NULL;--> statement-breakpoint
-CREATE UNIQUE INDEX "human_users_phone_index" ON "human_users" USING btree ("phone") WHERE "human_users"."phone" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "permission_grants_principal_uid_index" ON "permission_grants" USING btree ("principal_uid");--> statement-breakpoint
+CREATE INDEX "permission_grants_group_id_index" ON "permission_grants" USING btree ("group_id");--> statement-breakpoint
+CREATE INDEX "permission_grants_action_index" ON "permission_grants" USING btree ("action");--> statement-breakpoint
+CREATE UNIQUE INDEX "permission_grants_principal_upsert_index" ON "permission_grants" USING btree ("principal_uid","resource_pattern","action","condition") WHERE "permission_grants"."principal_uid" IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "permission_grants_group_upsert_index" ON "permission_grants" USING btree ("group_id","resource_pattern","action","condition") WHERE "permission_grants"."group_id" IS NOT NULL;--> statement-breakpoint
 CREATE INDEX "principal_external_identities_principal_uid_index" ON "principal_external_identities" USING btree ("principal_uid");--> statement-breakpoint
 CREATE UNIQUE INDEX "principal_external_identities_channel_actor_index" ON "principal_external_identities" USING btree ("adapter","channel_id","external_id") WHERE "principal_external_identities"."kind" = 'channel_actor';--> statement-breakpoint
 CREATE UNIQUE INDEX "principal_external_identities_provider_identity_index" ON "principal_external_identities" USING btree ("kind","provider","external_id") WHERE "principal_external_identities"."provider" IS NOT NULL AND "principal_external_identities"."external_id" IS NOT NULL AND "principal_external_identities"."adapter" IS NULL AND "principal_external_identities"."channel_id" IS NULL;--> statement-breakpoint
 CREATE UNIQUE INDEX "principal_external_identities_login_subject_index" ON "principal_external_identities" USING btree ("provider","external_id") WHERE "principal_external_identities"."kind" = 'login_subject';--> statement-breakpoint
 CREATE UNIQUE INDEX "principal_external_identities_outbound_actor_index" ON "principal_external_identities" USING btree ("provider","external_id") WHERE "principal_external_identities"."kind" = 'outbound_actor';--> statement-breakpoint
-CREATE INDEX "computer_agent_worker_bindings_worker_index" ON "computer_agent_worker_bindings" USING btree ("worker_id");--> statement-breakpoint
-CREATE INDEX "computer_agent_worker_pins_worker_index" ON "computer_agent_worker_pins" USING btree ("worker_id");--> statement-breakpoint
-CREATE INDEX "ai_agent_checkbacks_due_index" ON "ai_agent_checkbacks" USING btree ("status","due_at");--> statement-breakpoint
-CREATE INDEX "ai_agent_checkbacks_agent_index" ON "ai_agent_checkbacks" USING btree ("agent_uid","created_at");--> statement-breakpoint
-CREATE INDEX "ai_agent_checkbacks_conversation_index" ON "ai_agent_checkbacks" USING btree ("conversation_id");--> statement-breakpoint
-CREATE INDEX "ai_agent_checkbacks_trigger_message_index" ON "ai_agent_checkbacks" USING btree ("trigger_message_id");--> statement-breakpoint
-CREATE INDEX "ai_agent_checkbacks_lease_index" ON "ai_agent_checkbacks" USING btree ("lease_expires_at");--> statement-breakpoint
+CREATE INDEX "principal_group_external_bindings_group_id_index" ON "principal_group_external_bindings" USING btree ("group_id");--> statement-breakpoint
+CREATE INDEX "principal_group_memberships_group_id_index" ON "principal_group_memberships" USING btree ("group_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "principal_groups_name_index" ON "principal_groups" USING btree ("name");--> statement-breakpoint
+CREATE UNIQUE INDEX "runtime_credentials_default_index" ON "runtime_credentials" USING btree ("consumer_kind","consumer_name","credential_name") WHERE "runtime_credentials"."scope_kind" = 'default';--> statement-breakpoint
+CREATE UNIQUE INDEX "runtime_credentials_agent_index" ON "runtime_credentials" USING btree ("consumer_kind","consumer_name","credential_name","agent_uid") WHERE "runtime_credentials"."scope_kind" = 'agent';--> statement-breakpoint
+CREATE INDEX "runtime_credentials_lookup_index" ON "runtime_credentials" USING btree ("consumer_kind","consumer_name","credential_name","scope_kind","enabled");--> statement-breakpoint
 CREATE INDEX "scheduled_task_runs_task_index" ON "scheduled_task_runs" USING btree ("task_id","started_at");--> statement-breakpoint
 CREATE INDEX "scheduled_task_runs_conversation_index" ON "scheduled_task_runs" USING btree ("conversation_id");--> statement-breakpoint
 CREATE INDEX "scheduled_task_runs_trigger_message_index" ON "scheduled_task_runs" USING btree ("trigger_message_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "scheduled_tasks_agent_name_index" ON "scheduled_tasks" USING btree ("agent_uid","name");--> statement-breakpoint
 CREATE INDEX "scheduled_tasks_due_index" ON "scheduled_tasks" USING btree ("enabled","next_run_at");--> statement-breakpoint
-CREATE INDEX "scheduled_tasks_lease_index" ON "scheduled_tasks" USING btree ("lease_expires_at");--> statement-breakpoint
-CREATE UNIQUE INDEX "runtime_credentials_default_index" ON "runtime_credentials" USING btree ("consumer_kind","consumer_name","credential_name") WHERE "runtime_credentials"."scope_kind" = 'default';--> statement-breakpoint
-CREATE UNIQUE INDEX "runtime_credentials_agent_index" ON "runtime_credentials" USING btree ("consumer_kind","consumer_name","credential_name","agent_uid") WHERE "runtime_credentials"."scope_kind" = 'agent';--> statement-breakpoint
-CREATE INDEX "runtime_credentials_lookup_index" ON "runtime_credentials" USING btree ("consumer_kind","consumer_name","credential_name","scope_kind","enabled");
+CREATE INDEX "scheduled_tasks_lease_index" ON "scheduled_tasks" USING btree ("lease_expires_at");

--- a/app/db/meta/20260611111903_snapshot.json
+++ b/app/db/meta/20260611111903_snapshot.json
@@ -1,63 +1,11 @@
 {
-  "id": "449e9cb9-7285-489f-b88e-14bd8c1213c8",
+  "id": "55de3db6-af19-41e4-b156-7821b4fd83b3",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
-    "public.app_configure": {
-      "name": "app_configure",
-      "schema": "",
-      "columns": {
-        "key": {
-          "name": "key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "value": {
-          "name": "value",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "key_unique": {
-          "name": "key_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "key"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {
-        "app_configure_value_envelope": {
-          "name": "app_configure_value_envelope",
-          "value": "jsonb_typeof(\"app_configure\".\"value\") = 'object' AND \"app_configure\".\"value\" ? 'type' AND \"app_configure\".\"value\" ? 'value'"
-        }
-      },
-      "isRLSEnabled": false
-    },
-    "public.permission_grants": {
-      "name": "permission_grants",
+    "public.agent_library_container_entries": {
+      "name": "agent_library_container_entries",
       "schema": "",
       "columns": {
         "id": {
@@ -66,254 +14,60 @@
           "primaryKey": true,
           "notNull": true
         },
-        "principal_uid": {
-          "name": "principal_uid",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "group_id": {
-          "name": "group_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "resource_pattern": {
-          "name": "resource_pattern",
+        "agent_uid": {
+          "name": "agent_uid",
           "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "action": {
-          "name": "action",
+        "virtual_path": {
+          "name": "virtual_path",
           "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "condition": {
-          "name": "condition",
+        "entry_kind": {
+          "name": "entry_kind",
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'true'"
+          "default": "'file'"
         },
-        "description": {
-          "name": "description",
+        "source_kind": {
+          "name": "source_kind",
           "type": "text",
           "primaryKey": false,
-          "notNull": false
+          "notNull": true
         },
-        "metadata": {
-          "name": "metadata",
+        "source_ref": {
+          "name": "source_ref",
           "type": "jsonb",
           "primaryKey": false,
           "notNull": true,
           "default": "'{}'::jsonb"
         },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        }
-      },
-      "indexes": {
-        "permission_grants_principal_uid_index": {
-          "name": "permission_grants_principal_uid_index",
-          "columns": [
-            {
-              "expression": "principal_uid",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "permission_grants_group_id_index": {
-          "name": "permission_grants_group_id_index",
-          "columns": [
-            {
-              "expression": "group_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "permission_grants_action_index": {
-          "name": "permission_grants_action_index",
-          "columns": [
-            {
-              "expression": "action",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "permission_grants_principal_upsert_index": {
-          "name": "permission_grants_principal_upsert_index",
-          "columns": [
-            {
-              "expression": "principal_uid",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "resource_pattern",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "action",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "condition",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"permission_grants\".\"principal_uid\" IS NOT NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "permission_grants_group_upsert_index": {
-          "name": "permission_grants_group_upsert_index",
-          "columns": [
-            {
-              "expression": "group_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "resource_pattern",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "action",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "condition",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"permission_grants\".\"group_id\" IS NOT NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "permission_grants_principal_uid_principals_uid_fk": {
-          "name": "permission_grants_principal_uid_principals_uid_fk",
-          "tableFrom": "permission_grants",
-          "tableTo": "principals",
-          "columnsFrom": [
-            "principal_uid"
-          ],
-          "columnsTo": [
-            "uid"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "permission_grants_group_id_principal_groups_id_fk": {
-          "name": "permission_grants_group_id_principal_groups_id_fk",
-          "tableFrom": "permission_grants",
-          "tableTo": "principal_groups",
-          "columnsFrom": [
-            "group_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {
-        "permission_grants_principal_exclusive": {
-          "name": "permission_grants_principal_exclusive",
-          "value": "(\"permission_grants\".\"principal_uid\" IS NOT NULL AND \"permission_grants\".\"group_id\" IS NULL) OR (\"permission_grants\".\"principal_uid\" IS NULL AND \"permission_grants\".\"group_id\" IS NOT NULL)"
-        },
-        "permission_grants_action_no_colon": {
-          "name": "permission_grants_action_no_colon",
-          "value": "position(':' in \"permission_grants\".\"action\") = 0"
-        },
-        "permission_grants_resource_pattern_present": {
-          "name": "permission_grants_resource_pattern_present",
-          "value": "length(\"permission_grants\".\"resource_pattern\") > 0"
-        },
-        "permission_grants_action_present": {
-          "name": "permission_grants_action_present",
-          "value": "length(\"permission_grants\".\"action\") > 0"
-        },
-        "permission_grants_metadata_object": {
-          "name": "permission_grants_metadata_object",
-          "value": "jsonb_typeof(\"permission_grants\".\"metadata\") = 'object'"
-        }
-      },
-      "isRLSEnabled": false
-    },
-    "public.principal_group_external_bindings": {
-      "name": "principal_group_external_bindings",
-      "schema": "",
-      "columns": {
-        "provider": {
-          "name": "provider",
+        "content_text": {
+          "name": "content_text",
           "type": "text",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
-        "external_id": {
-          "name": "external_id",
+        "content_bytes": {
+          "name": "content_bytes",
           "type": "text",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
-        "group_id": {
-          "name": "group_id",
-          "type": "uuid",
+        "content_media_type": {
+          "name": "content_media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text/plain'"
+        },
+        "content_blake3": {
+          "name": "content_blake3",
+          "type": "text",
           "primaryKey": false,
           "notNull": true
         },
@@ -324,216 +78,282 @@
           "notNull": true,
           "default": "'{}'::jsonb"
         },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        }
-      },
-      "indexes": {
-        "principal_group_external_bindings_group_id_index": {
-          "name": "principal_group_external_bindings_group_id_index",
-          "columns": [
-            {
-              "expression": "group_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "principal_group_external_bindings_group_id_principal_groups_id_fk": {
-          "name": "principal_group_external_bindings_group_id_principal_groups_id_fk",
-          "tableFrom": "principal_group_external_bindings",
-          "tableTo": "principal_groups",
-          "columnsFrom": [
-            "group_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "principal_group_external_bindings_provider_external_id_pk": {
-          "name": "principal_group_external_bindings_provider_external_id_pk",
-          "columns": [
-            "provider",
-            "external_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {
-        "principal_group_external_bindings_provider_present": {
-          "name": "principal_group_external_bindings_provider_present",
-          "value": "length(btrim(\"principal_group_external_bindings\".\"provider\")) > 0"
-        },
-        "principal_group_external_bindings_provider_format": {
-          "name": "principal_group_external_bindings_provider_format",
-          "value": "\"principal_group_external_bindings\".\"provider\" ~ '^[a-z][a-z0-9_-]*$'"
-        },
-        "principal_group_external_bindings_external_id_present": {
-          "name": "principal_group_external_bindings_external_id_present",
-          "value": "length(btrim(\"principal_group_external_bindings\".\"external_id\")) > 0"
-        },
-        "principal_group_external_bindings_metadata_object": {
-          "name": "principal_group_external_bindings_metadata_object",
-          "value": "jsonb_typeof(\"principal_group_external_bindings\".\"metadata\") = 'object'"
-        }
-      },
-      "isRLSEnabled": false
-    },
-    "public.principal_group_memberships": {
-      "name": "principal_group_memberships",
-      "schema": "",
-      "columns": {
-        "principal_uid": {
-          "name": "principal_uid",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "group_id": {
-          "name": "group_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        }
-      },
-      "indexes": {
-        "principal_group_memberships_group_id_index": {
-          "name": "principal_group_memberships_group_id_index",
-          "columns": [
-            {
-              "expression": "group_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "principal_group_memberships_principal_uid_principals_uid_fk": {
-          "name": "principal_group_memberships_principal_uid_principals_uid_fk",
-          "tableFrom": "principal_group_memberships",
-          "tableTo": "principals",
-          "columnsFrom": [
-            "principal_uid"
-          ],
-          "columnsTo": [
-            "uid"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "principal_group_memberships_group_id_principal_groups_id_fk": {
-          "name": "principal_group_memberships_group_id_principal_groups_id_fk",
-          "tableFrom": "principal_group_memberships",
-          "tableTo": "principal_groups",
-          "columnsFrom": [
-            "group_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "principal_group_memberships_principal_uid_group_id_pk": {
-          "name": "principal_group_memberships_principal_uid_group_id_pk",
-          "columns": [
-            "principal_uid",
-            "group_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.principal_groups": {
-      "name": "principal_groups",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "kind": {
-          "name": "kind",
-          "type": "principal_group_kind",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'static'"
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "computed_condition": {
-          "name": "computed_condition",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "built_in": {
-          "name": "built_in",
+        "enabled": {
+          "name": "enabled",
           "type": "boolean",
           "primaryKey": false,
           "notNull": true,
-          "default": false
+          "default": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_library_entries_active_path_index": {
+          "name": "agent_library_entries_active_path_index",
+          "columns": [
+            {
+              "expression": "agent_uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "virtual_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_library_container_entries\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_library_entries_agent_index": {
+          "name": "agent_library_entries_agent_index",
+          "columns": [
+            {
+              "expression": "agent_uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "virtual_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_library_container_entries_agent_uid_agents_uid_fk": {
+          "name": "agent_library_container_entries_agent_uid_agents_uid_fk",
+          "tableFrom": "agent_library_container_entries",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_uid"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_library_entries_virtual_path_relative": {
+          "name": "agent_library_entries_virtual_path_relative",
+          "value": "\"agent_library_container_entries\".\"virtual_path\" !~ '(^/|(^|/)..(/|$)|//)'"
+        },
+        "agent_library_entries_kind_check": {
+          "name": "agent_library_entries_kind_check",
+          "value": "\"agent_library_container_entries\".\"entry_kind\" in ('file', 'directory')"
+        },
+        "agent_library_entries_source_check": {
+          "name": "agent_library_entries_source_check",
+          "value": "\"agent_library_container_entries\".\"source_kind\" in ('soul', 'mission', 'skill_append', 'setting', 'memory', 'system', 'user', 'computer')"
+        },
+        "agent_library_entries_one_content": {
+          "name": "agent_library_entries_one_content",
+          "value": "not (\"agent_library_container_entries\".\"content_text\" is not null and \"agent_library_container_entries\".\"content_bytes\" is not null)"
+        },
+        "agent_library_entries_metadata_object": {
+          "name": "agent_library_entries_metadata_object",
+          "value": "jsonb_typeof(\"agent_library_container_entries\".\"metadata\") = 'object'"
+        },
+        "agent_library_entries_source_ref_object": {
+          "name": "agent_library_entries_source_ref_object",
+          "value": "jsonb_typeof(\"agent_library_container_entries\".\"source_ref\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_skill_assignments": {
+      "name": "agent_skill_assignments",
+      "schema": "",
+      "columns": {
+        "agent_uid": {
+          "name": "agent_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skill_assignments_agent_index": {
+          "name": "agent_skill_assignments_agent_index",
+          "columns": [
+            {
+              "expression": "agent_uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_assignments_agent_uid_agents_uid_fk": {
+          "name": "agent_skill_assignments_agent_uid_agents_uid_fk",
+          "tableFrom": "agent_skill_assignments",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_uid"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skill_assignments_skill_id_library_skills_id_fk": {
+          "name": "agent_skill_assignments_skill_id_library_skills_id_fk",
+          "tableFrom": "agent_skill_assignments",
+          "tableTo": "library_skills",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skill_assignments_agent_uid_skill_id_pk": {
+          "name": "agent_skill_assignments_agent_uid_skill_id_pk",
+          "columns": [
+            "agent_uid",
+            "skill_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_skill_assignments_metadata_object": {
+          "name": "agent_skill_assignments_metadata_object",
+          "value": "jsonb_typeof(\"agent_skill_assignments\".\"metadata\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "agent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'llm_agentic_loop'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by_principal_uid": {
+          "name": "created_by_principal_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -551,38 +371,352 @@
         }
       },
       "indexes": {
-        "principal_groups_name_index": {
-          "name": "principal_groups_name_index",
+        "agents_created_by_principal_uid_index": {
+          "name": "agents_created_by_principal_uid_index",
           "columns": [
             {
-              "expression": "name",
+              "expression": "created_by_principal_uid",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
             }
           ],
-          "isUnique": true,
+          "isUnique": false,
           "concurrently": false,
           "method": "btree",
           "with": {}
         }
       },
-      "foreignKeys": {},
+      "foreignKeys": {
+        "agents_uid_principals_uid_fk": {
+          "name": "agents_uid_principals_uid_fk",
+          "tableFrom": "agents",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "uid"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agents_created_by_principal_uid_principals_uid_fk": {
+          "name": "agents_created_by_principal_uid_principals_uid_fk",
+          "tableFrom": "agents",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "created_by_principal_uid"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {
-        "principal_groups_name_present": {
-          "name": "principal_groups_name_present",
-          "value": "length(btrim(\"principal_groups\".\"name\")) > 0"
+        "agents_metadata_object": {
+          "name": "agents_metadata_object",
+          "value": "jsonb_typeof(\"agents\".\"metadata\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ai_agent_checkbacks": {
+      "name": "ai_agent_checkbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
         },
-        "principal_groups_name_lowercase": {
-          "name": "principal_groups_name_lowercase",
-          "value": "\"principal_groups\".\"name\" = lower(\"principal_groups\".\"name\")"
+        "agent_uid": {
+          "name": "agent_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
         },
-        "principal_groups_computed_condition_by_kind": {
-          "name": "principal_groups_computed_condition_by_kind",
-          "value": "(\"principal_groups\".\"kind\" = 'static' AND \"principal_groups\".\"computed_condition\" IS NULL) OR (\"principal_groups\".\"kind\" = 'computed' AND length(btrim(\"principal_groups\".\"computed_condition\")) > 0)"
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check": {
+          "name": "check",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_summary": {
+          "name": "context_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wake_message": {
+          "name": "wake_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_message_id": {
+          "name": "trigger_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_agent_checkbacks_due_index": {
+          "name": "ai_agent_checkbacks_due_index",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_agent_checkbacks_agent_index": {
+          "name": "ai_agent_checkbacks_agent_index",
+          "columns": [
+            {
+              "expression": "agent_uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_agent_checkbacks_conversation_index": {
+          "name": "ai_agent_checkbacks_conversation_index",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_agent_checkbacks_trigger_message_index": {
+          "name": "ai_agent_checkbacks_trigger_message_index",
+          "columns": [
+            {
+              "expression": "trigger_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_agent_checkbacks_lease_index": {
+          "name": "ai_agent_checkbacks_lease_index",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_agent_checkbacks_agent_uid_agents_uid_fk": {
+          "name": "ai_agent_checkbacks_agent_uid_agents_uid_fk",
+          "tableFrom": "ai_agent_checkbacks",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_uid"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_agent_checkbacks_conversation_id_ai_agent_conversations_id_fk": {
+          "name": "ai_agent_checkbacks_conversation_id_ai_agent_conversations_id_fk",
+          "tableFrom": "ai_agent_checkbacks",
+          "tableTo": "ai_agent_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_agent_checkbacks_trigger_message_id_ai_agent_messages_id_fk": {
+          "name": "ai_agent_checkbacks_trigger_message_id_ai_agent_messages_id_fk",
+          "tableFrom": "ai_agent_checkbacks",
+          "tableTo": "ai_agent_messages",
+          "columnsFrom": [
+            "trigger_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ai_agent_checkbacks_status_check": {
+          "name": "ai_agent_checkbacks_status_check",
+          "value": "\"ai_agent_checkbacks\".\"status\" in ('pending', 'running', 'succeeded', 'failed', 'cancelled')"
+        },
+        "ai_agent_checkbacks_timezone_nonempty": {
+          "name": "ai_agent_checkbacks_timezone_nonempty",
+          "value": "\"ai_agent_checkbacks\".\"timezone\" <> ''"
+        },
+        "ai_agent_checkbacks_reason_nonempty": {
+          "name": "ai_agent_checkbacks_reason_nonempty",
+          "value": "\"ai_agent_checkbacks\".\"reason\" <> ''"
+        },
+        "ai_agent_checkbacks_check_nonempty": {
+          "name": "ai_agent_checkbacks_check_nonempty",
+          "value": "\"ai_agent_checkbacks\".\"check\" <> ''"
+        },
+        "ai_agent_checkbacks_source_object": {
+          "name": "ai_agent_checkbacks_source_object",
+          "value": "jsonb_typeof(\"ai_agent_checkbacks\".\"source\") = 'object'"
+        },
+        "ai_agent_checkbacks_wake_message_array": {
+          "name": "ai_agent_checkbacks_wake_message_array",
+          "value": "jsonb_typeof(\"ai_agent_checkbacks\".\"wake_message\") = 'array'"
+        },
+        "ai_agent_checkbacks_metadata_object": {
+          "name": "ai_agent_checkbacks_metadata_object",
+          "value": "jsonb_typeof(\"ai_agent_checkbacks\".\"metadata\") = 'object'"
         }
       },
       "isRLSEnabled": false
@@ -1355,6 +1489,58 @@
       },
       "isRLSEnabled": false
     },
+    "public.app_configure": {
+      "name": "app_configure",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "key_unique": {
+          "name": "key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "app_configure_value_envelope": {
+          "name": "app_configure_value_envelope",
+          "value": "jsonb_typeof(\"app_configure\".\"value\") = 'object' AND \"app_configure\".\"value\" ? 'type' AND \"app_configure\".\"value\" ? 'value'"
+        }
+      },
+      "isRLSEnabled": false
+    },
     "public.chat_recall_embeddings": {
       "name": "chat_recall_embeddings",
       "schema": "",
@@ -1548,6 +1734,274 @@
           "value": "\"chat_recall_embeddings\".\"status\" in ('pending', 'processing', 'synced', 'failed')"
         }
       },
+      "isRLSEnabled": false
+    },
+    "public.computer_agent_worker_bindings": {
+      "name": "computer_agent_worker_bindings",
+      "schema": "",
+      "columns": {
+        "agent_uid": {
+          "name": "agent_uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_kind": {
+          "name": "binding_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_reason": {
+          "name": "binding_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_resolved_at": {
+          "name": "last_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "computer_agent_worker_bindings_worker_index": {
+          "name": "computer_agent_worker_bindings_worker_index",
+          "columns": [
+            {
+              "expression": "worker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_agent_worker_bindings_worker_id_computer_workers_worker_id_fk": {
+          "name": "computer_agent_worker_bindings_worker_id_computer_workers_worker_id_fk",
+          "tableFrom": "computer_agent_worker_bindings",
+          "tableTo": "computer_workers",
+          "columnsFrom": [
+            "worker_id"
+          ],
+          "columnsTo": [
+            "worker_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_agent_worker_pins": {
+      "name": "computer_agent_worker_pins",
+      "schema": "",
+      "columns": {
+        "agent_uid": {
+          "name": "agent_uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_principal_uid": {
+          "name": "created_by_principal_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "computer_agent_worker_pins_worker_index": {
+          "name": "computer_agent_worker_pins_worker_index",
+          "columns": [
+            {
+              "expression": "worker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_agent_worker_pins_worker_id_computer_workers_worker_id_fk": {
+          "name": "computer_agent_worker_pins_worker_id_computer_workers_worker_id_fk",
+          "tableFrom": "computer_agent_worker_pins",
+          "tableTo": "computer_workers",
+          "columnsFrom": [
+            "worker_id"
+          ],
+          "columnsTo": [
+            "worker_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_workers": {
+      "name": "computer_workers",
+      "schema": "",
+      "columns": {
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starting'"
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "load": {
+          "name": "load",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.external_agent_room_observations": {
@@ -2577,173 +3031,84 @@
       },
       "isRLSEnabled": false
     },
-    "public.agent_library_container_entries": {
-      "name": "agent_library_container_entries",
+    "public.human_users": {
+      "name": "human_users",
       "schema": "",
       "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
+        "principal_uid": {
+          "name": "principal_uid",
+          "type": "text",
           "primaryKey": true,
           "notNull": true
         },
-        "agent_uid": {
-          "name": "agent_uid",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "virtual_path": {
-          "name": "virtual_path",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "entry_kind": {
-          "name": "entry_kind",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'file'"
-        },
-        "source_kind": {
-          "name": "source_kind",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "source_ref": {
-          "name": "source_ref",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "content_text": {
-          "name": "content_text",
+        "email": {
+          "name": "email",
           "type": "text",
           "primaryKey": false,
           "notNull": false
         },
-        "content_bytes": {
-          "name": "content_bytes",
+        "phone": {
+          "name": "phone",
           "type": "text",
           "primaryKey": false,
           "notNull": false
-        },
-        "content_media_type": {
-          "name": "content_media_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'text/plain'"
-        },
-        "content_blake3": {
-          "name": "content_blake3",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "enabled": {
-          "name": "enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "version": {
-          "name": "version",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'1'"
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp with time zone",
+          "type": "timestamp",
           "primaryKey": false,
           "notNull": true,
-          "default": "now()"
+          "default": "CURRENT_TIMESTAMP"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp with time zone",
+          "type": "timestamp",
           "primaryKey": false,
           "notNull": true,
-          "default": "now()"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
+          "default": "CURRENT_TIMESTAMP"
         }
       },
       "indexes": {
-        "agent_library_entries_active_path_index": {
-          "name": "agent_library_entries_active_path_index",
+        "human_users_email_index": {
+          "name": "human_users_email_index",
           "columns": [
             {
-              "expression": "agent_uid",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "virtual_path",
+              "expression": "email",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
             }
           ],
           "isUnique": true,
-          "where": "\"agent_library_container_entries\".\"deleted_at\" IS NULL",
+          "where": "\"human_users\".\"email\" IS NOT NULL",
           "concurrently": false,
           "method": "btree",
           "with": {}
         },
-        "agent_library_entries_agent_index": {
-          "name": "agent_library_entries_agent_index",
+        "human_users_phone_index": {
+          "name": "human_users_phone_index",
           "columns": [
             {
-              "expression": "agent_uid",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "enabled",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "virtual_path",
+              "expression": "phone",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
             }
           ],
-          "isUnique": false,
+          "isUnique": true,
+          "where": "\"human_users\".\"phone\" IS NOT NULL",
           "concurrently": false,
           "method": "btree",
           "with": {}
         }
       },
       "foreignKeys": {
-        "agent_library_container_entries_agent_uid_agents_uid_fk": {
-          "name": "agent_library_container_entries_agent_uid_agents_uid_fk",
-          "tableFrom": "agent_library_container_entries",
-          "tableTo": "agents",
+        "human_users_principal_uid_principals_uid_fk": {
+          "name": "human_users_principal_uid_principals_uid_fk",
+          "tableFrom": "human_users",
+          "tableTo": "principals",
           "columnsFrom": [
-            "agent_uid"
+            "principal_uid"
           ],
           "columnsTo": [
             "uid"
@@ -2755,146 +3120,7 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {
-        "agent_library_entries_virtual_path_relative": {
-          "name": "agent_library_entries_virtual_path_relative",
-          "value": "\"agent_library_container_entries\".\"virtual_path\" !~ '(^/|(^|/)..(/|$)|//)'"
-        },
-        "agent_library_entries_kind_check": {
-          "name": "agent_library_entries_kind_check",
-          "value": "\"agent_library_container_entries\".\"entry_kind\" in ('file', 'directory')"
-        },
-        "agent_library_entries_source_check": {
-          "name": "agent_library_entries_source_check",
-          "value": "\"agent_library_container_entries\".\"source_kind\" in ('soul', 'mission', 'skill_append', 'setting', 'memory', 'system', 'user', 'computer')"
-        },
-        "agent_library_entries_one_content": {
-          "name": "agent_library_entries_one_content",
-          "value": "not (\"agent_library_container_entries\".\"content_text\" is not null and \"agent_library_container_entries\".\"content_bytes\" is not null)"
-        },
-        "agent_library_entries_metadata_object": {
-          "name": "agent_library_entries_metadata_object",
-          "value": "jsonb_typeof(\"agent_library_container_entries\".\"metadata\") = 'object'"
-        },
-        "agent_library_entries_source_ref_object": {
-          "name": "agent_library_entries_source_ref_object",
-          "value": "jsonb_typeof(\"agent_library_container_entries\".\"source_ref\") = 'object'"
-        }
-      },
-      "isRLSEnabled": false
-    },
-    "public.agent_skill_assignments": {
-      "name": "agent_skill_assignments",
-      "schema": "",
-      "columns": {
-        "agent_uid": {
-          "name": "agent_uid",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "skill_id": {
-          "name": "skill_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "enabled": {
-          "name": "enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reason": {
-          "name": "reason",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "agent_skill_assignments_agent_index": {
-          "name": "agent_skill_assignments_agent_index",
-          "columns": [
-            {
-              "expression": "agent_uid",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "agent_skill_assignments_agent_uid_agents_uid_fk": {
-          "name": "agent_skill_assignments_agent_uid_agents_uid_fk",
-          "tableFrom": "agent_skill_assignments",
-          "tableTo": "agents",
-          "columnsFrom": [
-            "agent_uid"
-          ],
-          "columnsTo": [
-            "uid"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "agent_skill_assignments_skill_id_library_skills_id_fk": {
-          "name": "agent_skill_assignments_skill_id_library_skills_id_fk",
-          "tableFrom": "agent_skill_assignments",
-          "tableTo": "library_skills",
-          "columnsFrom": [
-            "skill_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "agent_skill_assignments_agent_uid_skill_id_pk": {
-          "name": "agent_skill_assignments_agent_uid_skill_id_pk",
-          "columns": [
-            "agent_uid",
-            "skill_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {
-        "agent_skill_assignments_metadata_object": {
-          "name": "agent_skill_assignments_metadata_object",
-          "value": "jsonb_typeof(\"agent_skill_assignments\".\"metadata\") = 'object'"
-        }
-      },
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.library_builtin_sync_state": {
@@ -3307,23 +3533,52 @@
       },
       "isRLSEnabled": false
     },
-    "public.agents": {
-      "name": "agents",
+    "public.permission_grants": {
+      "name": "permission_grants",
       "schema": "",
       "columns": {
-        "uid": {
-          "name": "uid",
-          "type": "text",
+        "id": {
+          "name": "id",
+          "type": "uuid",
           "primaryKey": true,
           "notNull": true
         },
-        "type": {
-          "name": "type",
-          "type": "agent_type",
-          "typeSchema": "public",
+        "principal_uid": {
+          "name": "principal_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_pattern": {
+          "name": "resource_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'llm_agentic_loop'"
+          "default": "'true'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
         },
         "metadata": {
           "name": "metadata",
@@ -3331,12 +3586,6 @@
           "primaryKey": false,
           "notNull": true,
           "default": "'{}'::jsonb"
-        },
-        "created_by_principal_uid": {
-          "name": "created_by_principal_uid",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -3354,11 +3603,11 @@
         }
       },
       "indexes": {
-        "agents_created_by_principal_uid_index": {
-          "name": "agents_created_by_principal_uid_index",
+        "permission_grants_principal_uid_index": {
+          "name": "permission_grants_principal_uid_index",
           "columns": [
             {
-              "expression": "created_by_principal_uid",
+              "expression": "principal_uid",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -3368,122 +3617,110 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
-        }
-      },
-      "foreignKeys": {
-        "agents_uid_principals_uid_fk": {
-          "name": "agents_uid_principals_uid_fk",
-          "tableFrom": "agents",
-          "tableTo": "principals",
-          "columnsFrom": [
-            "uid"
-          ],
-          "columnsTo": [
-            "uid"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
         },
-        "agents_created_by_principal_uid_principals_uid_fk": {
-          "name": "agents_created_by_principal_uid_principals_uid_fk",
-          "tableFrom": "agents",
-          "tableTo": "principals",
-          "columnsFrom": [
-            "created_by_principal_uid"
-          ],
-          "columnsTo": [
-            "uid"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {
-        "agents_metadata_object": {
-          "name": "agents_metadata_object",
-          "value": "jsonb_typeof(\"agents\".\"metadata\") = 'object'"
-        }
-      },
-      "isRLSEnabled": false
-    },
-    "public.human_users": {
-      "name": "human_users",
-      "schema": "",
-      "columns": {
-        "principal_uid": {
-          "name": "principal_uid",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "phone": {
-          "name": "phone",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        }
-      },
-      "indexes": {
-        "human_users_email_index": {
-          "name": "human_users_email_index",
+        "permission_grants_group_id_index": {
+          "name": "permission_grants_group_id_index",
           "columns": [
             {
-              "expression": "email",
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permission_grants_action_index": {
+          "name": "permission_grants_action_index",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permission_grants_principal_upsert_index": {
+          "name": "permission_grants_principal_upsert_index",
+          "columns": [
+            {
+              "expression": "principal_uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "condition",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
             }
           ],
           "isUnique": true,
-          "where": "\"human_users\".\"email\" IS NOT NULL",
+          "where": "\"permission_grants\".\"principal_uid\" IS NOT NULL",
           "concurrently": false,
           "method": "btree",
           "with": {}
         },
-        "human_users_phone_index": {
-          "name": "human_users_phone_index",
+        "permission_grants_group_upsert_index": {
+          "name": "permission_grants_group_upsert_index",
           "columns": [
             {
-              "expression": "phone",
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "condition",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
             }
           ],
           "isUnique": true,
-          "where": "\"human_users\".\"phone\" IS NOT NULL",
+          "where": "\"permission_grants\".\"group_id\" IS NOT NULL",
           "concurrently": false,
           "method": "btree",
           "with": {}
         }
       },
       "foreignKeys": {
-        "human_users_principal_uid_principals_uid_fk": {
-          "name": "human_users_principal_uid_principals_uid_fk",
-          "tableFrom": "human_users",
+        "permission_grants_principal_uid_principals_uid_fk": {
+          "name": "permission_grants_principal_uid_principals_uid_fk",
+          "tableFrom": "permission_grants",
           "tableTo": "principals",
           "columnsFrom": [
             "principal_uid"
@@ -3493,12 +3730,46 @@
           ],
           "onDelete": "cascade",
           "onUpdate": "no action"
+        },
+        "permission_grants_group_id_principal_groups_id_fk": {
+          "name": "permission_grants_group_id_principal_groups_id_fk",
+          "tableFrom": "permission_grants",
+          "tableTo": "principal_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "permission_grants_principal_exclusive": {
+          "name": "permission_grants_principal_exclusive",
+          "value": "(\"permission_grants\".\"principal_uid\" IS NOT NULL AND \"permission_grants\".\"group_id\" IS NULL) OR (\"permission_grants\".\"principal_uid\" IS NULL AND \"permission_grants\".\"group_id\" IS NOT NULL)"
+        },
+        "permission_grants_action_no_colon": {
+          "name": "permission_grants_action_no_colon",
+          "value": "position(':' in \"permission_grants\".\"action\") = 0"
+        },
+        "permission_grants_resource_pattern_present": {
+          "name": "permission_grants_resource_pattern_present",
+          "value": "length(\"permission_grants\".\"resource_pattern\") > 0"
+        },
+        "permission_grants_action_present": {
+          "name": "permission_grants_action_present",
+          "value": "length(\"permission_grants\".\"action\") > 0"
+        },
+        "permission_grants_metadata_object": {
+          "name": "permission_grants_metadata_object",
+          "value": "jsonb_typeof(\"permission_grants\".\"metadata\") = 'object'"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.principal_external_identities": {
@@ -3731,6 +4002,298 @@
       },
       "isRLSEnabled": false
     },
+    "public.principal_group_external_bindings": {
+      "name": "principal_group_external_bindings",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "principal_group_external_bindings_group_id_index": {
+          "name": "principal_group_external_bindings_group_id_index",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principal_group_external_bindings_group_id_principal_groups_id_fk": {
+          "name": "principal_group_external_bindings_group_id_principal_groups_id_fk",
+          "tableFrom": "principal_group_external_bindings",
+          "tableTo": "principal_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "principal_group_external_bindings_provider_external_id_pk": {
+          "name": "principal_group_external_bindings_provider_external_id_pk",
+          "columns": [
+            "provider",
+            "external_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_group_external_bindings_provider_present": {
+          "name": "principal_group_external_bindings_provider_present",
+          "value": "length(btrim(\"principal_group_external_bindings\".\"provider\")) > 0"
+        },
+        "principal_group_external_bindings_provider_format": {
+          "name": "principal_group_external_bindings_provider_format",
+          "value": "\"principal_group_external_bindings\".\"provider\" ~ '^[a-z][a-z0-9_-]*$'"
+        },
+        "principal_group_external_bindings_external_id_present": {
+          "name": "principal_group_external_bindings_external_id_present",
+          "value": "length(btrim(\"principal_group_external_bindings\".\"external_id\")) > 0"
+        },
+        "principal_group_external_bindings_metadata_object": {
+          "name": "principal_group_external_bindings_metadata_object",
+          "value": "jsonb_typeof(\"principal_group_external_bindings\".\"metadata\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.principal_group_memberships": {
+      "name": "principal_group_memberships",
+      "schema": "",
+      "columns": {
+        "principal_uid": {
+          "name": "principal_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "principal_group_memberships_group_id_index": {
+          "name": "principal_group_memberships_group_id_index",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principal_group_memberships_principal_uid_principals_uid_fk": {
+          "name": "principal_group_memberships_principal_uid_principals_uid_fk",
+          "tableFrom": "principal_group_memberships",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "principal_uid"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "principal_group_memberships_group_id_principal_groups_id_fk": {
+          "name": "principal_group_memberships_group_id_principal_groups_id_fk",
+          "tableFrom": "principal_group_memberships",
+          "tableTo": "principal_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "principal_group_memberships_principal_uid_group_id_pk": {
+          "name": "principal_group_memberships_principal_uid_group_id_pk",
+          "columns": [
+            "principal_uid",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal_groups": {
+      "name": "principal_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "principal_group_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'static'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_condition": {
+          "name": "computed_condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "built_in": {
+          "name": "built_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "principal_groups_name_index": {
+          "name": "principal_groups_name_index",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "principal_groups_name_present": {
+          "name": "principal_groups_name_present",
+          "value": "length(btrim(\"principal_groups\".\"name\")) > 0"
+        },
+        "principal_groups_name_lowercase": {
+          "name": "principal_groups_name_lowercase",
+          "value": "\"principal_groups\".\"name\" = lower(\"principal_groups\".\"name\")"
+        },
+        "principal_groups_computed_condition_by_kind": {
+          "name": "principal_groups_computed_condition_by_kind",
+          "value": "(\"principal_groups\".\"kind\" = 'static' AND \"principal_groups\".\"computed_condition\" IS NULL) OR (\"principal_groups\".\"kind\" = 'computed' AND length(btrim(\"principal_groups\".\"computed_condition\")) > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
     "public.principals": {
       "name": "principals",
       "schema": "",
@@ -3796,276 +4359,8 @@
       },
       "isRLSEnabled": false
     },
-    "public.computer_agent_worker_bindings": {
-      "name": "computer_agent_worker_bindings",
-      "schema": "",
-      "columns": {
-        "agent_uid": {
-          "name": "agent_uid",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "worker_id": {
-          "name": "worker_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "binding_kind": {
-          "name": "binding_kind",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "binding_reason": {
-          "name": "binding_reason",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "instance_id": {
-          "name": "instance_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "last_resolved_at": {
-          "name": "last_resolved_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "computer_agent_worker_bindings_worker_index": {
-          "name": "computer_agent_worker_bindings_worker_index",
-          "columns": [
-            {
-              "expression": "worker_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "computer_agent_worker_bindings_worker_id_computer_workers_worker_id_fk": {
-          "name": "computer_agent_worker_bindings_worker_id_computer_workers_worker_id_fk",
-          "tableFrom": "computer_agent_worker_bindings",
-          "tableTo": "computer_workers",
-          "columnsFrom": [
-            "worker_id"
-          ],
-          "columnsTo": [
-            "worker_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.computer_agent_worker_pins": {
-      "name": "computer_agent_worker_pins",
-      "schema": "",
-      "columns": {
-        "agent_uid": {
-          "name": "agent_uid",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "worker_id": {
-          "name": "worker_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reason": {
-          "name": "reason",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_by_principal_uid": {
-          "name": "created_by_principal_uid",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "computer_agent_worker_pins_worker_index": {
-          "name": "computer_agent_worker_pins_worker_index",
-          "columns": [
-            {
-              "expression": "worker_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "computer_agent_worker_pins_worker_id_computer_workers_worker_id_fk": {
-          "name": "computer_agent_worker_pins_worker_id_computer_workers_worker_id_fk",
-          "tableFrom": "computer_agent_worker_pins",
-          "tableTo": "computer_workers",
-          "columnsFrom": [
-            "worker_id"
-          ],
-          "columnsTo": [
-            "worker_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.computer_workers": {
-      "name": "computer_workers",
-      "schema": "",
-      "columns": {
-        "worker_id": {
-          "name": "worker_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "instance_id": {
-          "name": "instance_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "base_url": {
-          "name": "base_url",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'starting'"
-        },
-        "version": {
-          "name": "version",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "features": {
-          "name": "features",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "capacity": {
-          "name": "capacity",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "load": {
-          "name": "load",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "registered_at": {
-          "name": "registered_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "last_heartbeat_at": {
-          "name": "last_heartbeat_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.ai_agent_checkbacks": {
-      "name": "ai_agent_checkbacks",
+    "public.runtime_credentials": {
+      "name": "runtime_credentials",
       "schema": "",
       "columns": {
         "id": {
@@ -4074,103 +4369,54 @@
           "primaryKey": true,
           "notNull": true
         },
+        "consumer_kind": {
+          "name": "consumer_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumer_name": {
+          "name": "consumer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_name": {
+          "name": "credential_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_kind": {
+          "name": "scope_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
         "agent_uid": {
           "name": "agent_uid",
           "type": "text",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
-        "due_at": {
-          "name": "due_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "timezone": {
-          "name": "timezone",
+        "encrypted_payload": {
+          "name": "encrypted_payload",
           "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "status": {
-          "name": "status",
+        "payload_media_type": {
+          "name": "payload_media_type",
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'pending'"
+          "default": "'text/plain'"
         },
-        "reason": {
-          "name": "reason",
+        "payload_blake3": {
+          "name": "payload_blake3",
           "type": "text",
           "primaryKey": false,
           "notNull": true
-        },
-        "check": {
-          "name": "check",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "context_summary": {
-          "name": "context_summary",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "source": {
-          "name": "source",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "wake_message": {
-          "name": "wake_message",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "conversation_id": {
-          "name": "conversation_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "trigger_message_id": {
-          "name": "trigger_message_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "completed_at": {
-          "name": "completed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "claimed_by": {
-          "name": "claimed_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "claimed_at": {
-          "name": "claimed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "lease_expires_at": {
-          "name": "lease_expires_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "error": {
-          "name": "error",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         },
         "metadata": {
           "name": "metadata",
@@ -4178,6 +4424,13 @@
           "primaryKey": false,
           "notNull": true,
           "default": "'{}'::jsonb"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
         },
         "created_at": {
           "name": "created_at",
@@ -4195,83 +4448,97 @@
         }
       },
       "indexes": {
-        "ai_agent_checkbacks_due_index": {
-          "name": "ai_agent_checkbacks_due_index",
+        "runtime_credentials_default_index": {
+          "name": "runtime_credentials_default_index",
           "columns": [
             {
-              "expression": "status",
+              "expression": "consumer_kind",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
             },
             {
-              "expression": "due_at",
+              "expression": "consumer_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "credential_name",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
             }
           ],
-          "isUnique": false,
+          "isUnique": true,
+          "where": "\"runtime_credentials\".\"scope_kind\" = 'default'",
           "concurrently": false,
           "method": "btree",
           "with": {}
         },
-        "ai_agent_checkbacks_agent_index": {
-          "name": "ai_agent_checkbacks_agent_index",
+        "runtime_credentials_agent_index": {
+          "name": "runtime_credentials_agent_index",
           "columns": [
+            {
+              "expression": "consumer_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumer_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "credential_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
             {
               "expression": "agent_uid",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"runtime_credentials\".\"scope_kind\" = 'agent'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_credentials_lookup_index": {
+          "name": "runtime_credentials_lookup_index",
+          "columns": [
+            {
+              "expression": "consumer_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
             },
             {
-              "expression": "created_at",
+              "expression": "consumer_name",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "ai_agent_checkbacks_conversation_index": {
-          "name": "ai_agent_checkbacks_conversation_index",
-          "columns": [
+            },
             {
-              "expression": "conversation_id",
+              "expression": "credential_name",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "ai_agent_checkbacks_trigger_message_index": {
-          "name": "ai_agent_checkbacks_trigger_message_index",
-          "columns": [
+            },
             {
-              "expression": "trigger_message_id",
+              "expression": "scope_kind",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "ai_agent_checkbacks_lease_index": {
-          "name": "ai_agent_checkbacks_lease_index",
-          "columns": [
+            },
             {
-              "expression": "lease_expires_at",
+              "expression": "enabled",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -4284,9 +4551,9 @@
         }
       },
       "foreignKeys": {
-        "ai_agent_checkbacks_agent_uid_agents_uid_fk": {
-          "name": "ai_agent_checkbacks_agent_uid_agents_uid_fk",
-          "tableFrom": "ai_agent_checkbacks",
+        "runtime_credentials_agent_uid_agents_uid_fk": {
+          "name": "runtime_credentials_agent_uid_agents_uid_fk",
+          "tableFrom": "runtime_credentials",
           "tableTo": "agents",
           "columnsFrom": [
             "agent_uid"
@@ -4296,65 +4563,43 @@
           ],
           "onDelete": "cascade",
           "onUpdate": "no action"
-        },
-        "ai_agent_checkbacks_conversation_id_ai_agent_conversations_id_fk": {
-          "name": "ai_agent_checkbacks_conversation_id_ai_agent_conversations_id_fk",
-          "tableFrom": "ai_agent_checkbacks",
-          "tableTo": "ai_agent_conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        },
-        "ai_agent_checkbacks_trigger_message_id_ai_agent_messages_id_fk": {
-          "name": "ai_agent_checkbacks_trigger_message_id_ai_agent_messages_id_fk",
-          "tableFrom": "ai_agent_checkbacks",
-          "tableTo": "ai_agent_messages",
-          "columnsFrom": [
-            "trigger_message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {
-        "ai_agent_checkbacks_status_check": {
-          "name": "ai_agent_checkbacks_status_check",
-          "value": "\"ai_agent_checkbacks\".\"status\" in ('pending', 'running', 'succeeded', 'failed', 'cancelled')"
+        "runtime_credentials_consumer_kind_check": {
+          "name": "runtime_credentials_consumer_kind_check",
+          "value": "\"runtime_credentials\".\"consumer_kind\" in ('skill', 'tool', 'runtime')"
         },
-        "ai_agent_checkbacks_timezone_nonempty": {
-          "name": "ai_agent_checkbacks_timezone_nonempty",
-          "value": "\"ai_agent_checkbacks\".\"timezone\" <> ''"
+        "runtime_credentials_scope_kind_check": {
+          "name": "runtime_credentials_scope_kind_check",
+          "value": "\"runtime_credentials\".\"scope_kind\" in ('default', 'agent')"
         },
-        "ai_agent_checkbacks_reason_nonempty": {
-          "name": "ai_agent_checkbacks_reason_nonempty",
-          "value": "\"ai_agent_checkbacks\".\"reason\" <> ''"
+        "runtime_credentials_scope_agent_shape": {
+          "name": "runtime_credentials_scope_agent_shape",
+          "value": "(\"runtime_credentials\".\"scope_kind\" = 'default' AND \"runtime_credentials\".\"agent_uid\" IS NULL) OR (\"runtime_credentials\".\"scope_kind\" = 'agent' AND \"runtime_credentials\".\"agent_uid\" IS NOT NULL)"
         },
-        "ai_agent_checkbacks_check_nonempty": {
-          "name": "ai_agent_checkbacks_check_nonempty",
-          "value": "\"ai_agent_checkbacks\".\"check\" <> ''"
+        "runtime_credentials_consumer_name_format": {
+          "name": "runtime_credentials_consumer_name_format",
+          "value": "\"runtime_credentials\".\"consumer_name\" ~ '^[a-z][a-z0-9_-]{0,63}$'"
         },
-        "ai_agent_checkbacks_source_object": {
-          "name": "ai_agent_checkbacks_source_object",
-          "value": "jsonb_typeof(\"ai_agent_checkbacks\".\"source\") = 'object'"
+        "runtime_credentials_name_format": {
+          "name": "runtime_credentials_name_format",
+          "value": "\"runtime_credentials\".\"credential_name\" ~ '^[a-z][a-z0-9_-]{0,63}$'"
         },
-        "ai_agent_checkbacks_wake_message_array": {
-          "name": "ai_agent_checkbacks_wake_message_array",
-          "value": "jsonb_typeof(\"ai_agent_checkbacks\".\"wake_message\") = 'array'"
+        "runtime_credentials_payload_nonempty": {
+          "name": "runtime_credentials_payload_nonempty",
+          "value": "length(\"runtime_credentials\".\"encrypted_payload\") > 0"
         },
-        "ai_agent_checkbacks_metadata_object": {
-          "name": "ai_agent_checkbacks_metadata_object",
-          "value": "jsonb_typeof(\"ai_agent_checkbacks\".\"metadata\") = 'object'"
+        "runtime_credentials_payload_media_type_nonempty": {
+          "name": "runtime_credentials_payload_media_type_nonempty",
+          "value": "length(trim(\"runtime_credentials\".\"payload_media_type\")) > 0"
+        },
+        "runtime_credentials_metadata_object": {
+          "name": "runtime_credentials_metadata_object",
+          "value": "jsonb_typeof(\"runtime_credentials\".\"metadata\") = 'object'"
         }
       },
       "isRLSEnabled": false
@@ -4811,262 +5056,9 @@
         }
       },
       "isRLSEnabled": false
-    },
-    "public.runtime_credentials": {
-      "name": "runtime_credentials",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "consumer_kind": {
-          "name": "consumer_kind",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "consumer_name": {
-          "name": "consumer_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "credential_name": {
-          "name": "credential_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "scope_kind": {
-          "name": "scope_kind",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "agent_uid": {
-          "name": "agent_uid",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "encrypted_payload": {
-          "name": "encrypted_payload",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "payload_media_type": {
-          "name": "payload_media_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'text/plain'"
-        },
-        "payload_blake3": {
-          "name": "payload_blake3",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "enabled": {
-          "name": "enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "runtime_credentials_default_index": {
-          "name": "runtime_credentials_default_index",
-          "columns": [
-            {
-              "expression": "consumer_kind",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "consumer_name",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "credential_name",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"runtime_credentials\".\"scope_kind\" = 'default'",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "runtime_credentials_agent_index": {
-          "name": "runtime_credentials_agent_index",
-          "columns": [
-            {
-              "expression": "consumer_kind",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "consumer_name",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "credential_name",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "agent_uid",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"runtime_credentials\".\"scope_kind\" = 'agent'",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "runtime_credentials_lookup_index": {
-          "name": "runtime_credentials_lookup_index",
-          "columns": [
-            {
-              "expression": "consumer_kind",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "consumer_name",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "credential_name",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "scope_kind",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "enabled",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "runtime_credentials_agent_uid_agents_uid_fk": {
-          "name": "runtime_credentials_agent_uid_agents_uid_fk",
-          "tableFrom": "runtime_credentials",
-          "tableTo": "agents",
-          "columnsFrom": [
-            "agent_uid"
-          ],
-          "columnsTo": [
-            "uid"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {
-        "runtime_credentials_consumer_kind_check": {
-          "name": "runtime_credentials_consumer_kind_check",
-          "value": "\"runtime_credentials\".\"consumer_kind\" in ('skill', 'tool', 'runtime')"
-        },
-        "runtime_credentials_scope_kind_check": {
-          "name": "runtime_credentials_scope_kind_check",
-          "value": "\"runtime_credentials\".\"scope_kind\" in ('default', 'agent')"
-        },
-        "runtime_credentials_scope_agent_shape": {
-          "name": "runtime_credentials_scope_agent_shape",
-          "value": "(\"runtime_credentials\".\"scope_kind\" = 'default' AND \"runtime_credentials\".\"agent_uid\" IS NULL) OR (\"runtime_credentials\".\"scope_kind\" = 'agent' AND \"runtime_credentials\".\"agent_uid\" IS NOT NULL)"
-        },
-        "runtime_credentials_consumer_name_format": {
-          "name": "runtime_credentials_consumer_name_format",
-          "value": "\"runtime_credentials\".\"consumer_name\" ~ '^[a-z][a-z0-9_-]{0,63}$'"
-        },
-        "runtime_credentials_name_format": {
-          "name": "runtime_credentials_name_format",
-          "value": "\"runtime_credentials\".\"credential_name\" ~ '^[a-z][a-z0-9_-]{0,63}$'"
-        },
-        "runtime_credentials_payload_nonempty": {
-          "name": "runtime_credentials_payload_nonempty",
-          "value": "length(\"runtime_credentials\".\"encrypted_payload\") > 0"
-        },
-        "runtime_credentials_payload_media_type_nonempty": {
-          "name": "runtime_credentials_payload_media_type_nonempty",
-          "value": "length(trim(\"runtime_credentials\".\"payload_media_type\")) > 0"
-        },
-        "runtime_credentials_metadata_object": {
-          "name": "runtime_credentials_metadata_object",
-          "value": "jsonb_typeof(\"runtime_credentials\".\"metadata\") = 'object'"
-        }
-      },
-      "isRLSEnabled": false
     }
   },
   "enums": {
-    "public.principal_group_kind": {
-      "name": "principal_group_kind",
-      "schema": "public",
-      "values": [
-        "static",
-        "computed"
-      ]
-    },
     "public.agent_type": {
       "name": "agent_type",
       "schema": "public",
@@ -5082,6 +5074,14 @@
         "channel_actor",
         "login_subject",
         "outbound_actor"
+      ]
+    },
+    "public.principal_group_kind": {
+      "name": "principal_group_kind",
+      "schema": "public",
+      "values": [
+        "static",
+        "computed"
       ]
     },
     "public.principal_status": {

--- a/app/db/meta/_journal.json
+++ b/app/db/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1781082787803,
-      "tag": "20260610091307_init",
+      "when": 1781176743823,
+      "tag": "20260611111903_ambitious_pyro",
       "breakpoints": true
     }
   ]


### PR DESCRIPTION
This PR squashes the database migrations to represent the current final schema, removing intermediate migration states.

### Changes
- Removed old migration files: `app/db/20260610091307_init.sql` and `app/db/meta/20260610091307_snapshot.json`
- Generated a clean, single initial migration: `app/db/20260611111903_ambitious_pyro.sql` and `app/db/meta/20260611111903_snapshot.json`
- Updated `app/db/meta/_journal.json`
- Added `CREATE EXTENSION IF NOT EXISTS vector;` to the top of the generated SQL migration file to ensure pgvector is available on clean database setups.

### Verification
- Ran `bun run migrate:gen` again to confirm no schema changes remain.
- Ran `bun run drizzle-kit check` to verify metadata snapshot integrity (passed).
- Ran `bun run type-check` to ensure TypeScript compilation passes (passed).