### PR TITLE
docs(feishu_openapi): comment core request/token/crypto layer

### DIFF
--- a/libs/feishu_openapi/lib/feishu_openapi.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi.ex
@@ -35,13 +35,27 @@ defmodule FeishuOpenAPI do
 
   alias FeishuOpenAPI.{Client, Error, Request, Spec, TokenManager}
 
+  # Feishu business codes the SDK reacts to (everything else is surfaced as-is):
+  #   * @token_invalid_codes — the access token went stale; drop it and retry once.
+  #   * @app_ticket_invalid_code (10012) — a marketplace app_ticket expired; re-push it.
+  #   * @rate_limit_code (99991400) — throttled; the code can ride on HTTP 429/400/200.
   @token_invalid_codes [99_991_663, 99_991_664, 99_991_671]
   @app_ticket_invalid_code 10_012
   @rate_limit_code 99_991_400
+  # Retries are intentionally capped at one for both stale-token and rate-limit
+  # recovery: a single retry covers the common "token just expired" / "brief
+  # throttle" cases without turning a real outage into a long retry storm that
+  # hides the failure from the caller.
   @max_token_invalid_retries 1
   @max_retry_after_retries 1
+  # Wait bounds for rate-limit backoff when the provider's hint is missing or
+  # absurd: default to 1s, never sleep more than 30s inside a single call so a
+  # GenServer.call timeout upstream stays predictable.
   @default_retry_after_ms :timer.seconds(1)
   @max_retry_after_ms :timer.seconds(30)
+  # Allowlist of multipart field names Feishu upload endpoints accept as binary
+  # keys, mapped to the atoms Req wants. See `build_multipart_field/1` for why
+  # binary keys are not turned into atoms dynamically.
   @multipart_field_names %{
     "file_type" => :file_type,
     "file_name" => :file_name,
@@ -132,6 +146,10 @@ defmodule FeishuOpenAPI do
 
       result
     catch
+      # Emit an :exception telemetry span on the way out, then re-raise the
+      # original crash unchanged. The SDK does not turn unexpected crashes into
+      # error tuples here — only instrumented request/response failures become
+      # `{:error, %Error{}}`. Genuine bugs/exits keep propagating.
       kind, reason ->
         duration = System.monotonic_time() - start_time
 
@@ -305,6 +323,10 @@ defmodule FeishuOpenAPI do
   defp maybe_decode_json_body(resp, %Spec{raw: true}), do: resp
   defp maybe_decode_json_body(resp, %Spec{}), do: decode_json_body(resp)
 
+  # The client requests bodies undecoded (`decode_body: false` in Request), so
+  # this is where JSON is parsed before any envelope/rate-limit interpretation.
+  # A decode failure is not an error: non-JSON 2xx bodies (binary downloads,
+  # odd endpoints) are left as raw bytes and handled later as a raw response.
   defp decode_json_body(%Req.Response{body: body} = resp) when is_binary(body) do
     case Torque.decode(body) do
       {:ok, decoded} -> %{resp | body: decoded}
@@ -482,6 +504,9 @@ defmodule FeishuOpenAPI do
 
   defp maybe_recover_app_ticket(_client), do: :ok
 
+  # Drop exactly the cached credential that just failed, so the retry refetches
+  # it. User tokens (explicit bearer or :user_access_token mode) are not owned by
+  # the app/tenant token cache, so there is nothing here to invalidate for them.
   defp invalidate_for_retry(client, %Spec{} = spec) do
     cond do
       is_binary(spec.user_access_token) ->
@@ -517,6 +542,8 @@ defmodule FeishuOpenAPI do
       {:ok, %File.Stat{type: :regular, size: size}} ->
         # Req can stream regular files with a known size. Rejecting directories
         # and special files avoids hanging uploads or provider-side body errors.
+        # 64KB chunks keep large uploads off the heap; `size:` lets Req set a
+        # correct Content-Length instead of falling back to chunked encoding.
         {:ok, {:file, {File.stream!(path, 64_000, []), filename: name, size: size}}}
 
       {:ok, %File.Stat{type: type}} ->

--- a/libs/feishu_openapi/lib/feishu_openapi/application.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/application.ex
@@ -5,6 +5,10 @@ defmodule FeishuOpenAPI.Application do
 
   @impl true
   def start(_type, _args) do
+    # Order matters: the ETS token store and the Registry must be up before the
+    # DynamicSupervisor that starts per-app TokenManagers (they register in the
+    # Registry and read/write the store). The shared EventTaskSupervisor backs
+    # async token fetches, refreshes, and app_ticket resends.
     children = [
       FeishuOpenAPI.TokenStore,
       {Registry, keys: :unique, name: FeishuOpenAPI.TokenRegistry},

--- a/libs/feishu_openapi/lib/feishu_openapi/client.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/client.ex
@@ -37,6 +37,9 @@ defmodule FeishuOpenAPI.Client do
           headers: list()
         }
 
+  # Only non-sensitive fields are inspectable. Combined with `app_secret_fn`
+  # being a closure (never the raw secret), this keeps credentials out of logs,
+  # crash dumps, and `:sys.get_state/1`.
   @derive {Inspect, only: [:app_id, :app_type, :domain, :base_url]}
   defstruct app_id: nil,
             app_secret_fn: nil,
@@ -262,6 +265,11 @@ defmodule FeishuOpenAPI.Client do
     raise ArgumentError, "req_options must be a keyword list, got: #{inspect(req_options)}"
   end
 
+  # Token caches are keyed by this namespace, so two clients must share cached
+  # tokens iff they would authenticate identically. Every input that can change
+  # which credential/endpoint a token is valid against is folded into the hash;
+  # changing the secret (or domain, base_url, headers, ...) yields a new
+  # namespace and prevents a token from one credential set leaking to another.
   defp build_cache_namespace(app_id, app_secret, app_type, domain, base_url, headers, req_options) do
     fingerprint =
       :erlang.term_to_binary(%{
@@ -279,6 +287,11 @@ defmodule FeishuOpenAPI.Client do
     |> Base.encode16(case: :lower)
   end
 
+  # The secret only contributes its hash to the namespace — never its plaintext.
+  # A closure secret is fingerprinted by function identity (`phash2`) rather than
+  # by invoking it: avoids reading the secret here, but means two closures that
+  # return the same secret get distinct namespaces (separate caches, still
+  # correct). Pass a string if you want closures to share a token cache.
   defp secret_fingerprint(secret) when is_binary(secret),
     do: {:binary, :crypto.hash(:sha256, secret)}
 

--- a/libs/feishu_openapi/lib/feishu_openapi/crypto.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/crypto.ex
@@ -115,6 +115,9 @@ defmodule FeishuOpenAPI.Crypto do
         stripped_size = byte_size(bin) - pad
         <<stripped::binary-size(^stripped_size), padding::binary-size(^pad)>> = bin
 
+        # Verify every padding byte, not just the last one. A garbled key/IV or
+        # tampered ciphertext usually yields plausible-looking trailing bytes;
+        # checking the whole padding block rejects those as :invalid_padding.
         if padding == :binary.copy(<<pad>>, pad) do
           {:ok, stripped}
         else

--- a/libs/feishu_openapi/lib/feishu_openapi/error.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/error.ex
@@ -48,6 +48,9 @@ defmodule FeishuOpenAPI.Error do
   def from_response(%{"code" => code} = body, %Req.Response{} = resp) do
     error_details = Map.get(body, "error")
 
+    # Some Feishu endpoints put the human-readable message and a log id only
+    # inside a nested `"error"` object rather than top-level `"msg"` / the
+    # response header. Fall back to those so errors stay attributable.
     %__MODULE__{
       code: code,
       msg: Map.get(body, "msg") || nested_message(error_details),

--- a/libs/feishu_openapi/lib/feishu_openapi/request.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/request.ex
@@ -19,6 +19,11 @@ defmodule FeishuOpenAPI.Request do
       headers = auth_headers ++ client.headers ++ spec.headers
       url = build_url(client.base_url, spec.path)
 
+      # Layering is deliberate: per-request overrides win over client defaults,
+      # but `decode_body: false` is forced last and cannot be overridden. The
+      # SDK decodes JSON itself (in FeishuOpenAPI.decode_json_body/1) so it can
+      # tell a Feishu envelope / rate-limit body apart from a raw binary download
+      # before interpreting it. Letting Req auto-decode would erase that signal.
       req_opts =
         [method: spec.method, url: url, headers: headers]
         |> maybe_put(:params, normalize_query(spec.query))
@@ -91,6 +96,9 @@ defmodule FeishuOpenAPI.Request do
     Keyword.put(req_opts, :form_multipart, fm)
   end
 
+  # `:unset` is the sentinel for "no `:body` option was passed" — send no body
+  # at all (e.g. GET/DELETE). An explicit `false`/`nil` body is different: the
+  # caller asked to send that literal JSON value, so it is encoded and sent.
   defp put_body(req_opts, %Spec{body: :unset}), do: req_opts
 
   defp put_body(req_opts, %Spec{body: body}) when body in [false, nil] do

--- a/libs/feishu_openapi/lib/feishu_openapi/spec.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/spec.ex
@@ -132,6 +132,10 @@ defmodule FeishuOpenAPI.Spec do
     end
   end
 
+  # Substitutes `:name` placeholders from `path_params`. Each value is percent-
+  # encoded down to URI-unreserved characters so an id containing `/`, spaces, or
+  # other reserved bytes stays within a single path segment instead of altering
+  # the URL structure. A missing param is a programmer error and aborts the build.
   defp render_path(path, params) do
     try do
       rendered =
@@ -153,6 +157,9 @@ defmodule FeishuOpenAPI.Spec do
     end
   end
 
+  # A present-but-nil value counts as missing: rendering "nil" into a URL is
+  # never intended, so it falls through to the missing-param error. Atom keys are
+  # also accepted, hence the fallback to the enum scan when the string lookup misses.
   defp fetch_param(params, name) when is_map(params) and is_binary(name) do
     case Map.fetch(params, name) do
       {:ok, nil} -> :error

--- a/libs/feishu_openapi/lib/feishu_openapi/token_manager.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/token_manager.ex
@@ -48,8 +48,15 @@ defmodule FeishuOpenAPI.TokenManager do
 
   alias FeishuOpenAPI.{Client, Error, TokenStore}
 
+  # Treat a token as expired this long before its nominal expiry, so a token is
+  # never used right as it lapses (clock skew between hosts, server-side early
+  # expiry, in-flight request latency).
   @expiry_delta_ms :timer.minutes(3)
+  # Fire the proactive refresh this far ahead of the (already shortened) expiry,
+  # so a fresh token is usually warm in ETS before any caller needs it.
   @refresh_lead_ms :timer.seconds(30)
+  # Caller-side bound on a token fetch. Must exceed Req's receive timeout so a
+  # slow-but-succeeding upstream fetch isn't cut off by the GenServer.call.
   @call_timeout :timer.seconds(15)
 
   @type key ::
@@ -65,6 +72,10 @@ defmodule FeishuOpenAPI.TokenManager do
 
   @doc false
   def child_spec(%Client{} = client) do
+    # `:transient` because these processes are started lazily on first cache miss
+    # and hold no durable state of their own (tokens live in shared ETS). A clean
+    # exit should not be restarted; a crash will be, and the next miss simply
+    # refetches. The cache-namespace id keeps one manager per credential set.
     %{
       id: {__MODULE__, Client.cache_namespace(client)},
       start: {__MODULE__, :start_link, [client]},
@@ -235,6 +246,12 @@ defmodule FeishuOpenAPI.TokenManager do
     {waiters, fetches} = Map.pop(state.fetches, key, [])
     state = %{state | fetches: fetches}
 
+    # A single in-flight fetch serves everyone queued on this key. Real callers
+    # are stored as `{:waiter, from}` and get GenServer.reply'd — this is what
+    # deduplicates a concurrent burst into one upstream request. A proactive
+    # refresh enqueues an empty waiter list, so this loop just warms the cache
+    # without replying to anyone. (`:refresh` is a defensive no-op clause; the
+    # bare atom is never actually placed in the waiter list.)
     Enum.each(waiters, fn
       {:waiter, from} -> GenServer.reply(from, client_result(result))
       :refresh -> :ok
@@ -419,6 +436,9 @@ defmodule FeishuOpenAPI.TokenManager do
     state = cancel_refresh_timer(state, key)
     delay = expires_at_ms - System.monotonic_time(:millisecond) - @refresh_lead_ms
 
+    # Skip proactive refresh when the lead time already overshoots expiry (very
+    # short-lived token). No timer is armed; the next caller takes the reactive
+    # miss-and-refetch path instead.
     if delay > 0 do
       timer = Process.send_after(self(), {:refresh, key}, delay)
       %{state | refresh_timers: Map.put(state.refresh_timers, key, timer)}

--- a/libs/feishu_openapi/lib/feishu_openapi/user_token_manager.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/user_token_manager.ex
@@ -227,6 +227,10 @@ defmodule FeishuOpenAPI.UserTokenManager do
      }}
   end
 
+  # A refresh response may or may not include a new refresh_token. When it omits
+  # one, keep using the existing refresh_token (and its existing expiry) rather
+  # than losing the ability to refresh again. Other fields (token_type, scope)
+  # are likewise carried forward when the response leaves them out.
   defp merge_refresh(existing, token_resp) do
     refresh_token = Map.get(token_resp, :refresh_token) || existing.refresh_token
 
@@ -241,6 +245,11 @@ defmodule FeishuOpenAPI.UserTokenManager do
     }
   end
 
+  # Decide the refresh_token's expiry after a refresh:
+  #   * a fresh `refresh_expires_in` always wins;
+  #   * otherwise, if the refresh_token was NOT rotated, keep its old expiry;
+  #   * if it WAS rotated but came without an expiry, we don't know — leave nil
+  #     (treated as "no known refresh window").
   defp refresh_expires_at(existing, token_resp, refresh_token) do
     case Map.get(token_resp, :refresh_expires_in) do
       expires_in when is_integer(expires_in) ->
@@ -296,10 +305,14 @@ defmodule FeishuOpenAPI.UserTokenManager do
 
   defp fresh?(expires_at), do: System.monotonic_time(:millisecond) < expires_at
 
+  # Same early-expiry margin as the app/tenant manager (see @expiry_delta_ms):
+  # a token is considered stale a few minutes before its nominal lifetime.
   defp expires_at(expires_in) when is_integer(expires_in) do
     System.monotonic_time(:millisecond) + :timer.seconds(expires_in) - @expiry_delta_ms
   end
 
+  # No lifetime given by the provider: place expiry in the past so the token is
+  # treated as already-stale and a refresh is attempted on next use.
   defp expires_at(_), do: System.monotonic_time(:millisecond) - @expiry_delta_ms
 
   defp task_supervisor do


### PR DESCRIPTION
## What

Comment-only pass over the `libs/feishu_openapi` **core request / auth / token / crypto** layer. Adds intent-focused comments for an engineer reading Ankole's Feishu/Lark SDK for the first time. **No code, logic, control flow, names, or ordering changed** — `git diff` is added comments + formatter only (98 insertions, 0 deletions).

## Files

- `feishu_openapi.ex` — retry/rate-limit constants, the telemetry `catch`/re-raise, explicit JSON decode, `invalidate_for_retry`, streaming upload chunking
- `request.ex` — why `decode_body: false` is forced last; the `:unset` vs explicit `false`/`nil` body sentinel
- `client.ex` — Inspect redaction, the per-credential cache namespace, secret fingerprinting (binary hashed / closure by identity, never invoked)
- `spec.ex` — `:param` path rendering with per-segment percent-encoding; nil-param-is-missing
- `token_manager.ex` — expiry margin / refresh-lead / call-timeout rationale, `:transient` child spec, the concurrent-fetch dedup via stored `from` waiters, refresh scheduling
- `user_token_manager.ex` — refresh-token rotation / expiry carry-forward, stale-on-unknown-lifetime
- `crypto.ex` — full PKCS#7 padding verification
- `error.ex` — nested `error.message` / `error.logid` fallback
- `application.ex` — supervision child ordering

`pagination.ex` and `token_store.ex` were already sufficiently documented and were left untouched (no padding).

## Verification

- `mix format` — clean
- `MIX_ENV=test mix compile --warnings-as-errors` — **passes** (required gate)
- `MIX_ENV=test mix test` — **128 passed**
- `git diff --check` clean; every added line is a `#` comment / `@doc` / blank
- Comments were fact-checked against the code; one initially-misleading note about the `:refresh` waiter clause in `token_manager.ex` was corrected to match the actual (defensive no-op) behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)