### PR TITLE
docs(ai_agent): add intent-focused comments

### DIFF
--- a/app/control_plane/lib/ankole/ai_agent.ex
+++ b/app/control_plane/lib/ankole/ai_agent.ex
@@ -310,6 +310,11 @@ defmodule Ankole.AIAgent do
       metadata: metadata_for_input(actor_input, history)
     }
 
+    # The conflict target must spell out the partial unique index's WHERE clause
+    # verbatim (only inbound normal user/ambient rows with a real event are
+    # deduplicated), so Postgres matches this insert to that exact index. On
+    # conflict we keep the existing row; `message_insert_result/3` then refetches
+    # it because `on_conflict: :nothing` returns a row with a nil id.
     %Message{}
     |> Message.changeset(attrs)
     |> repo.insert(

--- a/app/control_plane/lib/ankole/ai_agent/library.ex
+++ b/app/control_plane/lib/ankole/ai_agent/library.ex
@@ -25,7 +25,12 @@ defmodule Ankole.AIAgent.Library do
   @agent_append_file "AGENT_APPEND.md"
   @soul_file "SOUL.md"
   @mission_file "MISSION.md"
+  # Explicit allowlist of first-party skill directories that sync into Postgres.
+  # Intentionally narrow: only vetted bundles become part of the canonical
+  # catalog, even if more skill folders exist on disk.
   @builtin_skill_names ~w(jupyter-live-kernel nano-pdf powerpoint)
+  # Used only if the bundled SOUL/MISSION templates are unreadable, so a fresh
+  # agent still gets a usable (if minimal) persona rather than failing to seed.
   @fallback_soul "You are an Ankole AI colleague. Reply in plain text."
   @fallback_mission ""
 
@@ -46,6 +51,9 @@ defmodule Ankole.AIAgent.Library do
     now = Keyword.get(opts, :now, DateTime.utc_now(:microsecond))
 
     with {:ok, sources} <- read_builtin_skill_sources() do
+      # The whole on-disk catalog is hashed and compared to the stored cursor so
+      # this (boot-time) sync is a cheap no-op when nothing changed. `force?`
+      # exists for tests and manual re-syncs that want to write regardless.
       content_hash = catalog_hash(sources)
       current_state = repo.get(LibraryBuiltinSyncState, @sync_name)
 
@@ -425,6 +433,10 @@ defmodule Ankole.AIAgent.Library do
         assignment =
           repo.get_by(AgentSkillAssignment, agent_uid: agent_uid, skill_name: skill_name)
 
+        # An explicit per-agent assignment always wins over the catalog default:
+        # an `enabled: false` override disables a default-on skill, and an
+        # `enabled: true` override enables a default-off one. With no assignment,
+        # the catalog's `default_enabled` decides.
         cond do
           match?(%AgentSkillAssignment{enabled: false}, assignment) ->
             {:error, :skill_not_enabled}
@@ -460,6 +472,10 @@ defmodule Ankole.AIAgent.Library do
 
   defp do_skill_view(repo, agent_uid, %LibrarySkill{} = skill, file_path) do
     case repo.get_by(LibrarySkillFile, skill_name: skill.skill_name, path: file_path) do
+      # Reading the skill's main `SKILL.md` returns the canonical body with this
+      # agent's `AGENT_APPEND.md` (if any) spliced on under a divider. That is how
+      # an agent personalizes a shared first-party skill without forking it: the
+      # catalog row stays canonical, the per-agent delta lives in a writable entry.
       %LibrarySkillFile{} = file when file_path == @skill_file ->
         base_content = skill_body(file.content)
         append_content = agent_append_content(repo, agent_uid, skill.skill_name)
@@ -626,6 +642,9 @@ defmodule Ankole.AIAgent.Library do
       |> Kernel.||(directory_name)
 
     with {:ok, name} <- normalize_skill_name(name),
+         # The skill's declared `name` must equal its directory name; the
+         # directory name is the catalog primary key, so a mismatch would let a
+         # bundle masquerade under the wrong key. Reject rather than guess.
          true <-
            name == directory_name ||
              {:error, {:skill_name_directory_mismatch, name, directory_name}},
@@ -800,6 +819,10 @@ defmodule Ankole.AIAgent.Library do
     end
   end
 
+  # Path-traversal guard for writing library files to a real host directory.
+  # Virtual paths come from DB rows and skill bundles, so even after
+  # normalization we re-check the expanded path is still inside the mount root
+  # before touching the filesystem; anything escaping it is a hard error.
   defp safe_join!(root, virtual_path) do
     root = Path.expand(root)
     path = Path.expand(normalize_virtual_path!(virtual_path), root)

--- a/app/control_plane/lib/ankole/ai_agent/library/schemas/agent_library_container_entry.ex
+++ b/app/control_plane/lib/ankole/ai_agent/library/schemas/agent_library_container_entry.ex
@@ -13,6 +13,10 @@ defmodule Ankole.AIAgent.Library.Schemas.AgentLibraryContainerEntry do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :string
   @timestamps_opts [type: :utc_datetime_usec]
+  # What kind of agent-owned file this row backs. `soul`/`mission` are the
+  # persona docs seeded per agent, `skill_append` is the per-agent override
+  # spliced into a shared skill; the rest are other writable surfaces the agent
+  # accumulates over its lifetime.
   @source_kinds ~w(soul mission skill_append setting memory system user computer)
 
   schema "agent_library_container_entries" do
@@ -50,6 +54,10 @@ defmodule Ankole.AIAgent.Library.Schemas.AgentLibraryContainerEntry do
     |> validate_inclusion(:source_kind, @source_kinds)
     |> JsonPayload.validate_map(:metadata, allow_datetime: true)
     |> foreign_key_constraint(:agent_uid)
+    # Uniqueness is over *live* rows only (the backing index is partial on
+    # `deleted_at IS NULL`). Deletes are soft, so a previously deleted path can be
+    # re-created, and `Library.upsert_agent_text_entry_in_tx/2` un-deletes via the
+    # same partial-index conflict target.
     |> unique_constraint([:agent_uid, :path],
       name: :agent_library_container_entries_active_path_index
     )

--- a/app/control_plane/lib/ankole/ai_agent/llm_providers.ex
+++ b/app/control_plane/lib/ankole/ai_agent/llm_providers.ex
@@ -1,6 +1,12 @@
 defmodule Ankole.AIAgent.LlmProviders do
   @moduledoc """
   CRUD and projection service for operator-configured LLM providers.
+
+  A provider row holds an endpoint plus an encrypted credential. Plaintext
+  credentials only ever leave through `plaintext_credential/1` (for the broker)
+  and the live-check path; every console/API shape goes through `projection/1`,
+  which masks the secret. "Deleting" a provider is a soft disable that is refused
+  while any agent model profile still references it.
   """
 
   import Ecto.Query, warn: false
@@ -11,7 +17,12 @@ defmodule Ankole.AIAgent.LlmProviders do
   alias Ankole.Principals.Agent
   alias Ankole.Repo
 
+  # Sentinel distinguishing "caller did not mention the credential" (preserve it)
+  # from "caller passed nil/blank" (clear it). A plain nil cannot express that
+  # difference, so writes use this marker as the default.
   @credential_omitted :__ankole_credential_omitted__
+  # Operator live-checks hit a third-party endpoint; cap both connect and read so
+  # a slow or hanging provider cannot stall the Console request.
   @live_check_timeout_ms 15_000
 
   @type provider_result :: {:ok, Provider.t()} | {:error, term()}
@@ -308,6 +319,11 @@ defmodule Ankole.AIAgent.LlmProviders do
     |> repo.one()
   end
 
+  # Finds every agent model profile still pointing at this provider, returned as
+  # "agent_uid:profile" labels. A non-empty list blocks the disable so an
+  # operator cannot silently break agents that depend on the provider; profiles
+  # live inside each agent's `options` JSON, so this scans agents rather than a
+  # dedicated join table.
   defp provider_references(repo, provider_id) do
     Agent
     |> select([agent], {agent.uid, agent.options})

--- a/app/control_plane/lib/ankole/ai_agent/llm_providers/crypto.ex
+++ b/app/control_plane/lib/ankole/ai_agent/llm_providers/crypto.ex
@@ -43,6 +43,10 @@ defmodule Ankole.AIAgent.LlmProviders.Crypto do
     end
   end
 
+  # Roots the per-row key derivation in the endpoint's `secret_key_base` rather
+  # than a separate KMS: one operator-managed secret already gates the
+  # installation, so provider credentials are bound to it. Rotating it
+  # invalidates all stored ciphertexts.
   defp root_secret do
     :ankole
     |> Application.get_env(AnkoleWeb.Endpoint, [])

--- a/app/control_plane/lib/ankole/ai_agent/message_context.ex
+++ b/app/control_plane/lib/ankole/ai_agent/message_context.ex
@@ -13,7 +13,13 @@ defmodule Ankole.AIAgent.MessageContext do
   alias Ankole.AIAgent.Schemas.Message
 
   @metadata_key "message_context"
+  # "Sparse injection": scene facts (time, room, actor) are rendered into the
+  # prompt only when they have changed since the model last saw them, to avoid
+  # repeating a timestamp/room banner on every message. Time re-injects only
+  # after a 1h gap; below that the previous time line is still considered fresh.
   @time_context_gap_ms 60 * 60 * 1_000
+  # Hard cap on any single injected context line (speaker, room, think). Bounds
+  # how much untrusted chat metadata can bloat the frozen prompt prefix.
   @max_context_line_text 800
 
   @type history_item :: %{metadata: map()}
@@ -113,6 +119,9 @@ defmodule Ankole.AIAgent.MessageContext do
         %{
           "actor_key" => actor.key,
           "display_name" => actor.display_name,
+          # Only worth telling the model "who is speaking" in a group chat, and
+          # only when the speaker changed. In a DM the counterpart is implicit,
+          # so the actor banner is never injected.
           "injected" => not is_nil(room) and !room.is_dm and should_inject_actor?(actor, history)
         }
         |> reject_nil()

--- a/app/control_plane/lib/ankole/ai_agent/model_profiles.ex
+++ b/app/control_plane/lib/ankole/ai_agent/model_profiles.ex
@@ -15,6 +15,10 @@ defmodule Ankole.AIAgent.ModelProfiles do
   alias Ankole.Principals.Agent
   alias Ankole.Repo
 
+  # Fixed slots an agent can bind a model to. `primary`/`light`/`heavy` are the
+  # everyday tiers and must be configured for the agent to run real turns;
+  # `codex` is optional and only meaningful on Codex-compatible provider sources,
+  # so a missing `codex` returns a typed error rather than blocking startup.
   @profiles ~w(primary light heavy codex)
   @required_profiles ~w(primary light heavy)
 

--- a/app/control_plane/lib/ankole/ai_agent/provider_sources.ex
+++ b/app/control_plane/lib/ankole/ai_agent/provider_sources.ex
@@ -7,6 +7,10 @@ defmodule Ankole.AIAgent.ProviderSources do
   the worker.
   """
 
+  # Header names an operator is forbidden from setting in `connection_options`.
+  # Credentials must flow through the sealed `encrypted_credential` column, not
+  # plaintext connection headers, so any header that could smuggle a secret is
+  # rejected at validation time.
   @secret_header_names MapSet.new([
                          "authorization",
                          "proxy-authorization",
@@ -68,6 +72,11 @@ defmodule Ankole.AIAgent.ProviderSources do
           }
   end
 
+  # One static entry per supported source. The two key-list fields are
+  # allowlists used to reject unknown options: `connection_option_keys` gates
+  # what an operator may store on a provider row, `runtime_provider_option_keys`
+  # gates the per-call options an agent profile may carry. `model_catalog_policy`
+  # records how much the source constrains model names (known list vs. anything).
   @source_attrs [
     %{
       source: "openrouter",

--- a/app/control_plane/lib/ankole/ai_agent/schemas/conversation.ex
+++ b/app/control_plane/lib/ankole/ai_agent/schemas/conversation.ex
@@ -41,6 +41,12 @@ defmodule Ankole.AIAgent.Schemas.Conversation do
     |> JsonPayload.validate_map(:generation, allow_datetime: true)
     |> JsonPayload.validate_map(:metadata, allow_datetime: true)
     |> foreign_key_constraint(:agent_uid)
+    # Only one *active* (not yet `ended_at`) conversation may exist per
+    # (agent, conversation_key). The backing index is partial on `ended_at IS
+    # NULL`, so an ended session can be superseded by a new one under the same
+    # key. This collision is what `AIAgent.ensure_conversation_in_tx/3` relies on
+    # to make concurrent first-input safe: it inserts, and on conflict refetches
+    # the row the racing writer created.
     |> unique_constraint([:agent_uid, :conversation_key],
       name: :ai_agent_conversations_active_key_index
     )

--- a/app/control_plane/lib/ankole/ai_agent/schemas/llm_turn.ex
+++ b/app/control_plane/lib/ankole/ai_agent/schemas/llm_turn.ex
@@ -18,7 +18,21 @@ defmodule Ankole.AIAgent.Schemas.LlmTurn do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :string
   @timestamps_opts [type: :utc_datetime_usec]
+  # Why a turn exists, for transcript readability and retry accounting:
+  #   generation          - normal turn triggered by new actor input
+  #   retry_generation    - re-run of inputs whose prior turn failed (same work,
+  #                         labelled so repeated attempts are explainable)
+  #   scheduled_task      - turn driven by a scheduler, not live chat
+  #   checkback_generation- turn that follows up on earlier deferred work
+  #   compression         - turn whose job is to condense older history into a
+  #                         summary while preserving concrete facts (file paths,
+  #                         IDs, decisions) so later turns lose context, not state
+  #   overflow_retry      - re-run after a context-window overflow
   @kinds ~w(generation retry_generation scheduled_task checkback_generation compression overflow_retry)
+  # Turn lifecycle. A turn is created `started` (before the worker is even told
+  # to run) and moves to exactly one terminal state. `failed` is recoverable:
+  # `AIAgent.mark_turn_failed/3` records the error and releases the generation
+  # lease so the inputs can be retried.
   @statuses ~w(started succeeded failed cancelled)
   @profiles ~w(primary light heavy codex)
 
@@ -126,6 +140,10 @@ defmodule Ankole.AIAgent.Schemas.LlmTurn do
     |> JsonPayload.validate_map(:provider_metadata, allow_datetime: true)
     |> foreign_key_constraint(:agent_uid)
     |> foreign_key_constraint(:conversation_id)
+    # A generation lease can drive several provider calls in one local loop, each
+    # numbered by `call_index`. Uniqueness over (conversation, lease, call_index)
+    # makes each call insert-once: a retried delivery for the same lease and step
+    # collides instead of recording a duplicate turn.
     |> unique_constraint([:conversation_id, :lease_id, :call_index],
       name: :ai_agent_llm_turns_generation_call_index
     )

--- a/app/control_plane/lib/ankole/ai_agent/schemas/message.ex
+++ b/app/control_plane/lib/ankole/ai_agent/schemas/message.ex
@@ -18,8 +18,21 @@ defmodule Ankole.AIAgent.Schemas.Message do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :string
   @timestamps_opts [type: :utc_datetime_usec]
+  # Roles map an inbound transcript row to where it belongs in the LLM
+  # conversation. `im_ambient` is Ankole-specific: a chat message the agent saw
+  # but was not directly addressed to it (a "may intervene" signal). Only
+  # inbound roles (`user`, `tool`, `im_ambient`) are materialized here and fed
+  # into runtime proposals; `assistant` rows are the model's own output, written
+  # back by a different path and never re-proposed as new input.
   @roles ~w(user assistant tool im_ambient)
+  # `kind` separates ordinary turns from transcript-shaping rows: `summary` rows
+  # stand in for compacted history, `introspection` is internal reasoning the
+  # agent recorded, `error` marks a surfaced failure. The idempotency and
+  # history paths only treat `normal` (and sometimes `introspection`) rows as
+  # real inbound scene facts.
   @kinds ~w(normal summary introspection error)
+  # A message is `generating` while its content is still being streamed in and
+  # `complete` once final; inbound user/ambient rows are written `complete`.
   @statuses ~w(generating complete)
 
   schema "ai_agent_messages" do
@@ -79,6 +92,12 @@ defmodule Ankole.AIAgent.Schemas.Message do
     |> JsonPayload.validate_map(:metadata, allow_datetime: true)
     |> foreign_key_constraint(:agent_uid)
     |> foreign_key_constraint(:conversation_id)
+    # Backstops inbound idempotency: one ingress event (`event_source` +
+    # `event_id`) yields at most one transcript row per conversation, so a
+    # provider redelivery or a retried turn cannot duplicate the same user/
+    # ambient message. The matching DB index is partial (only inbound rows),
+    # which is why `AIAgent.materialize_user_message/4` uses an unsafe-fragment
+    # conflict target instead of these plain columns.
     |> unique_constraint([:conversation_id, :event_source, :event_id],
       name: :ai_agent_messages_inbound_event_index
     )


### PR DESCRIPTION
## What

Comment-only pass over the durable AI-agent conversation subsystem
(`app/control_plane/lib/ankole/ai_agent.ex` and all 15 files under
`ai_agent/`). Adds WHY-focused comments for a senior engineer reading
Ankole for the first time. **No code, logic, control flow, names, or
ordering changed** — the diff is 121 added lines, 0 deletions.

## Focus areas (per the unit brief)

- **Conversation idempotence** — `conversation.ex`: the partial unique
  index on active (`ended_at IS NULL`) rows that makes insert-then-refetch
  tolerate concurrent first input; `ai_agent.ex`: why the message
  `on_conflict` target restates that partial index verbatim.
- **Turn state machine + lease/fence** — `llm_turn.ex`: each `kind`
  (incl. `compression` and `overflow_retry`) and `status` explained;
  the `(conversation, lease, call_index)` insert-once fence.
- **Message-role filtering** — `message.ex`: why only inbound
  `user`/`tool`/`im_ambient` roles are materialized and `assistant` is
  not; what `im_ambient` (may-intervene) means; the inbound-event
  idempotency index.
- **Sparse injection / message context** — `message_context.ex`: the
  injection concept, the 1h time gap and 800-char line cap, and the
  DM-vs-group actor-banner rule.
- **Library** — builtin-skill allowlist, content-hash sync cursor,
  `SKILL.md` + `AGENT_APPEND.md` merge, soft-delete path re-creation,
  path-traversal guard, assignment-over-default precedence.
- **LLM providers** — credential-masking boundary, soft-disable-while-
  referenced, secret-header rejection, `secret_key_base`-rooted
  per-row credential binding.

## Verification

- `mix format` — no changes.
- `MIX_ENV=test mix compile --warnings-as-errors --force` — clean
  (`Generated ankole app`); confirms no duplicate-`@doc` and that all
  comments are well-formed. This clean compile is the e2e signal for a
  comment-only change.
- `git diff --check` — clean; every changed line is a comment or
  `@moduledoc`/`@doc` prose.
- Test suite (`mix test`) — **not run: no local Postgres in this
  worktree** (`pg_isready` → no response on :5432).

🤖 Generated with [Claude Code](https://claude.com/claude-code)