### PR TITLE
docs(actor_runtime): add comments to OTP/transport/worker layer

### DIFF
--- a/app/control_plane/lib/ankole/actor_runtime/outbox_dispatcher.ex
+++ b/app/control_plane/lib/ankole/actor_runtime/outbox_dispatcher.ex
@@ -1,6 +1,13 @@
 defmodule Ankole.ActorRuntime.OutboxDispatcher do
   @moduledoc """
   Periodically dispatches provider-visible outbox rows through SignalsGateway.
+
+  When a turn commits a side effect (a message to send, etc.) it records a
+  durable outbox row inside the same transaction; this loop is what actually
+  performs those effects against external providers. Polling is the source of
+  truth for delivery — `wake/0` only shaves latency. The outbox row stays the
+  durable record and carries its own retry metadata, so a crash or a missed tick
+  just means the effect goes out on a later pass, never that it is lost.
   """
 
   use GenServer
@@ -9,7 +16,12 @@ defmodule Ankole.ActorRuntime.OutboxDispatcher do
 
   alias Ankole.SignalsGateway
 
+  # Poll every 500ms: low enough that a freshly committed side effect reaches its
+  # provider promptly even if the wake/0 nudge is missed, cheap enough to run
+  # continuously.
   @default_interval_ms 500
+  # Cap rows per pass so one busy tick can't monopolize provider calls or the DB;
+  # leftover due rows are simply picked up on the next tick.
   @default_limit 25
 
   @doc """

--- a/app/control_plane/lib/ankole/actor_runtime/session_controller.ex
+++ b/app/control_plane/lib/ankole/actor_runtime/session_controller.ex
@@ -1,6 +1,13 @@
 defmodule Ankole.ActorRuntime.SessionController do
   @moduledoc """
   Serial process for one `{agent_uid, session_id}` actor key.
+
+  This GenServer is the in-memory serialization point for one actor: by funneling
+  that actor's scheduling work through a single process, the common path never
+  has two turns racing for the same actor key. It is an optimization for
+  reasoning, not the correctness boundary — durable database fences (turn and
+  delivery rows) remain the real guard, so a controller crash or restart cannot
+  corrupt an actor's state.
   """
 
   use GenServer
@@ -9,6 +16,9 @@ defmodule Ankole.ActorRuntime.SessionController do
   alias Ankole.ActorRuntime.ActorDirectory
   alias Ankole.ActorRuntime.SessionSupervisor
 
+  # Processing one ready batch can drive an LLM turn end to end, so the
+  # caller-side call timeout is generous (30s) to avoid spurious exits while the
+  # actor does real work. The DB fences still bound correctness if it does run long.
   @call_timeout 30_000
 
   @doc """
@@ -44,6 +54,10 @@ defmodule Ankole.ActorRuntime.SessionController do
     {:reply, ActorRuntime.process_ready_inputs_for_actor(state.actor_key, opts), state}
   end
 
+  # Accept both atom-keyed (internal) and string-keyed (decoded JSON) actor keys,
+  # and downcase the agent uid so a single actor always maps to one Registry name
+  # and one controller — case differences in the uid must not fork the actor into
+  # two serial processes. Must match ActorDirectory.key/1's normalization exactly.
   defp normalize_actor_key(%{agent_uid: agent_uid, session_id: session_id}) do
     %{agent_uid: normalize_uid(agent_uid), session_id: session_id}
   end

--- a/app/control_plane/lib/ankole/actor_runtime/session_supervisor.ex
+++ b/app/control_plane/lib/ankole/actor_runtime/session_supervisor.ex
@@ -1,6 +1,12 @@
 defmodule Ankole.ActorRuntime.SessionSupervisor do
   @moduledoc """
   Dynamic supervisor for per-actor session controllers.
+
+  One `SessionController` is spawned on demand per `{agent_uid, session_id}`
+  actor key and named in the `ActorDirectory` Registry. Using a dynamic
+  supervisor lets actors come and go at runtime without a static child list, and
+  makes each controller its own failure unit: one crashing controller (or one
+  misbehaving actor) is isolated and restarted without touching the others.
   """
 
   use DynamicSupervisor
@@ -17,6 +23,11 @@ defmodule Ankole.ActorRuntime.SessionSupervisor do
 
   @doc """
   Ensures the controller for an actor key is running.
+
+  Idempotent get-or-start: two concurrent wakeups for the same actor race to
+  start the controller, and the loser gets `{:already_started, pid}` from the
+  Registry-unique name. Both callers treat that as success and return the live
+  pid, so callers never have to coordinate who starts the actor.
   """
   @spec ensure_session_controller(map()) :: {:ok, pid()} | {:error, term()}
   def ensure_session_controller(actor_key) do
@@ -29,6 +40,8 @@ defmodule Ankole.ActorRuntime.SessionSupervisor do
 
   @impl true
   def init(_opts) do
+    # :one_for_one — controllers are independent. One actor's crash must not
+    # restart unrelated actors' controllers.
     DynamicSupervisor.init(strategy: :one_for_one)
   end
 end

--- a/app/control_plane/lib/ankole/actor_runtime/supervisor.ex
+++ b/app/control_plane/lib/ankole/actor_runtime/supervisor.ex
@@ -1,6 +1,14 @@
 defmodule Ankole.ActorRuntime.Supervisor do
   @moduledoc """
   Supervision root for control-plane actor-runtime services.
+
+  This supervisor is the failure domain for the actor runtime. It uses
+  `:one_for_one`: each child is an independent concern (transport, naming,
+  per-actor controllers, and several recovery loops), so one crashing does not
+  invalidate the others' state. Durable correctness lives in Postgres, not in
+  these processes, so a single child restart is always safe to recover from
+  cold — the recovery loops below simply re-derive runtime state from the
+  ledger on their next tick.
   """
 
   use Supervisor
@@ -19,9 +27,12 @@ defmodule Ankole.ActorRuntime.Supervisor do
   def init(opts) do
     runtime_opts = runtime_opts(opts)
 
-    # The transport broker, directory, and dynamic supervisor are the core path.
-    # Reconciler, polling, watchdog, and outbox dispatch are repeatable recovery
-    # loops that can be disabled in focused tests.
+    # The transport broker, directory, and dynamic supervisor are the core path:
+    # without them no actor turn can be sent or routed. The reconciler,
+    # activation manager, watchdog, and outbox dispatcher are repeatable recovery
+    # loops — each one re-reads the durable ledger and is idempotent, so tests
+    # that want to drive recovery by hand (or isolate one concern) switch them
+    # off via opts without breaking the core path.
     children =
       [
         broker_child(opts),
@@ -86,6 +97,12 @@ defmodule Ankole.ActorRuntime.Supervisor do
     end
   end
 
+  # Decides whether the broker boots with a real ZeroMQ ROUTER or stays in
+  # local-route-only mode. No endpoint configured (the test default) -> start the
+  # broker bare so local route handlers can stand in for workers. An endpoint
+  # configured -> hand the broker router opts so it binds the production socket.
+  # A malformed config is an operator error at boot, so we crash startup loudly
+  # rather than silently come up with no transport.
   defp broker_child(opts) do
     case router_opts(opts) do
       {:ok, nil} ->
@@ -126,6 +143,13 @@ defmodule Ankole.ActorRuntime.Supervisor do
 
   defp normalize_router_opts(_value), do: {:error, :invalid_router_config}
 
+  # Resolves how the native ROUTER will authenticate workers (ZAP). Caller-given
+  # credentials win in priority order: a pre-shared token, an explicit key list,
+  # or an explicit auth database URL. `worker_auth: false` disables ZAP entirely
+  # (test/dev only). The default — and the production path — is to point the
+  # router at the Repo's own database so it can verify worker pre-auth keys
+  # against the live `agent_computer_worker_auth_keys` table. The `:worker_auth`
+  # marker is internal and never forwarded to the native layer, so we drop it.
   defp router_opts_with_token(endpoint, opts) do
     opts =
       cond do

--- a/app/control_plane/lib/ankole/actor_runtime/transport/broker.ex
+++ b/app/control_plane/lib/ankole/actor_runtime/transport/broker.ex
@@ -4,6 +4,26 @@ defmodule Ankole.ActorRuntime.Transport.Broker do
 
   The production transport route is ZeroMQ; this GenServer keeps the Elixir API
   stable and provides a local route handler for deterministic smoke tests.
+
+  There are two transport routes behind one identical API:
+
+    * Production: a single ZeroMQ ROUTER socket (owned by the native Actor Bus)
+      reaches every connected worker. A "transport route" is the worker's ROUTER
+      identity — the address ZeroMQ uses to deliver an envelope to that worker.
+    * Local (test only): an in-process handler (function or pid) registered
+      under a route string. This exercises the same envelope decode/dispatch
+      code without spinning up a ZeroMQ worker, so smoke tests stay fast and
+      deterministic.
+
+  `send_mandatory/2` resolves a route to whichever transport owns it: a local
+  route if one is registered, otherwise the production ROUTER. Inbound traffic
+  arrives the other way — the native ROUTER forwards decoded envelopes here as
+  `:actor_bus_router_received` messages, already tagged with the worker identity
+  the transport authenticated.
+
+  Keeping the single ROUTER socket behind this one GenServer means every route
+  failure surfaces in one place, where it can be turned into a scheduling signal
+  instead of a lost actor turn.
   """
 
   use GenServer
@@ -47,6 +67,10 @@ defmodule Ankole.ActorRuntime.Transport.Broker do
 
   @doc """
   Starts the ZeroMQ ROUTER transport owned by this broker.
+
+  Binding the native socket is a synchronous NIF call, so we cap the GenServer
+  call at 5s: long enough for a normal `bind()` plus ZAP setup, short enough that
+  a wedged native layer fails the caller instead of blocking the broker forever.
   """
   @spec start_router(String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
   def start_router(endpoint, opts \\ []) when is_binary(endpoint) and is_list(opts) do
@@ -55,6 +79,9 @@ defmodule Ankole.ActorRuntime.Transport.Broker do
 
   @doc """
   Stops the ZeroMQ ROUTER transport if it is running.
+
+  Same 5s bound as `start_router/2` — closing the native socket is a blocking
+  NIF call and should not be able to hang the broker indefinitely.
   """
   @spec stop_router() :: :ok | {:error, term()}
   def stop_router do
@@ -86,6 +113,10 @@ defmodule Ankole.ActorRuntime.Transport.Broker do
   def init(opts) do
     state = %{local_routes: %{}, router: nil, router_endpoint: nil}
 
+    # Bind the ROUTER in a continuation, not inline in init/1: binding is a
+    # blocking NIF call, and deferring it keeps the supervisor's start_link fast
+    # and lets a bind failure be logged (see handle_continue) instead of
+    # crash-looping the whole actor-runtime supervisor at boot.
     case Keyword.get(opts, :router) do
       nil -> {:ok, state}
       false -> {:ok, state}
@@ -132,6 +163,9 @@ defmodule Ankole.ActorRuntime.Transport.Broker do
 
   @impl true
   def handle_call({:send_mandatory, route, envelope}, _from, state) do
+    # Local routes win over the production ROUTER so a test handler can shadow a
+    # route. A locally dispatched envelope is always "sent": the handler runs
+    # in-process and cannot be lost on the wire.
     case Map.fetch(state.local_routes, route) do
       {:ok, handler} ->
         dispatch(handler, envelope)
@@ -147,6 +181,11 @@ defmodule Ankole.ActorRuntime.Transport.Broker do
     endpoint = Keyword.fetch!(router_opts, :endpoint)
     opts = Keyword.delete(router_opts, :endpoint)
 
+    # A failed bind at boot logs and leaves the broker running with no router:
+    # the process stays up so operators can retry via start_router/2 (e.g. after
+    # freeing the port), rather than crash-looping the whole runtime supervisor.
+    # With no router, send_mandatory/2 reports :unknown_route, which the caller
+    # treats as worker staleness — outbound turns stay durable and retryable.
     case start_router_in_state(endpoint, opts, state) do
       {:ok, state} ->
         {:noreply, state}
@@ -158,6 +197,11 @@ defmodule Ankole.ActorRuntime.Transport.Broker do
   end
 
   @impl true
+  # The native ROUTER forwards inbound frames in two shapes. The 3-tuple is the
+  # unauthenticated form (ZAP disabled, e.g. in tests): route + raw JSON only.
+  # The 5-tuple is the production form: the transport has already verified the
+  # worker's pre-auth key and tells us which worker_id / key_revision the route
+  # belongs to, so lifecycle messages can be bound to a proven identity below.
   def handle_info({:actor_bus_router_received, route, envelope_json}, state) do
     handle_router_received(route, nil, nil, envelope_json, state)
   end
@@ -186,6 +230,12 @@ defmodule Ankole.ActorRuntime.Transport.Broker do
     {:noreply, state}
   end
 
+  # Entry point for every inbound envelope. The LLM-credential request is the one
+  # request/response RPC on this socket: a worker asks the control plane to mint
+  # provider credentials and waits for the reply on the same route, so it is
+  # answered inline and the response is sent straight back. Everything else is
+  # one-way (lifecycle projections, turn results) and goes through
+  # dispatch_router_envelope/2, which never replies on the socket.
   defp handle_router_received(
          route,
          authenticated_worker_id,
@@ -209,6 +259,9 @@ defmodule Ankole.ActorRuntime.Transport.Broker do
     {:noreply, state}
   end
 
+  # Delivers to a local (test) route handler. A handler may be a 1-arity function
+  # (called synchronously) or a pid (gets an `{:actor_bus, envelope}` message),
+  # so tests can assert on either a return value or a received message.
   defp dispatch(handler, envelope) when is_function(handler, 1), do: handler.(envelope)
   defp dispatch(handler, envelope) when is_pid(handler), do: send(handler, {:actor_bus, envelope})
 
@@ -339,6 +392,11 @@ defmodule Ankole.ActorRuntime.Transport.Broker do
     )
   end
 
+  # Same ZAP-auth defaulting as the supervisor, applied here for callers that
+  # start the router directly via start_router/2 (e.g. tests) without going
+  # through the supervisor's config path. Unless the caller supplies its own
+  # credentials, point the native router at the Repo database so it can verify
+  # worker pre-auth keys.
   defp maybe_database_worker_auth(opts) do
     cond do
       Keyword.has_key?(opts, :pre_auth_token) ->
@@ -368,6 +426,10 @@ defmodule Ankole.ActorRuntime.Transport.Broker do
     }
   end
 
+  # Collapse "no identity" sentinels from the native layer to nil so downstream
+  # auth checks see a clean optional. A blank worker id or a non-positive key
+  # revision means the transport did not authenticate this frame (ZAP disabled),
+  # not "authenticated as the empty worker".
   defp normalize_auth_worker_id(value) when is_binary(value) do
     case String.trim(value) do
       "" -> nil

--- a/app/control_plane/lib/ankole/actor_runtime/watchdog.ex
+++ b/app/control_plane/lib/ankole/actor_runtime/watchdog.ex
@@ -1,6 +1,14 @@
 defmodule Ankole.ActorRuntime.Watchdog do
   @moduledoc """
   Periodic recovery owner for stale workers, expired leases, and projection gaps.
+
+  The watchdog is the heartbeat-lease enforcer for the runtime. Each tick runs
+  idempotent, repeatable repairs against the durable ledger: expire workers whose
+  heartbeats lapsed, release activation leases past their deadline, and re-derive
+  runtime projections for durable turns that lost theirs (e.g. after a control-
+  plane restart). Because every pass re-reads the database and only ever moves
+  state toward consistency, missing or doubling a tick is harmless — which is why
+  failures are logged and the loop simply keeps going.
   """
 
   use GenServer
@@ -9,6 +17,9 @@ defmodule Ankole.ActorRuntime.Watchdog do
 
   alias Ankole.ActorRuntime
 
+  # Recovery cadence. 1s keeps lease/heartbeat expiry latency low (an actor stuck
+  # behind a dead worker recovers within ~a second) while the queries are cheap
+  # enough to run that often. Operators can raise it via :interval_ms.
   @default_interval_ms 1_000
 
   @doc """
@@ -32,11 +43,20 @@ defmodule Ankole.ActorRuntime.Watchdog do
   def init(opts) do
     state = %{
       interval_ms: Keyword.get(opts, :interval_ms, @default_interval_ms),
+      # Declare a worker dead after 60s without a heartbeat — several missed
+      # ~heartbeat intervals, so a brief network blip doesn't evict a live worker,
+      # but a truly gone worker's in-flight turns are freed within a minute.
       stale_after_seconds: Keyword.get(opts, :stale_after_seconds, 60),
+      # Keep stale/stopped worker rows for 1h before deleting them, so operators
+      # can still see why a worker dropped out before the projection is reaped.
       stale_worker_ttl_seconds: Keyword.get(opts, :stale_worker_ttl_seconds, 3_600),
+      # No extra slack past a lease deadline by default; tunable if clock skew
+      # between control plane and workers ever needs absorbing.
       lease_grace_seconds: Keyword.get(opts, :lease_grace_seconds, 0)
     }
 
+    # Run one pass immediately on boot (via continue) so recovery doesn't wait a
+    # full interval after a control-plane restart, then settle into the timer loop.
     {:ok, state, {:continue, :initial_watchdog}}
   end
 

--- a/app/control_plane/lib/ankole/actor_runtime/worker_admission.ex
+++ b/app/control_plane/lib/ankole/actor_runtime/worker_admission.ex
@@ -1,6 +1,20 @@
 defmodule Ankole.ActorRuntime.WorkerAdmission do
   @moduledoc """
   Worker admission boundary for authenticated Actor Bus lifecycle messages.
+
+  Every worker lifecycle message (ready / heartbeat / capacity) lands here after
+  the transport has authenticated the route, and gets projected into the durable
+  `agent_computer_worker` table — the scheduler's single source of worker
+  liveness. Two invariants drive most of the logic in this module:
+
+    * Identity fencing: the message must come from the route+instance the worker
+      currently owns. A reconnected worker gets a fresh `worker_instance_id`, so
+      a stale connection (or an old process) can never refresh or keep alive a
+      projection that has moved on.
+    * Safe staleness: when a worker dies or its route breaks, its created/sent
+      deliveries are superseded and its assignments released, but the underlying
+      actor input rows stay open so the scheduler can simply retry them — worker
+      death never loses user-visible work.
   """
 
   import Ecto.Query, warn: false
@@ -11,6 +25,8 @@ defmodule Ankole.ActorRuntime.WorkerAdmission do
   alias Ankole.Repo
 
   @ready_worker_status "ready"
+  # Only "ready"/"draining" workers can be made stale or block a duplicate claim;
+  # already-stale/stopped rows are inert and handled by the TTL reaper instead.
   @stale_worker_statuses ~w(ready draining)
 
   @doc """
@@ -52,6 +68,10 @@ defmodule Ankole.ActorRuntime.WorkerAdmission do
       |> Map.put(:last_worker_heartbeat_at, now)
       |> maybe_put(:transport_route, route)
 
+    # Upsert keyed on worker_id: a worker restarting under the same stable id
+    # overwrites its prior projection (new instance id, route, capacity, fresh
+    # lease) in one statement, rather than racing an insert against a delete of
+    # the old row. The replace list is every field a re-ready should refresh.
     Repo.transact(fn repo ->
       with :ok <- worker_instance_available(repo, attrs),
            :ok <- worker_route_available(repo, attrs) do
@@ -83,6 +103,11 @@ defmodule Ankole.ActorRuntime.WorkerAdmission do
 
   @doc """
   Records an authenticated worker heartbeat projection.
+
+  A heartbeat renews the worker's lease (its `last_worker_heartbeat_at`), which is
+  the clock the watchdog reads to decide staleness. It is accepted only if the
+  authenticated identity matches and the worker still owns its instance+route, so
+  heartbeats from a previous process cannot keep a superseded worker alive.
   """
   @spec handle_worker_heartbeat(map(), String.t() | map()) ::
           {:ok, AgentComputerWorker.t()} | {:error, term()}
@@ -101,6 +126,10 @@ defmodule Ankole.ActorRuntime.WorkerAdmission do
 
   @doc """
   Records an authenticated worker capacity projection.
+
+  Capacity updates feed `WorkerPool` placement decisions (free turn slots). Like
+  heartbeats, this also refreshes the lease and is identity/route fenced so a
+  stale connection cannot rewrite a live worker's capacity.
   """
   @spec handle_worker_capacity(map(), String.t() | map()) ::
           {:ok, AgentComputerWorker.t()} | {:error, term()}
@@ -109,6 +138,8 @@ defmodule Ankole.ActorRuntime.WorkerAdmission do
          {:ok, worker_id} <- fetch_required_text(worker_capacity, "worker_id"),
          :ok <- authenticated_worker_matches(auth, worker_id),
          {:ok, worker_instance_id} <- fetch_required_text(worker_capacity, "worker_instance_id") do
+      # Prefer the structured capacity map; fall back to the scalar
+      # available_turn_slots field for older workers that don't send capacity_json.
       capacity =
         worker_capacity
         |> fetch_map("capacity_json")
@@ -352,6 +383,10 @@ defmodule Ankole.ActorRuntime.WorkerAdmission do
 
   defp authenticated_route(_route), do: {:error, :unauthenticated_worker_route}
 
+  # When the transport did not authenticate an identity (ZAP-disabled test path,
+  # worker_id == nil) there is nothing to cross-check, so accept. When it did,
+  # the payload's worker_id must equal the proven one — otherwise a worker is
+  # claiming to be someone else and the message is rejected.
   defp authenticated_worker_matches(%{worker_id: nil}, _worker_id), do: :ok
 
   defp authenticated_worker_matches(%{worker_id: authenticated_worker_id}, worker_id)

--- a/app/control_plane/lib/ankole/actor_runtime/worker_auth_keys.ex
+++ b/app/control_plane/lib/ankole/actor_runtime/worker_auth_keys.ex
@@ -1,6 +1,13 @@
 defmodule Ankole.ActorRuntime.WorkerAuthKeys do
   @moduledoc """
   Worker-scoped pre-auth key bootstrap service.
+
+  Each stable `worker_id` owns one long-lived pre-auth key (a generated secret)
+  used as the password in ZeroMQ's ZAP PLAIN handshake. The native ROUTER calls
+  `verify/2` during a worker's connect to authenticate it before any envelope is
+  accepted; `bootstrap_key/2` mints (or fetches) the key an operator hands to the
+  worker container. This is the identity that the worker-admission layer then
+  fences every lifecycle message against.
   """
 
   import Ecto.Query, warn: false
@@ -11,6 +18,11 @@ defmodule Ankole.ActorRuntime.WorkerAuthKeys do
 
   @doc """
   Builds the current Repo database URL for worker auth bootstrap and router ZAP checks.
+
+  The native ROUTER runs its ZAP key lookups by connecting to Postgres directly,
+  so it needs the same database URL the Repo uses. When the Repo is configured
+  with discrete fields instead of a URL, reconstruct one (URL-encoding each part
+  so credentials with special characters survive).
   """
   @spec database_url!() :: String.t()
   def database_url! do
@@ -33,6 +45,12 @@ defmodule Ankole.ActorRuntime.WorkerAuthKeys do
 
   @doc """
   Fetches or creates the pre-auth key for a stable worker id.
+
+  Bootstrap is sticky: an existing key is reused (its secret never rotates here)
+  so re-bootstrapping the same worker is idempotent and doesn't invalidate a
+  worker that is already connected. A row locked under `FOR UPDATE` keeps two
+  concurrent bootstraps from both inserting. A disabled key is refused outright —
+  a revoked worker must not be silently re-enabled by asking for its key again.
   """
   @spec bootstrap_key(String.t(), keyword()) ::
           {:ok, AgentComputerWorkerAuthKey.t()} | {:error, term()}
@@ -64,6 +82,12 @@ defmodule Ankole.ActorRuntime.WorkerAuthKeys do
 
   @doc """
   Verifies a worker id/password pair for ZAP PLAIN semantics.
+
+  Called by the ROUTER's ZAP handler on every worker connect. The supplied secret
+  is pinned directly in the match (`pre_auth_key: ^pre_auth_key`), so only an
+  exact, enabled key authenticates; a disabled key, a wrong key, and an unknown
+  worker are each rejected with a distinct reason for operator diagnostics. The
+  fallback clause rejects non-binary input so malformed ZAP frames cannot pass.
   """
   @spec verify(String.t(), String.t()) :: {:ok, AgentComputerWorkerAuthKey.t()} | {:error, term()}
   def verify(worker_id, pre_auth_key) when is_binary(worker_id) and is_binary(pre_auth_key) do
@@ -86,6 +110,10 @@ defmodule Ankole.ActorRuntime.WorkerAuthKeys do
 
   @doc """
   Disables one worker key.
+
+  Operator revocation: sets `disabled_at` so the next `verify/2` (and any future
+  bootstrap) is refused. Existing connections are not torn down here — the worker
+  is locked out on its next ZAP handshake.
   """
   @spec disable(String.t()) :: {:ok, AgentComputerWorkerAuthKey.t()} | {:error, term()}
   def disable(worker_id) do
@@ -111,6 +139,9 @@ defmodule Ankole.ActorRuntime.WorkerAuthKeys do
     |> repo.one()
   end
 
+  # Worker ids are matched case-insensitively and trimmed so a stray space or
+  # casing difference between bootstrap and the ZAP handshake can't lock a worker
+  # out of its own key. Must stay consistent across bootstrap/verify/disable.
   defp normalize_worker_id(worker_id), do: worker_id |> String.trim() |> String.downcase()
 
   defp url_encode(value), do: value |> to_string() |> URI.encode_www_form()

--- a/app/control_plane/lib/ankole/actor_runtime/worker_bootstrap.ex
+++ b/app/control_plane/lib/ankole/actor_runtime/worker_bootstrap.ex
@@ -47,6 +47,9 @@ defmodule Ankole.ActorRuntime.WorkerBootstrap do
     end
   end
 
+  # Pre-creates the three host directories the worker bind-mounts below. Docker
+  # would create missing mount sources as root-owned dirs; making them up front
+  # (and `&&`-chaining before `docker run`) keeps them owned by the operator.
   defp workspace_setup_command(workspace_root) do
     Enum.join(
       [
@@ -90,6 +93,10 @@ defmodule Ankole.ActorRuntime.WorkerBootstrap do
     end
   end
 
+  # Single-quotes the value for safe inclusion in the rendered shell command
+  # (endpoint, secret, ids may contain shell metacharacters). The `'\"'\"'`
+  # sequence is the standard POSIX idiom for embedding a literal single quote
+  # inside a single-quoted string: close-quote, escaped-quote, reopen-quote.
   defp shell_escape(value) do
     "'" <> String.replace(value, "'", "'\"'\"'") <> "'"
   end

--- a/app/control_plane/lib/ankole/actor_runtime/worker_pool.ex
+++ b/app/control_plane/lib/ankole/actor_runtime/worker_pool.ex
@@ -1,6 +1,16 @@
 defmodule Ankole.ActorRuntime.WorkerPool do
   @moduledoc """
   Worker placement boundary for actor sessions.
+
+  Maps an actor key to a ready worker. Assignments are sticky (an actor reuses
+  the same worker while it stays usable, to cut churn) but they are only hints:
+  the `agent_computer_worker` table remains the liveness source, and every
+  placement revalidates the worker behind the assignment. If the assigned worker
+  is gone, the assignment is released and re-placed. Crucially, an assignment is
+  not part of the durable user story — losing one only means the actor input is
+  retried onto another worker, never that work is dropped. Placement deliberately
+  considers only liveness and free capacity because all workers run one image; a
+  heterogeneous pool is out of scope for this path.
   """
 
   import Ecto.Query, warn: false
@@ -30,6 +40,12 @@ defmodule Ankole.ActorRuntime.WorkerPool do
 
   @doc """
   Releases live assignments for a worker that is no longer usable.
+
+  Called inside the worker-staleness transition (see `WorkerAdmission`) so that
+  marking a worker stale and detaching its actor sessions commit together. Fences
+  on `worker_instance_id` as well as `worker_id`, so a worker that has since
+  reconnected under a new instance keeps its current assignments. Returns the
+  Ecto `update_all` count tuple.
   """
   @spec release_assignments_for_worker(module(), AgentComputerWorker.t()) ::
           {non_neg_integer(), nil | [term()]}

--- a/app/control_plane/lib/ankole/actor_runtime/worker_registry.ex
+++ b/app/control_plane/lib/ankole/actor_runtime/worker_registry.ex
@@ -1,6 +1,12 @@
 defmodule Ankole.ActorRuntime.WorkerRegistry do
   @moduledoc """
   Durable worker projection API.
+
+  Thin compatibility facade kept for callers that still reach for a "worker
+  registry" name. It delegates straight to `Ankole.ActorRuntime.WorkerAdmission`,
+  where the admission rules, identity fencing, and route handling actually live.
+  Note this is the *durable* projection (a Postgres table), not the in-process
+  `ActorDirectory` Registry used to name session controllers.
   """
 
   alias Ankole.ActorRuntime.Schemas.AgentComputerWorker


### PR DESCRIPTION
## What

Comment-only PR for the **actor-runtime OTP / ZeroMQ transport / worker-lifecycle** layer. Adds intent-focused (WHY over WHAT) `@moduledoc` / `@doc` / inline comments aimed at a senior engineer reading Ankole for the first time. No code, logic, control flow, names, or ordering changed.

## Files (11)

- `actor_runtime/supervisor.ex` — failure-domain shape, why `:one_for_one`, core-path vs disable-able recovery loops, why a bad router config crashes boot.
- `actor_runtime/session_supervisor.ex` / `session_controller.ex` — per-actor dynamic supervision, idempotent get-or-start race, serial-per-actor model as a reasoning optimization (durable DB fences are the real guard), why the 30s call timeout.
- `actor_runtime/transport/broker.ex` — local-route (test) vs production ZeroMQ ROUTER split, what a "transport route" is, dual-arity authenticated-frame contract, mandatory-send semantics (`unknown_route` → worker staleness, turn stays durable/retryable), why bind is deferred to `handle_continue`, why the 5s router-call bound.
- `actor_runtime/watchdog.ex` — heartbeat-lease enforcer, rationale for the 1s interval / 60s stale-after / 1h TTL / 0 lease-grace constants, log-and-continue recovery.
- `actor_runtime/outbox_dispatcher.ex` — poll-is-truth / wake-only-shaves-latency, 500ms & 25-row constants, durable-outbox retry.
- `actor_runtime/worker_admission.ex` — identity/route fencing, safe-staleness (deliveries superseded but actor inputs stay retryable), upsert-on-reconnect, auth-identity match rules.
- `actor_runtime/worker_pool.ex` / `worker_registry.ex` — sticky-but-hint assignments, liveness from the worker table, durable projection vs in-process `ActorDirectory`.
- `actor_runtime/worker_auth_keys.ex` / `worker_bootstrap.ex` — ZAP PLAIN pre-auth key lifecycle (bootstrap/verify/disable), rendered-not-launched Docker bootstrap, POSIX single-quote escaping.

## Verification

- `MIX_ENV=test mix compile --warnings-as-errors` — **clean (exit 0)**; the required gate. A clean recompile proves the doc comments are well-formed and no code changed (the de-facto e2e for a comment-only change).
- `mix format` / `mix format --check-formatted` — **clean**.
- `git diff --check` — clean; an independent review confirmed byte-identical executable-code skeletons across all 11 files (243 insertions / 3 deletions, all comment/doc lines).
- `MIX_ENV=test mix test` — **not run: no local Postgres** reachable in this environment (test config expects `localhost:5433`, port closed). Comment-only change, so no behavioral e2e applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)