### PR TITLE
docs(agent_computer): comment BullX LLM wrappers

### DIFF
--- a/app/agent_computer/src/llm/bullx-ai-sdk.ts
+++ b/app/agent_computer/src/llm/bullx-ai-sdk.ts
@@ -9,7 +9,19 @@ import {
   type SimpleStreamOptions
 } from './bullx'
 
-/** Converts BullX's durable transcript format into the AI SDK wire format used by provider calls. */
+// The seam between Ankole's durable BullX shapes (bullx.ts) and the vendored AI SDK's
+// per-call wire shapes. Everything here is pure translation, in BOTH directions:
+//  - outbound: BullX transcript -> AI SDK request (messages, provider options, reasoning)
+//  - inbound:  AI SDK result    -> BullX assistant message (stop reason, usage, cost)
+
+/**
+ * Maps a BullX transcript onto the AI SDK request shape. The non-obvious renames:
+ *  - BullX block `thinking` -> AI SDK `reasoning` content part.
+ *  - BullX `toolCall` (fields id/name/arguments) -> AI SDK `tool-call` (toolCallId/toolName/input).
+ *  - BullX role `toolResult` -> AI SDK role `tool`.
+ * Tool results are flattened to text: image blocks become an `[image:...]` placeholder because
+ * the tool-result wire slot only carries text, and `isError` selects the SDK's error-text variant.
+ */
 export function convertBullXMessagesToModelMessages(messages: Message[]): ModelMessage[] {
   return messages.map(message => {
     if (message.role === 'user') {
@@ -21,7 +33,9 @@ export function convertBullXMessagesToModelMessages(messages: Message[]): ModelM
             : message.content.map(block =>
                 block.type === 'text'
                   ? { type: 'text' as const, text: block.text }
-                  : { type: 'image' as const, image: block.data, mediaType: block.mimeType }
+                  : // BullX stores image bytes inline (base64) in `data`; the SDK image part wants
+                    // them under `image` with the mime type as `mediaType`.
+                    { type: 'image' as const, image: block.data, mediaType: block.mimeType }
               )
       }
     }
@@ -31,6 +45,7 @@ export function convertBullXMessagesToModelMessages(messages: Message[]): ModelM
         role: 'assistant',
         content: message.content.map(block => {
           if (block.type === 'text') return { type: 'text' as const, text: block.text }
+          // Replaying our own prior reasoning back to the provider as a 'reasoning' part.
           if (block.type === 'thinking') return { type: 'reasoning' as const, text: block.thinking }
           return {
             type: 'tool-call' as const,
@@ -42,6 +57,7 @@ export function convertBullXMessagesToModelMessages(messages: Message[]): ModelM
       }
     }
 
+    // toolResult: join all content blocks into a single text payload (images degraded to a tag).
     const text = message.content
       .map(block => (block.type === 'text' ? block.text : `[image:${block.mimeType}]`))
       .join('\n')
@@ -61,7 +77,12 @@ export function convertBullXMessagesToModelMessages(messages: Message[]): ModelM
   })
 }
 
-/** Builds a BullX assistant message with stable defaults for error paths and provider calls without usage data. */
+/**
+ * Stamps a BullX assistant message with model provenance and safe defaults. Used both for
+ * the success path (with `extra` carrying real usage/responseId) and for error/abort paths
+ * where there is no provider response at all. Usage defaults to a fresh copy of ZERO_USAGE
+ * (cost included) so callers never alias the shared constant; `extra` can override any field.
+ */
 export function createBullXAssistantMessage(
   model: Model<any>,
   stopReason: AssistantMessage['stopReason'],
@@ -86,10 +107,22 @@ export function toBullXStopReason(reason: string): AssistantMessage['stopReason'
   if (reason === 'length') return 'length'
   if (reason === 'tool-calls') return 'toolUse'
   if (reason === 'error') return 'error'
+  // Everything else (including the SDK's 'stop', 'content-filter', 'other', 'unknown')
+  // folds into 'stop'; 'aborted' is not produced here — callers set it from the abort signal.
   return 'stop'
 }
 
-/** Normalizes provider usage into BullX token buckets and computes cost in the same pass. */
+/**
+ * Folds the AI SDK's nested usage report into BullX's four flat token buckets and prices it.
+ *
+ * Cache tokens come from `inputTokenDetails` (Anthropic cache-read/write, OpenAI cached input);
+ * each missing field defaults to 0 because not every provider reports them. NOTE: `input` here
+ * is the SDK's reported input count, which on cache-aware providers may already include cached
+ * tokens — BullX records cacheRead/cacheWrite as separate line items and lets the per-bucket
+ * prices in the model sort out the billing, rather than trying to subtract them. `totalTokens`
+ * falls back to input+output when the provider omits a grand total. Cost is computed in the same
+ * pass via calculateCost so usage and cost are always consistent.
+ */
 export function toBullXUsage(usage: LanguageModelUsage | undefined, model: Model<any>): AssistantMessage['usage'] {
   const input = usage?.inputTokens ?? 0
   const output = usage?.outputTokens ?? 0
@@ -118,7 +151,13 @@ export function resolveBullXReasoning(
   return options.reasoning
 }
 
-/** Builds provider-specific cache controls from BullX's provider-neutral cache retention option. */
+/**
+ * Translates BullX's provider-neutral `cacheRetention` ('short'|'long') into each provider's
+ * own prompt-cache controls. Only OpenAI and Anthropic have explicit knobs here; every other
+ * provider falls through and just keeps the caller's explicit options (caching, if any, is
+ * implicit). Returns `explicitOptions` untouched when caching is off so we never fabricate a
+ * provider-options object the caller didn't ask for.
+ */
 export function createBullXProviderOptions(
   model: Model<any>,
   options: SimpleStreamOptions
@@ -128,17 +167,22 @@ export function createBullXProviderOptions(
   if (!cacheRetention || cacheRetention === 'none') return explicitOptions
 
   if (model.provider === 'openai') {
+    // OpenAI prompt caching keys on a caller-supplied string. Without a stable key we can't
+    // safely opt in (an empty/shared key would risk cross-conversation reuse), so bail.
     const promptCacheKey = promptCacheKeyFromOptions(model, options)
     if (!promptCacheKey) return explicitOptions
     return mergeProviderOptions(explicitOptions, {
       openai: {
         promptCacheKey,
+        // 'long' -> persisted 24h cache; 'short' -> in-memory (lives only for the burst).
         promptCacheRetention: cacheRetention === 'long' ? '24h' : 'in_memory'
       }
     })
   }
 
   if (model.provider === 'anthropic') {
+    // Anthropic caches via an ephemeral cache-control breakpoint; we pick the TTL.
+    // 'long' -> 1h, 'short' -> 5m (Anthropic's two supported ephemeral TTLs).
     return mergeProviderOptions(explicitOptions, {
       anthropic: {
         cacheControl: {
@@ -152,7 +196,12 @@ export function createBullXProviderOptions(
   return explicitOptions
 }
 
-/** Merges control-plane provider options with BullX-local cache controls without dropping either side. */
+/**
+ * Deep-merges two provider-options maps one level into each provider's sub-object so
+ * BullX's cache controls (`right`) and the caller's explicit options (`left`) coexist.
+ * Precedence: `right` wins on key collisions, but only within the same provider — other
+ * providers' settings are preserved untouched.
+ */
 function mergeProviderOptions(
   left: ProviderOptions | undefined,
   right: ProviderOptions | undefined
@@ -170,7 +219,12 @@ function mergeProviderOptions(
   return merged
 }
 
-/** Names OpenAI prompt-cache entries by installation conversation so cache reuse never crosses conversations. */
+/**
+ * Derives a stable OpenAI prompt-cache key scoped to one conversation. Including provider +
+ * model id in the key means a cache entry is never reused across a different model, and the
+ * conversation id means it never bleeds between conversations (privacy + correctness). Returns
+ * undefined when no conversation id is in metadata, which disables caching for that call.
+ */
 function promptCacheKeyFromOptions(model: Model<any>, options: SimpleStreamOptions): string | undefined {
   const conversationId =
     stringMetadata(options.metadata, 'conversation_id') ?? stringMetadata(options.metadata, 'cache_key')
@@ -186,5 +240,7 @@ function stringMetadata(metadata: Record<string, unknown> | undefined, key: stri
 
 /** Keeps cache-key parts inside provider-safe characters and bounded length. */
 function sanitizeCacheKeyPart(value: string): string {
+  // Replace anything outside a conservative whitelist, then cap at 128 chars to stay under
+  // provider key-length limits (a long conversation id won't blow the budget).
   return value.replace(/[^a-zA-Z0-9_.:-]/g, '_').slice(0, 128)
 }

--- a/app/agent_computer/src/llm/bullx-generate.ts
+++ b/app/agent_computer/src/llm/bullx-generate.ts
@@ -9,12 +9,22 @@ import {
   toBullXUsage
 } from './bullx-ai-sdk'
 
-/** Runs a non-streaming BullX LLM call through the AI SDK and returns the durable assistant message shape. */
+/**
+ * One-shot (non-streaming) BullX call: maps the BullX context onto an AI SDK generateText
+ * request, runs it, and folds the result back into a durable AssistantMessage.
+ *
+ * This NEVER throws. Every outcome — missing model instance, provider error, caller abort —
+ * is returned as an assistant message with the matching stop reason, so the agent runtime can
+ * persist the turn and recover instead of unwinding the loop. The streaming counterpart lives
+ * elsewhere; this is the wrapper used for single-response generations.
+ */
 export async function generateBullXText(
   model: Model<any>,
   context: Context,
   options: SimpleStreamOptions = {}
 ): Promise<AssistantMessage> {
+  // A catalog Model without a resolved sdkModel (no API key / base URL bound yet) can't be
+  // called — surface that as an error turn rather than dereferencing undefined.
   if (!model.sdkModel) {
     return createBullXAssistantMessage(model, 'error', [], {
       errorMessage: `LLM model ${model.provider}/${model.id} is missing an AI SDK model instance`
@@ -22,6 +32,7 @@ export async function generateBullXText(
   }
 
   try {
+    // Treat 0 / negative / non-number as "no cap" so a bad option doesn't request zero tokens.
     const maxOutputTokens =
       typeof options.maxTokens === 'number' && options.maxTokens > 0 ? options.maxTokens : undefined
     const result = await generateText({
@@ -30,6 +41,7 @@ export async function generateBullXText(
       messages: convertBullXMessagesToModelMessages(context.messages),
       maxOutputTokens,
       temperature: options.temperature,
+      // Drops the reasoning request on non-reasoning models so we don't send an unsupported option.
       reasoning: resolveBullXReasoning(model, options),
       maxRetries: options.maxRetries,
       timeout: options.timeoutMs,
@@ -40,6 +52,7 @@ export async function generateBullXText(
     return createBullXAssistantMessage(
       model,
       toBullXStopReason(result.finishReason),
+      // generateText returns the text already joined; wrap it as a single text block (empty -> no blocks).
       result.text ? [{ type: 'text', text: result.text }] : [],
       {
         responseId: result.response.id,
@@ -48,6 +61,8 @@ export async function generateBullXText(
       }
     )
   } catch (error) {
+    // Distinguish a caller-initiated cancel ('aborted') from a genuine failure ('error') so the
+    // runtime can tell intentional stops apart from things worth retrying/alerting on.
     return createBullXAssistantMessage(model, options.signal?.aborted ? 'aborted' : 'error', [], {
       errorMessage: error instanceof Error ? error.message : String(error)
     })

--- a/app/agent_computer/src/llm/bullx.ts
+++ b/app/agent_computer/src/llm/bullx.ts
@@ -3,12 +3,25 @@ import type { LanguageModel } from './types'
 import type { ProviderOptions } from './provider-utils'
 import type { z } from 'zod'
 
+// "BullX" is Ankole's own LLM abstraction layer. It sits ON TOP of the vendored
+// Vercel AI SDK (everything else under src/llm/) and defines the provider-neutral,
+// durable shapes the agent runtime persists to the ledger: Message, AssistantMessage,
+// Usage, ToolCall, Model. The AI SDK speaks the per-call wire format (ModelMessage /
+// content parts); BullX speaks the format that survives across turns, recovery, and
+// audit. The translation between the two lives in bullx-ai-sdk.ts.
+
+/** Provider API dialect (e.g. 'openai-responses', 'anthropic-messages', 'openai-completions'); selects which AI SDK transport a model speaks. */
 export type Api = string
+/** Provider kind as stored in installation config (e.g. 'openai', 'anthropic', 'openrouter'). */
 export type Provider = string
 export type ThinkingLevel = 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
+/** Per-model reasoning capability: 'off' disables it, otherwise one of the shared thinking levels. */
 export type ModelThinkingLevel = 'off' | ThinkingLevel
+/** Per-call reasoning request: 'none' opts out even on a reasoning-capable model. */
 export type ReasoningEffort = 'none' | ThinkingLevel
+/** Maps a BullX thinking level to the provider's own reasoning token/string (null = unsupported at that level). */
 export type ThinkingLevelMap = Partial<Record<ModelThinkingLevel, string | null>>
+/** Provider-neutral prompt-cache request. 'short'/'long' map to per-provider TTLs in bullx-ai-sdk.ts; 'none' disables caching. */
 export type CacheRetention = 'none' | 'short' | 'long'
 
 export interface ProviderResponse {
@@ -16,6 +29,7 @@ export interface ProviderResponse {
   headers: Record<string, string>
 }
 
+/** Caller-supplied knobs for a single BullX LLM call, normalized away from any one provider's option names. */
 export interface StreamOptions {
   temperature?: number
   maxTokens?: number
@@ -28,10 +42,15 @@ export interface StreamOptions {
   timeoutMs?: number
   maxRetries?: number
   maxRetryDelayMs?: number
+  // Free-form trace context (e.g. conversation_id / cache_key). Drives prompt-cache key
+  // derivation in bullx-ai-sdk.ts so cache reuse never leaks across conversations.
   metadata?: Record<string, unknown>
+  // Escape hatch: raw AI SDK provider options from the control plane, merged with (not
+  // overwritten by) BullX's own cache controls.
   providerOptions?: ProviderOptions
 }
 
+/** StreamOptions plus a reasoning effort request; the everyday option shape callers pass to generate/stream. */
 export interface SimpleStreamOptions extends StreamOptions {
   reasoning?: ReasoningEffort
 }
@@ -39,30 +58,53 @@ export interface SimpleStreamOptions extends StreamOptions {
 export interface TextContent {
   type: 'text'
   text: string
+  // Opaque provider signature for this text block (e.g. Anthropic's signed content),
+  // round-tripped verbatim so a replayed transcript stays acceptable to the provider.
   textSignature?: string
 }
 
 export interface ThinkingContent {
   type: 'thinking'
   thinking: string
+  // Opaque provider signature proving this reasoning block was emitted by the model;
+  // must be preserved to send the thinking back on later turns.
   thinkingSignature?: string
+  // Provider hid the reasoning text (safety-redacted); the block still occupies a slot
+  // so signatures and ordering line up on replay.
   redacted?: boolean
 }
 
 export interface ImageContent {
   type: 'image'
+  // Base64-encoded image bytes (not a URL); the agent computer keeps image data inline.
   data: string
   mimeType: string
 }
 
+/** A model's request to invoke an Ankole tool. `id` correlates with the matching ToolResultMessage on the next turn. */
 export interface ToolCall {
   type: 'toolCall'
   id: string
   name: string
   arguments: Record<string, any>
+  // Gemini-style signed-thought token attached to a tool call; preserved for replay.
   thoughtSignature?: string
 }
 
+/**
+ * Token accounting for one assistant turn, in BullX's normalized buckets.
+ *
+ * Providers report cache hits/misses inconsistently; BullX flattens them to four input
+ * buckets so cost is comparable across providers:
+ *  - input:      prompt tokens billed at full rate (provider's reported input count)
+ *  - cacheRead:  prompt tokens served from a prompt cache (cheap; e.g. Anthropic cache-read,
+ *                OpenAI cached input)
+ *  - cacheWrite: prompt tokens written INTO the cache this turn (a one-time premium on some
+ *                providers; zero where the provider doesn't bill cache writes)
+ *  - output:     completion tokens
+ * `cost` mirrors those buckets in currency and is filled in by calculateCost() using the
+ * model's per-token prices. `totalTokens` is the provider's grand total when given.
+ */
 export interface Usage {
   input: number
   output: number
@@ -78,14 +120,23 @@ export interface Usage {
   }
 }
 
+/** Why a turn ended. 'toolUse' means the model wants tools run; 'aborted' means a caller signal cancelled it. */
 export type StopReason = 'stop' | 'length' | 'toolUse' | 'error' | 'aborted'
 
 export interface UserMessage {
   role: 'user'
+  // Plain string for the common text-only case; the array form carries mixed text + images.
   content: string | (TextContent | ImageContent)[]
   timestamp: number
 }
 
+/**
+ * A persisted assistant turn. This is the durable record BullX writes to the ledger, so it
+ * keeps provenance the wire format discards: which model/provider/api produced it, the
+ * provider's response id (for support/debugging), token usage+cost, and why it stopped.
+ * `model` is the requested model id; `responseModel` is what the provider actually served
+ * (they differ when a provider aliases or upgrades a model).
+ */
 export interface AssistantMessage {
   role: 'assistant'
   content: (TextContent | ThinkingContent | ToolCall)[]
@@ -97,10 +148,18 @@ export interface AssistantMessage {
   diagnostics?: unknown[]
   usage: Usage
   stopReason: StopReason
+  // Set only when stopReason is 'error'/'aborted'; carries the raw provider/SDK error text
+  // (also matched against OVERFLOW_PATTERNS below to detect context overflow).
   errorMessage?: string
   timestamp: number
 }
 
+/**
+ * The outcome of running one tool, fed back to the model on the next turn. `toolCallId`
+ * must equal the originating ToolCall.id so the provider can pair them. `details` is an
+ * Ankole-side typed payload kept out of the model-visible `content` (for UI/audit, not sent
+ * to the LLM).
+ */
 export interface ToolResultMessage<TDetails = any> {
   role: 'toolResult'
   toolCallId: string
@@ -111,20 +170,31 @@ export interface ToolResultMessage<TDetails = any> {
   timestamp: number
 }
 
+/** One entry in a durable BullX transcript. Note: BullX's role is 'toolResult'; the AI SDK wire role is 'tool'. */
 export type Message = UserMessage | AssistantMessage | ToolResultMessage
 
+/** A tool offered to the model: name + description for the prompt, plus a Zod schema used to validate the model's arguments. */
 export interface BullXTool<TParameters extends z.ZodType = z.ZodType> {
   name: string
   description: string
   schema: TParameters
 }
 
+/** Everything needed to make one BullX call: the system prompt, the transcript so far, and the tools in scope. */
 export interface Context {
   systemPrompt?: string
   messages: Message[]
   tools?: BullXTool[]
 }
 
+/**
+ * The streaming protocol BullX emits while an assistant turn is being produced.
+ * Every event carries `partial`: the assistant message accumulated so far (so a consumer
+ * can render or checkpoint mid-stream). `contentIndex` is the slot in `partial.content`
+ * the event applies to, letting interleaved text/thinking/tool-call blocks be tracked
+ * independently. The stream ends with exactly one terminal event: `done` on success or
+ * `error` on abort/failure.
+ */
 export type AssistantMessageEvent =
   | { type: 'start'; partial: AssistantMessage }
   | { type: 'text_start'; contentIndex: number; partial: AssistantMessage }
@@ -139,6 +209,15 @@ export type AssistantMessageEvent =
   | { type: 'done'; reason: Extract<StopReason, 'stop' | 'length' | 'toolUse'>; message: AssistantMessage }
   | { type: 'error'; reason: Extract<StopReason, 'aborted' | 'error'>; error: AssistantMessage }
 
+/**
+ * Resolved metadata for one model BullX can call. Built from the catalog (see catalog.ts)
+ * and then enriched at request time once provider config is known.
+ *
+ * `cost` is per-token price in the same four buckets as Usage, so calculateCost() is a
+ * straight multiply. `sdkModel` is the concrete AI SDK LanguageModel instance, attached
+ * only after API key / base URL are resolved (catalog entries leave it undefined). A model
+ * with no `sdkModel` cannot be called — generate/stream short-circuit to an error.
+ */
 export interface Model<TApi extends Api = Api> {
   id: string
   name: string
@@ -157,10 +236,17 @@ export interface Model<TApi extends Api = Api> {
   contextWindow: number
   maxTokens: number
   headers?: Record<string, string>
+  // Provider-specific compatibility flags (e.g. quirks for OpenAI-compatible endpoints).
   compat?: Record<string, unknown>
   sdkModel?: LanguageModel
 }
 
+/**
+ * Canonical empty Usage, used as the baseline for turns that produced no measurable usage
+ * (error paths, providers that return no usage block). Treat it as immutable: callers that
+ * need a mutable copy spread BOTH `usage` and the nested `cost` (e.g.
+ * `{ ...ZERO_USAGE, cost: { ...ZERO_USAGE.cost } }`) so the shared `cost` object isn't aliased.
+ */
 export const ZERO_USAGE: Usage = {
   input: 0,
   output: 0,
@@ -176,7 +262,12 @@ export const ZERO_USAGE: Usage = {
   }
 }
 
-/** Calculates the normalized cost fields from model metadata after provider usage has been mapped to BullX tokens. */
+/**
+ * Multiplies each token bucket by the model's per-token price to fill in `usage.cost`.
+ * Runs after provider usage has been mapped into BullX's four buckets (see toBullXUsage).
+ * `total` is the plain sum of the four — cache reads/writes are already separate line items,
+ * so it does NOT double-count them with `input`.
+ */
 export function calculateCost(model: Model<any>, usage: Usage): Usage['cost'] {
   return {
     input: usage.input * model.cost.input,
@@ -198,17 +289,26 @@ export function validateToolArguments(
   },
   toolCall: ToolCall
 ): any {
+  // Duck-typed on `.parse` rather than instanceof ZodType so it tolerates tools whose schema
+  // is absent or non-Zod; in that case the raw arguments pass through unvalidated.
   if (typeof tool.schema?.parse === 'function') return tool.schema.parse(toolCall.arguments)
   return toolCall.arguments
 }
 
-/** Repairs common malformed JSON from lightweight LLM calls before falling back to strict parsing. */
+/**
+ * Tolerant JSON parse for model output that may be truncated or slightly malformed.
+ * `fixJson` returns undefined when it can't repair the input — in that case we fall back to
+ * strict JSON.parse so the caller still gets a real SyntaxError rather than a silent null.
+ */
 export function parseJsonWithRepair<T>(json: string): T {
   const fixed = fixJson(json)
   if (fixed === undefined) return JSON.parse(json) as T
   return JSON.parse(fixed) as T
 }
 
+// No provider exposes a machine-readable "context overflow" code, so we sniff their error
+// strings. This list is deliberately broad to cover OpenAI/Anthropic/Google/compatible
+// wordings; the agent loop uses a positive match to trigger context compaction/summarization.
 const OVERFLOW_PATTERNS = [
   /context (?:window|length)/i,
   /maximum context/i,
@@ -225,10 +325,15 @@ const OVERFLOW_PATTERNS = [
 
 /** Detects context overflow across providers that report it either as text errors, length stops, or usage counts. */
 export function isContextOverflow(message: AssistantMessage, contextWindow?: number): boolean {
+  // Path 1: provider rejected the request outright — match its error text.
   if (message.stopReason === 'error' && message.errorMessage) {
     return OVERFLOW_PATTERNS.some(pattern => pattern.test(message.errorMessage!))
   }
+  // Path 2: provider accepted but billed more input than the window holds.
   if (contextWindow && contextWindow > 0 && message.usage.input > contextWindow) return true
+  // Path 3: a 'length' stop at exactly the window with ZERO output means the prompt itself
+  // filled the window (true overflow), as opposed to a normal turn that simply hit maxTokens
+  // while generating (output > 0) — which is NOT overflow.
   if (contextWindow && contextWindow > 0 && message.stopReason === 'length' && message.usage.input >= contextWindow) {
     return message.usage.output === 0
   }

--- a/app/agent_computer/src/llm/catalog.ts
+++ b/app/agent_computer/src/llm/catalog.ts
@@ -8,6 +8,13 @@ import { createOpenAICompatible } from './providers/openai-compatible'
 import type { LanguageModel } from './types'
 import type { Api, Model } from './bullx'
 
+// Static catalog of the LLM providers/models Ankole ships with, plus the resolution helpers
+// the control plane uses to turn a (provider, modelId) pair from DB config into a callable
+// Model. Two provider classes live here: "first-class" providers with a fixed model list and
+// their own AI SDK adapter, and "compatible" (OpenAI-compatible) providers where an operator
+// may type ANY model id — for those, unknown ids are resolved to a synthetic Model.
+
+/** Provider kinds Ankole knows how to build an AI SDK adapter for. The string is what's stored in installation config. */
 export type LlmProviderKind =
   | 'openai'
   | 'anthropic'
@@ -25,6 +32,7 @@ export type LlmProviderKind =
   | 'fireworks'
   | 'together'
 
+/** One row in the static catalog. `compatible: true` marks an OpenAI-compatible provider that accepts arbitrary model ids. */
 export interface LlmProviderCatalogEntry {
   id: string
   name: string
@@ -34,6 +42,7 @@ export interface LlmProviderCatalogEntry {
   compatible?: boolean
 }
 
+/** Everything createLanguageModel needs from resolved DB config; `baseUrl` null/absent falls back to the model's default. */
 export interface CreateLanguageModelInput {
   llmProvider: string
   model: Model
@@ -43,8 +52,14 @@ export interface CreateLanguageModelInput {
   providerOptions?: Record<string, unknown>
 }
 
+// Default pricing for catalog models is ZERO across all buckets. Real per-token prices are
+// expected to be supplied out-of-band (e.g. from operator config), so calculateCost on a
+// raw catalog model reports 0 cost rather than a stale hardcoded number that would drift.
 const zeroCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
 
+// The shipped provider list. `model(...)` args after the names are: reasoning?, contextWindow,
+// maxTokens — see the `model` factory below. Compatible providers may ship a seed model list
+// (e.g. OpenRouter) or none at all (the operator enters ids by hand).
 const catalog: LlmProviderCatalogEntry[] = [
   provider('openai', 'OpenAI', 'https://api.openai.com/v1', 'openai-responses', [
     model('gpt-5', 'GPT-5', 'openai', 'openai-responses', true, 400000, 128000),
@@ -113,7 +128,12 @@ export function getModels(llmProvider: string): Model[] {
   return getProviderEntry(llmProvider)?.models.map(cloneModel) ?? []
 }
 
-/** Resolves a known model or creates a synthetic model for compatible providers with arbitrary model ids. */
+/**
+ * Resolves a (provider, modelId) pair to a Model. If the id is in the catalog, returns a clone
+ * of that entry. If not, falls back to a synthetic model — this is how compatible providers
+ * support model ids Ankole has never heard of. Returns undefined only when the PROVIDER is
+ * unknown; an unknown model under a known provider always resolves (via the synthetic fallback).
+ */
 export function getModel(llmProvider: string, modelId: string): Model | undefined {
   const entry = getProviderEntry(llmProvider)
   if (!entry) return undefined
@@ -126,8 +146,15 @@ export function getProviderEntry(llmProvider: string): LlmProviderCatalogEntry |
   return catalog.find(entry => entry.id === llmProvider)
 }
 
-/** Creates the concrete AI SDK language model used by BullX after DB provider config has been resolved. */
+/**
+ * Instantiates the concrete AI SDK LanguageModel for a resolved provider/model. The result is
+ * what gets attached to Model.sdkModel so generate/stream can actually call out. First-class
+ * providers each get their dedicated adapter; every other provider id falls through to the
+ * OpenAI-compatible adapter (the `default` case), which is why new compatible providers need
+ * no code change here beyond a catalog entry.
+ */
 export function createLanguageModel(input: CreateLanguageModelInput): LanguageModel {
+  // Operator-provided base URL wins; otherwise use the model's catalog default endpoint.
   const baseUrl = input.baseUrl ?? input.model.baseUrl
   const headers = input.headers
   const providerOptions = input.providerOptions ?? {}
@@ -155,6 +182,9 @@ export function createLanguageModel(input: CreateLanguageModelInput): LanguageMo
         ...(providerOptions as Record<string, never>)
       })(input.model.id as never)
     default:
+      // All compatible providers (openrouter, xai, groq, deepseek, custom, …) share this path.
+      // includeUsage asks the endpoint to return token usage so cost accounting works;
+      // supportsStructuredOutputs assumes JSON-schema response support (most OpenAI clones have it).
       return createOpenAICompatible({
         name: input.llmProvider,
         apiKey: input.apiKey,
@@ -168,6 +198,8 @@ export function createLanguageModel(input: CreateLanguageModelInput): LanguageMo
 
 /** Builds a first-class provider entry and stamps its default base URL onto every bundled model. */
 function provider(id: string, name: string, baseUrl: string, api: Api, models: Model[]): LlmProviderCatalogEntry {
+  // `item.baseUrl || baseUrl`: model() leaves baseUrl '' so each model inherits the provider's
+  // endpoint here, while still allowing a per-model override to win if one is ever set.
   return { id, name, baseUrl, api, models: models.map(item => ({ ...item, baseUrl: item.baseUrl || baseUrl })) }
 }
 
@@ -177,13 +209,19 @@ function compatibleProvider(id: string, name: string, baseUrl: string, models: M
     id,
     name,
     baseUrl,
+    // Compatible providers always speak the OpenAI completions dialect regardless of vendor.
     api: 'openai-completions',
     models: models.map(item => ({ ...item, baseUrl: item.baseUrl || baseUrl })),
     compatible: true
   }
 }
 
-/** Defines the minimal model metadata BullX needs for routing, limits, and context-overflow decisions. */
+/**
+ * Factory for a catalog model. baseUrl is intentionally '' so the provider/compatibleProvider
+ * wrappers fill it in; cost defaults to zero (see zeroCost). The two numbers are contextWindow
+ * (total prompt budget, feeds isContextOverflow) and maxTokens (output cap). `input` is fixed to
+ * text+image for every catalog model.
+ */
 function model(
   id: string,
   name: string,
@@ -207,7 +245,12 @@ function model(
   }
 }
 
-/** Provides conservative defaults for custom compatible-provider model ids that are not in the catalog. */
+/**
+ * Fallback Model for a custom id under a compatible provider. Defaults are deliberately
+ * conservative because we know nothing about the model: reasoning is assumed true (callers can
+ * still opt out per-call), text+image input, zero cost, and a modest 128k window / 8k output cap
+ * so context-overflow handling has a sane bound to work against.
+ */
 function syntheticModel(entry: LlmProviderCatalogEntry, id: string): Model {
   return {
     id,
@@ -223,7 +266,11 @@ function syntheticModel(entry: LlmProviderCatalogEntry, id: string): Model {
   }
 }
 
-/** Clones nested model metadata so provider resolution can merge headers/compat without mutating the catalog. */
+/**
+ * Deep-ish clone of a catalog model so callers can mutate runtime fields (headers, compat,
+ * cost, sdkModel) without corrupting the shared catalog singleton. Nested objects/arrays are
+ * copied; the rest are primitives that copy by value via the spread.
+ */
 function cloneModel<TApi extends Api>(item: Model<TApi>): Model<TApi> {
   return {
     ...item,

--- a/app/agent_computer/src/llm/index.ts
+++ b/app/agent_computer/src/llm/index.ts
@@ -1,4 +1,9 @@
-// import globals
+// Public entry point for the src/llm/ module. It flattens two layers into one import surface:
+// the vendored Vercel AI SDK (gateway, provider-utils, and the directory exports below) and
+// Ankole's first-party BullX layer (bullx*, catalog, testing). Consumers import from '@/llm'
+// and shouldn't need to know which half a symbol came from.
+
+// Side-effect import: installs AI SDK global shims; must run before anything else here.
 import './global'
 
 // re-exports:
@@ -52,6 +57,7 @@ export * from './ui-message-stream'
 export * from './upload-file'
 export * from './upload-skill'
 export * from './util'
+// --- Ankole's first-party BullX layer (everything above this line is the vendored AI SDK) ---
 export {
   ZERO_USAGE,
   calculateCost,

--- a/app/agent_computer/src/llm/testing.ts
+++ b/app/agent_computer/src/llm/testing.ts
@@ -7,10 +7,17 @@ import type {
 } from './provider'
 import type { AssistantMessage, Model, ToolCall, Usage } from './bullx'
 
+// In-process FAKE LLM provider for tests. It lets a test script a sequence of canned
+// AssistantMessages and exposes them through a real AI SDK LanguageModelV4 instance, so the
+// whole BullX -> AI SDK -> BullX round trip (including streaming) can be exercised with zero
+// network calls. The model's `api`/`provider` are the literal string 'faux'.
+
+/** One scripted turn: either a fixed AssistantMessage, or a function that can inspect the prompt/signal and decide. */
 export type FauxResponseStep =
   | AssistantMessage
   | ((context: unknown, options: { signal?: AbortSignal }) => AssistantMessage | Promise<AssistantMessage>)
 
+/** Handle returned to a test for driving one fake provider: swap its scripted responses, look up its models, or tear it down. */
 export interface FauxProviderRegistration {
   provider: string
   getModel(id: string): Model<any> | undefined
@@ -18,8 +25,16 @@ export interface FauxProviderRegistration {
   unregister(): void
 }
 
+// Module-level registry of live fake providers. Currently a bookkeeping set so unregister()
+// has somewhere to remove from; tests hold their own registration handle for lookups.
 const registrations = new Set<FauxProviderRegistration>()
 
+/**
+ * Spins up a fake provider with the given models. Each model gets a working `sdkModel` wired
+ * to a shared response queue. The queue advances one step per call and, once exhausted, keeps
+ * replaying the LAST scripted response (so a test that scripts N turns but the agent loops more
+ * doesn't fall off the end). With no script at all, it answers with an empty assistant message.
+ */
 export function registerFauxProvider(input: {
   provider: string
   models: Array<{ id: string; contextWindow?: number; maxTokens?: number }>
@@ -28,12 +43,15 @@ export function registerFauxProvider(input: {
   let calls = 0
   const models = new Map<string, Model<any>>()
   const nextResponse = async (context: unknown, options: { signal?: AbortSignal }) => {
+    // Clamp the index so calls past the end stick to the final scripted step (or index 0 when empty).
     const step = responses[Math.min(calls, Math.max(0, responses.length - 1))]
     calls += 1
     if (!step) return fauxAssistantMessage('')
     return typeof step === 'function' ? await step(context, options) : step
   }
 
+  // Build a ready-to-call Model per id, mirroring the real catalog shape so code under test
+  // can't tell a fake model from a real one. All share the same nextResponse queue.
   for (const item of input.models) {
     models.set(item.id, {
       id: item.id,
@@ -53,6 +71,7 @@ export function registerFauxProvider(input: {
   const registration: FauxProviderRegistration = {
     provider: input.provider,
     getModel: id => models.get(id),
+    // Re-script and rewind: a test calls this to set the next run's responses from call 0.
     setResponses(next) {
       responses = [...next]
       calls = 0
@@ -65,6 +84,7 @@ export function registerFauxProvider(input: {
   return registration
 }
 
+/** Convenience for scripting a tool-call block in a faux response; id defaults to a stable `call_<name>`. */
 export function fauxToolCall(name: string, args: Record<string, unknown> = {}, id = `call_${name}`): ToolCall {
   return {
     type: 'toolCall',
@@ -74,6 +94,12 @@ export function fauxToolCall(name: string, args: Record<string, unknown> = {}, i
   }
 }
 
+/**
+ * Builds a faux AssistantMessage from either a plain string (one text block; empty string -> no
+ * blocks) or explicit content blocks. The stop reason is inferred: a response containing any
+ * tool call is 'toolUse', otherwise 'stop' — matching how a real provider would finish those
+ * turns. `extra` overrides any field (e.g. set stopReason 'error' + errorMessage to script a failure).
+ */
 export function fauxAssistantMessage(
   content: string | AssistantMessage['content'],
   extra: Partial<AssistantMessage> = {}
@@ -93,6 +119,13 @@ export function fauxAssistantMessage(
   }
 }
 
+/**
+ * Implements the AI SDK's LanguageModelV4 interface against the scripted response queue.
+ * Both entry points pull the next scripted AssistantMessage and re-encode it into the SDK's
+ * wire shape: doGenerate returns it whole; doStream replays it as a sequence of stream parts.
+ * The prompt the SDK built is forwarded to the script as `context`, and the abort signal is
+ * passed through so a script can assert on cancellation.
+ */
 function createFauxSdkModel(
   provider: string,
   modelId: string,
@@ -111,6 +144,7 @@ function createFauxSdkModel(
         usage: v4Usage(response.usage),
         response: {
           id: response.responseId,
+          // Prefer the scripted served-model id, else fall back to the requested model id.
           modelId: response.responseModel ?? response.model,
           timestamp: new Date(response.timestamp)
         },
@@ -118,10 +152,14 @@ function createFauxSdkModel(
       }
     },
     async doStream(options) {
+      // Resolve the whole response up front, THEN emit it as a stream — there is no real
+      // incremental generation, so streaming is a deterministic replay of a known message.
       const response = await nextResponse(options.prompt, { signal: options.abortSignal })
       return {
         stream: new ReadableStream<LanguageModelV4StreamPart>({
           start(controller) {
+            // Frame the stream exactly as a real provider would: start, metadata, the body
+            // parts, then a single finish carrying final usage + finish reason.
             controller.enqueue({ type: 'stream-start', warnings: [] })
             controller.enqueue({
               type: 'response-metadata',
@@ -143,6 +181,7 @@ function createFauxSdkModel(
   }
 }
 
+/** Maps BullX content blocks to AI SDK content parts for the non-streaming path (thinking -> reasoning, toolCall -> tool-call with JSON-stringified args). */
 function responseContent(response: AssistantMessage): LanguageModelV4Content[] {
   return response.content.map(part => {
     if (part.type === 'text') return { type: 'text', text: part.text }
@@ -156,6 +195,13 @@ function responseContent(response: AssistantMessage): LanguageModelV4Content[] {
   })
 }
 
+/**
+ * Expands a finished AssistantMessage into the start/delta/end stream parts a real provider
+ * would emit. Each block becomes the whole delta in ONE chunk (no token-by-token splitting) —
+ * enough to exercise the SDK's streaming state machine deterministically. Tool calls emit the
+ * input-streaming parts AND a final consolidated `tool-call`. Non-tool blocks get a synthetic
+ * `part_<n>` id since only tool calls carry their own id; an 'error' stop appends an error part.
+ */
 function streamParts(response: AssistantMessage): LanguageModelV4StreamPart[] {
   const parts: LanguageModelV4StreamPart[] = []
   let index = 0
@@ -183,6 +229,7 @@ function streamParts(response: AssistantMessage): LanguageModelV4StreamPart[] {
   return parts
 }
 
+/** Inverse of toBullXStopReason: turns a BullX stop reason back into the SDK's finish-reason shape for the fake. */
 function finishReason(response: AssistantMessage): LanguageModelV4FinishReason {
   if (response.stopReason === 'length') return { unified: 'length', raw: 'length' }
   if (response.stopReason === 'toolUse') return { unified: 'tool-calls', raw: 'tool-calls' }
@@ -190,6 +237,11 @@ function finishReason(response: AssistantMessage): LanguageModelV4FinishReason {
   return { unified: 'stop', raw: response.stopReason }
 }
 
+/**
+ * Re-expands BullX's flat Usage into the SDK's nested usage shape. BullX's `input` is the full
+ * input count, so the SDK's `noCache` is derived by subtracting the cache buckets back out
+ * (floored at 0). This is the mirror image of toBullXUsage, which flattens the SDK shape down.
+ */
 function v4Usage(usage: Usage): LanguageModelV4Usage {
   return {
     inputTokens: {
@@ -206,6 +258,7 @@ function v4Usage(usage: Usage): LanguageModelV4Usage {
   }
 }
 
+/** Fresh zeroed Usage for faux messages (local copy of ZERO_USAGE so the shared constant is never aliased). */
 function zeroUsage(): Usage {
   return {
     input: 0,


### PR DESCRIPTION
## Summary

Adds intent-focused code comments to the six first-party **BullX** files in the Agent Computer (`app/agent_computer/src/llm/`). These wrap the vendored Vercel AI SDK and bridge Ankole's durable transcript/model abstractions to the SDK's per-call wire format.

**This is comment-only.** No code, logic, control flow, behavior, names, or ordering changed. The single non-comment diff line is the AI SDK image-branch object literal, line-split (verbatim tokens) to host an inline comment — semantically identical TypeScript.

The audience is a senior engineer already fluent in the OpenAI/Vercel AI SDK and token/usage accounting, reading Ankole for the first time. Comments explain Ankole's specific use, not the AI SDK itself.

## What got commented

- **`bullx.ts`** — the durable `Message` / `AssistantMessage` / `Usage` / `Model` shapes; the four-bucket (input/output/cacheRead/cacheWrite) token+cost model and the `ZERO_USAGE` aliasing hazard; `calculateCost`; the three-path `isContextOverflow` heuristic.
- **`bullx-ai-sdk.ts`** — the durable↔wire shape mapping (`thinking`→`reasoning`, `toolCall`→`tool-call`, `toolResult`→`tool`); usage/cost normalization including cache-read/write semantics; the conversation-scoped OpenAI prompt-cache key and per-provider cache TTLs.
- **`bullx-generate.ts`** — the never-throws contract and the aborted-vs-error split.
- **`catalog.ts`** — catalog lookup vs synthetic fallback for OpenAI-compatible providers; zero default pricing rationale; the OpenAI-compatible `default` adapter path.
- **`index.ts`** — the boundary between the vendored AI SDK exports and the first-party BullX surface.
- **`testing.ts`** — the faux provider's scripted-response queue and the deterministic streaming simulation.

## Verification

- `bun run --filter @ankole/agent-computer type-check` — **passes** (the required gate; also the e2e for comment-only work).
- `bunx oxfmt` on all six files — clean.
- `git diff --check` — clean; token-level comparison confirms only comments + one line-split were added.
- Unit tests show 5 pre-existing failures in `src/llm/generate-text/stream-text.ts` (a vendored `@ts-nocheck` file, unrelated to this change) — identical with and without these comments (verified via stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)