### PR TITLE
docs(control_plane): comment plugins/actors/json/i18n misc

### DIFF
--- a/app/control_plane/lib/ankole/actors.ex
+++ b/app/control_plane/lib/ankole/actors.ex
@@ -1,6 +1,25 @@
 defmodule Ankole.Actors do
   @moduledoc """
-  Actor input store boundary shared by SignalsGateway and ActorRuntime.
+  The actor input journal: durable inbox shared by SignalsGateway and ActorRuntime.
+
+  SignalsGateway *appends* normalized inputs for an actor session; ActorRuntime
+  *consumes* them when a turn commits. The model is deliberately "queue + audit
+  marker", not a log:
+
+    - Append is idempotent on the ingress key, and a per-session `broker_sequence`
+      (allocated under a Postgres advisory lock) gives the runtime one stable
+      ordered stream per actor session.
+    - On consume, the input row is *deleted* and an `ActorInputConsumption` marker
+      is written in the same transaction. The marker is the durable link from
+      provider ingress to the committed turn and the recovery-time guard against
+      double consumption; the deletion keeps the live queue small (compaction).
+    - That consume transaction is the single commit point: marking the input
+      consumed and scheduling any provider reply (outbox intents) succeed or fail
+      together, so "message handled" and "reply will be sent" are one decision.
+
+  Several `*_in_tx` functions take a `repo` and run inside a caller-owned
+  transaction because the AI-agent message/turn writes that fence a consumption
+  belong to the caller, not to this boundary.
   """
 
   import Ecto.Query, warn: false

--- a/app/control_plane/lib/ankole/admin_auth.ex
+++ b/app/control_plane/lib/ankole/admin_auth.ex
@@ -1,6 +1,10 @@
 defmodule Ankole.AdminAuth do
   @moduledoc """
-  Admin-session authorization checks.
+  Coarse "is this caller a platform admin?" gate for operator-only surfaces.
+
+  This sits in front of the finer-grained `Ankole.AuthZ` permission grants: the
+  console and other operator endpoints use it as a blunt yes/no before they even
+  consider per-resource authorization.
   """
 
   import Ecto.Query
@@ -11,6 +15,9 @@ defmodule Ankole.AdminAuth do
   alias Ankole.Principals.Principal
   alias Ankole.Repo
 
+  # The built-in admin group is identified by this reserved name. The query below
+  # also pins `built_in == true` and `kind == :static` so a human-created group
+  # that merely happens to be named "admin" can never grant admin power.
   @admin_group_name "admin"
 
   @doc """
@@ -18,6 +25,10 @@ defmodule Ankole.AdminAuth do
   """
   @spec active_human_admin?(String.t()) :: boolean()
   def active_human_admin?(principal_uid) do
+    # `type == :human` deliberately excludes agent principals: agents never get
+    # operator admin even if added to the group. `status == :active` denies a
+    # suspended/disabled human without having to scrub group memberships. A
+    # malformed uid normalizes to an error and is treated as "not admin".
     with {:ok, principal_uid} <- Principals.normalize_uid(principal_uid) do
       Repo.exists?(
         from membership in Membership,

--- a/app/control_plane/lib/ankole/ankole.ex
+++ b/app/control_plane/lib/ankole/ankole.ex
@@ -1,9 +1,11 @@
 defmodule Ankole do
   @moduledoc """
-  Ankole keeps the contexts that define your domain
-  and business logic.
+  Namespace root for the control-plane domain contexts.
 
-  Contexts are also responsible for managing your data, regardless
-  if it comes from the database, an external API or others.
+  Ankole is an AgentOS: this control plane owns Principals/AuthZ, AppConfigure,
+  the plugin registry, SignalsGateway ingress, the actor runtime, and the
+  operator web shell. Each concern lives in its own context module
+  (`Ankole.Principals`, `Ankole.Plugins`, `Ankole.Actors`, ...); this bare
+  module only anchors the namespace and carries no behavior.
   """
 end

--- a/app/control_plane/lib/ankole/application.ex
+++ b/app/control_plane/lib/ankole/application.ex
@@ -7,6 +7,18 @@ defmodule Ankole.Application do
 
   @impl true
   def start(_type, _args) do
+    # Child order is load-bearing, not cosmetic. `:one_for_one` restarts a single
+    # failed child in place, but the initial boot still proceeds top to bottom, so
+    # anything later may assume earlier children are already up.
+    #
+    #   - Repo before AppConfigure: durable config is read from Postgres.
+    #   - AppConfigure.Registry + Cache before Plugins/I18n: those subsystems read
+    #     and register AppConfigure definitions during their own `init/1`.
+    #   - Plugins.Registry before Plugins.Supervisor: the registry discovers and
+    #     activates plugins, then the supervisor reads that active set to know
+    #     which plugin-contributed children to start (snapshot taken once at boot).
+    #   - Endpoint last: accept web traffic only after every subsystem it serves
+    #     (auth, config, plugins, actors, i18n) is ready.
     children = [
       AnkoleWeb.Telemetry,
       Ankole.Repo,

--- a/app/control_plane/lib/ankole/plugins.ex
+++ b/app/control_plane/lib/ankole/plugins.ex
@@ -1,6 +1,21 @@
 defmodule Ankole.Plugins do
   @moduledoc """
   Public facade for Ankole's first-party Elixir plugin registry.
+
+  Ankole plugins are not a marketplace of installable extensions. They are
+  first-party Elixir modules compiled into the release that contribute things
+  like signal adapters, identity providers, AppConfigure keys, and supervised
+  children. The lifecycle has two stages with deliberately different meanings:
+
+    - **discovered**: every plugin module found and validated at boot. This is
+      the full catalog the operator can see.
+    - **active**: the discovered plugins that are *not* in the global disable
+      list. Only active plugins register config and start children.
+
+  Because plugins are installation-global and default-on, the operator opts
+  plugins *out* via a single global disable list (`put_disabled_ids/1`), rather
+  than opting each one in. That list is read once at registry startup, so a
+  change takes effect on the next Ankole process start (see `Plugins.Config`).
   """
 
   alias Ankole.Plugins.Config

--- a/app/control_plane/lib/ankole/plugins/config.ex
+++ b/app/control_plane/lib/ankole/plugins/config.ex
@@ -1,6 +1,13 @@
 defmodule Ankole.Plugins.Config do
   @moduledoc """
-  Core AppConfigure definitions owned by the plugin subsystem.
+  AppConfigure storage for the global plugin disable list.
+
+  Plugins are installation-global and default-on, so the only operator knob is a
+  durable list of disabled plugin ids. It lives in AppConfigure (Postgres) rather
+  than in process state because the registry reads it once at startup; a change
+  therefore takes effect on the next Ankole process start, not immediately. This
+  is deliberate — activating/deactivating a plugin can add or remove supervised
+  children and config keys, which is a boot-time concern, not a hot-swap.
   """
 
   alias Ankole.AppConfigure
@@ -57,6 +64,10 @@ defmodule Ankole.Plugins.Config do
     end
   end
 
+  # Validate at write time so a malformed disable list is rejected when an
+  # operator sets it, not silently mishandled at boot. The value must be an array
+  # of well-formed, unique plugin ids; ids need not correspond to a plugin that
+  # currently exists, so disabling an id ahead of installing its plugin is fine.
   defp disabled_ids_schema do
     Schema.new(fn
       values when is_list(values) -> normalize_disabled_ids(values)

--- a/app/control_plane/lib/ankole/plugins/discovery.ex
+++ b/app/control_plane/lib/ankole/plugins/discovery.ex
@@ -1,10 +1,21 @@
 defmodule Ankole.Plugins.Discovery do
   @moduledoc """
-  Discovers compiled first-party plugin modules from local plugin roots.
+  Finds first-party plugin modules under the repo's plugin source roots.
+
+  Discovery reads `.ex` source files and extracts every `defmodule` name from the
+  AST, then loads each candidate to check whether it implements the
+  `Ankole.Plugins.Plugin` behaviour. We scan source rather than reflecting over
+  all loaded modules so discovery only sees modules that actually live in a
+  plugin root — code in `app/control_plane` that happens to implement the
+  behaviour is not swept in. Any unparseable plugin source fails discovery loudly
+  instead of silently shrinking the plugin set.
   """
 
   alias Ankole.Plugins.Spec
 
+  # `__DIR__` is .../app/control_plane/lib/ankole/plugins, so five `..` hops reach
+  # the repo root. The two roots are the open-source `plugins/` tree and the
+  # optional private `internals/plugins/` tree; a missing root is simply skipped.
   @repo_root Path.expand("../../../../../", __DIR__)
   @default_roots [
     Path.join(@repo_root, "plugins"),
@@ -20,7 +31,12 @@ defmodule Ankole.Plugins.Discovery do
   def default_roots, do: @default_roots
 
   @doc """
-  Discovers plugin specs from source roots and explicit modules.
+  Discovers and normalizes plugin specs, sorted by plugin id.
+
+  `:roots` overrides the scanned directories and `:modules` injects extra plugin
+  modules directly; both exist so tests can exercise fixture plugins without
+  placing them in a real plugin root. Returns `{:error, reason}` on the first
+  unparseable source, unloadable module, or invalid spec rather than dropping it.
   """
   @spec discover(opts()) :: {:ok, [Spec.t()]} | {:error, term()}
   def discover(opts \\ []) do
@@ -67,6 +83,9 @@ defmodule Ankole.Plugins.Discovery do
     end
   end
 
+  # Collects fully-qualified names of every `defmodule` in the file, including
+  # nested ones, by walking the quoted AST. This is name extraction only; whether
+  # a name is actually a plugin is decided later by the behaviour check.
   defp defmodules(ast) do
     {_ast, modules} =
       Macro.prewalk(ast, [], fn
@@ -100,6 +119,9 @@ defmodule Ankole.Plugins.Discovery do
     end
   end
 
+  # A discovered name only becomes a plugin if its module declares the
+  # `Ankole.Plugins.Plugin` behaviour. A name parsed from source that cannot be
+  # loaded is an error (a real compiled plugin should always load), not a skip.
   defp root_plugin_module?(module) do
     case Code.ensure_loaded(module) do
       {:module, ^module} ->

--- a/app/control_plane/lib/ankole/plugins/plugin.ex
+++ b/app/control_plane/lib/ankole/plugins/plugin.ex
@@ -1,6 +1,14 @@
 defmodule Ankole.Plugins.Plugin do
   @moduledoc """
-  Behaviour implemented by first-party Ankole plugin modules.
+  Contract a first-party plugin module declares to the registry.
+
+  A plugin advertises an identity (`plugin_id/0`, `api_version/0`) and may
+  contribute any of: AppConfigure keys, setup wizard steps, adapter declarations
+  (the data that lets a plugin plug into a subsystem contract such as
+  `signals_gateway.adapter` or `principals.identity_provider`), and supervised
+  children. Everything except identity is optional, so a minimal plugin only
+  implements the two required callbacks. `Ankole.Plugins.Spec.from_module/1`
+  reads these callbacks and normalizes the result into a `Spec`.
   """
 
   alias Ankole.AppConfigure.Definition

--- a/app/control_plane/lib/ankole/plugins/registry.ex
+++ b/app/control_plane/lib/ankole/plugins/registry.ex
@@ -1,6 +1,14 @@
 defmodule Ankole.Plugins.Registry do
   @moduledoc """
-  Process-local registry of discovered and active Ankole plugins.
+  GenServer holding the boot-time snapshot of discovered and active plugins.
+
+  The whole plugin set is resolved once in `init/1`: discover specs, reject the
+  globally disabled ids to get the active set, then register the active plugins'
+  AppConfigure keys. State is immutable for the lifetime of the process, so
+  enabling or disabling a plugin requires an Ankole restart — there is no live
+  reload. If discovery, a uniqueness invariant, or config registration fails,
+  `init/1` returns `:stop`, which fails application boot rather than starting up
+  with a half-registered plugin set.
   """
 
   use GenServer
@@ -54,7 +62,7 @@ defmodule Ankole.Plugins.Registry do
   end
 
   @doc """
-  Returns whether a discovered plugin id is active.
+  Returns whether a plugin id is currently active (discovered and not disabled).
   """
   @spec active?(String.t(), GenServer.server()) :: boolean()
   def active?(id, server \\ __MODULE__) when is_binary(id) do
@@ -62,7 +70,10 @@ defmodule Ankole.Plugins.Registry do
   end
 
   @doc """
-  Lists active adapter declarations for one subsystem contract id.
+  Returns adapter declarations from active plugins for one contract id.
+
+  Subsystems (SignalsGateway, Principals identity, ...) call this with their own
+  contract id to find which plugins plug into them, e.g. "signals_gateway.adapter".
   """
   @spec adapter_declarations(String.t(), GenServer.server()) :: [map()]
   def adapter_declarations(contract_id, server \\ __MODULE__) when is_binary(contract_id) do
@@ -89,6 +100,10 @@ defmodule Ankole.Plugins.Registry do
   def init(opts) do
     discovery_opts = Keyword.get(opts, :discovery, [])
 
+    # Resolve everything up front. Note the disable list is read from durable
+    # AppConfigure exactly once here, which is why a disable/enable change only
+    # lands on the next boot. Adapter-uniqueness and config registration run over
+    # the *active* set only, so a disabled plugin can never collide or register.
     with {:ok, specs} <- Discovery.discover(discovery_opts),
          :ok <- ensure_unique_ids(specs),
          :ok <- Config.ensure_registered(),
@@ -166,6 +181,10 @@ defmodule Ankole.Plugins.Registry do
     Enum.reject(specs, &MapSet.member?(disabled, &1.id))
   end
 
+  # Two active plugins must not claim the same `{contract_id, adapter_id}` slot,
+  # or a subsystem lookup would be ambiguous about which adapter to use.
+  # Declarations missing either key are skipped here; `Spec` already rejected
+  # truly malformed ones, and partial maps simply cannot collide.
   defp ensure_unique_adapter_declarations(specs) do
     specs
     |> Enum.flat_map(fn spec ->
@@ -213,6 +232,8 @@ defmodule Ankole.Plugins.Registry do
     }
   end
 
+  # Adapter declarations are plain maps authored by plugins, so a key may arrive
+  # as either an atom or a string. These helpers accept both forms.
   defp adapter_contract?(%{contract_id: contract_id}, contract_id), do: true
   defp adapter_contract?(%{"contract_id" => contract_id}, contract_id), do: true
   defp adapter_contract?(_declaration, _contract_id), do: false

--- a/app/control_plane/lib/ankole/plugins/spec.ex
+++ b/app/control_plane/lib/ankole/plugins/spec.ex
@@ -1,12 +1,23 @@
 defmodule Ankole.Plugins.Spec do
   @moduledoc """
-  Normalized declaration for one discovered Ankole plugin.
+  Validates a plugin module's callbacks into a normalized `Spec` struct.
+
+  This is the gate that turns a discovered module into a usable plugin. It runs
+  at boot (via the registry), so validation is strict and fail-fast: every
+  callback value is checked, and for known subsystem contracts the declared
+  adapter modules are checked to actually export the callbacks that contract
+  requires. A plugin that mis-declares an adapter fails Ankole startup here
+  rather than crashing later when a subsystem first tries to invoke it.
   """
 
   alias Ankole.AppConfigure.Definition
   alias Ankole.AppConfigure.PatternDefinition
 
+  # Only api_version 1 exists today; a plugin declaring anything else is rejected
+  # so an incompatible future plugin cannot load against an old runtime.
   @api_version 1
+  # Plugin/adapter ids are lowercase slugs. Contract ids additionally allow dots
+  # so subsystem contracts can be namespaced, e.g. "signals_gateway.adapter".
   @id_pattern ~r/\A[a-z][a-z0-9_-]*\z/
   @contract_id_pattern ~r/\A[a-z][a-z0-9_.-]*\z/
 
@@ -40,6 +51,10 @@ defmodule Ankole.Plugins.Spec do
 
   @doc """
   Builds a normalized plugin spec from a loaded plugin module.
+
+  Required identity callbacks must be present and valid; every optional callback
+  defaults to empty/`nil` when the module does not export it. Errors are wrapped
+  with the offending module so a boot failure points at the responsible plugin.
   """
   @spec from_module(module()) :: {:ok, t()} | {:error, term()}
   def from_module(module) when is_atom(module) do
@@ -199,6 +214,11 @@ defmodule Ankole.Plugins.Spec do
     end
   end
 
+  # Per-contract structural checks. A declaration names which contract it plugs
+  # into; for the contracts Ankole ships, we verify the declared adapter modules
+  # actually export the callbacks that contract will call at runtime. Unknown
+  # contract ids pass through (last clause) so plugins can declare adapters for
+  # contracts this validator does not yet know about.
   defp validate_known_adapter_contract("signals_gateway.adapter", declaration) do
     with :ok <- validate_signals_ingress(declaration),
          :ok <- validate_signals_outbox(declaration),
@@ -217,6 +237,10 @@ defmodule Ankole.Plugins.Spec do
 
   defp validate_known_adapter_contract(_contract_id, _declaration), do: :ok
 
+  # A plugin opts into ingress by listing inbound capabilities; each capability
+  # name maps to one required callback on its ingress module (see the
+  # `validate_signals_inbound_capability/2` clauses). Declaring no inbound
+  # capabilities is valid for an outbound-only adapter.
   defp validate_signals_ingress(declaration) do
     capabilities = declaration_list(declaration, :inbound_capabilities)
 
@@ -369,6 +393,8 @@ defmodule Ankole.Plugins.Spec do
     end
   end
 
+  # Plugins may author declaration maps with atom or string keys, so every read
+  # tries the atom key first and falls back to its string form.
   defp declaration_value(declaration, key) do
     case Map.fetch(declaration, key) do
       {:ok, value} -> {:ok, value}

--- a/app/control_plane/lib/ankole/plugins/supervisor.ex
+++ b/app/control_plane/lib/ankole/plugins/supervisor.ex
@@ -1,6 +1,12 @@
 defmodule Ankole.Plugins.Supervisor do
   @moduledoc """
-  Starts supervised children contributed by active plugins.
+  Static supervisor for the children active plugins contribute.
+
+  It asks the registry for the active plugins' child specs once at startup and
+  supervises them under `:one_for_one`. Because that list is read in `init/1`,
+  the set of plugin children is fixed for the process lifetime — the same boot
+  snapshot the registry uses (see `Ankole.Plugins.Registry`). This is why it
+  starts after the registry in the application boot order.
   """
 
   use Supervisor

--- a/app/control_plane/lib/ankole/types/json_value.ex
+++ b/app/control_plane/lib/ankole/types/json_value.ex
@@ -1,10 +1,19 @@
 defmodule Ankole.Types.JsonValue do
   @moduledoc """
-  Ecto type for JSONB values that may be objects, arrays, or scalars.
+  Ecto type for a JSONB column whose value may be any JSON shape.
+
+  The stock `:map` Ecto type only accepts objects. Several Ankole columns
+  (signal payloads, plugin config blobs, outbox payloads) legitimately store a
+  top-level array or scalar, so this type validates the *whole* JSON value tree
+  instead. The validation is identical on the way in and out (`cast`, `dump`,
+  and `load` all funnel through one check), so a row that fails to load loudly
+  signals that something wrote a non-JSON term directly to the column.
   """
 
   use Ecto.Type
 
+  # Postgres column type stays JSONB; only the Elixir-side validation differs
+  # from the built-in `:map` type.
   def type, do: :map
 
   def cast(value), do: cast_json(value)
@@ -28,6 +37,11 @@ defmodule Ankole.Types.JsonValue do
   defp json_value?(value) when is_float(value), do: true
   defp json_value?(values) when is_list(values), do: Enum.all?(values, &json_value?/1)
 
+  # Structs are rejected even though they are maps: a `DateTime`, `Decimal`, or
+  # schema struct has no faithful JSONB round-trip here, so it must be converted
+  # to plain JSON terms by the caller before it reaches this column. Object keys
+  # must be strings (JSON has no atom keys, and that is the form Postgres returns
+  # on load), so atom-keyed maps are rejected on the way in too.
   defp json_value?(value) when is_map(value) do
     not is_struct(value) and
       Enum.all?(value, fn {key, nested} -> is_binary(key) and json_value?(nested) end)


### PR DESCRIPTION
## What

Comment-only documentation pass over the control-plane "miscellaneous" set, written for a senior engineer reading Ankole for the first time. No code, logic, control flow, names, or ordering changed — `git diff` is only added comments plus formatter whitespace.

## Files

Top-level `app/control_plane/lib/ankole/`: `ankole.ex`, `application.ex`, `admin_auth.ex`; plus `plugins.ex` + `plugins/*`, `actors.ex`, `types/json_value.ex`.

(`repo.ex`, `json.ex`, `i18n.ex`, `i18n/*`, and the two actor schemas were already thoroughly commented in the target style and were left as-is to avoid padding.)

## Highlights

- **`application.ex`** — documents the load-bearing OTP boot order (Repo → AppConfigure → Plugins.Registry → Plugins.Supervisor → Endpoint) and why each dependency comes before its dependents.
- **Plugins** (`plugins.ex`, `config.ex`, `registry.ex`, `supervisor.ex`) — the discovered-vs-active model, the installation-global default-on disable list, and why enable/disable is a boot-time concern read once at registry startup.
- **`discovery.ex`** — why plugins are discovered by scanning source `.ex` AST rather than reflecting over loaded modules.
- **`spec.ex`** — why adapter declarations are validated fail-fast at boot (mis-declared adapters fail startup, not first use).
- **`actors.ex`** — the append/consume "queue + audit marker" journal lifecycle: idempotent append, advisory-lock sequencing, consume-and-delete with the consumption marker, and the single outbox-in-same-transaction commit point.
- **`types/json_value.ex`** — why this exists over the stock `:map` type and why structs / atom keys are rejected.
- **`admin_auth.ex`** — the strict built-in/static/human/active admin gating.

## Verification

- `MIX_ENV=test mix compile --warnings-as-errors` — passes (no warnings from the `ankole` app).
- `mix format` — clean.
- `MIX_ENV=test mix test` — 211 passed.
- All load-bearing technical claims in the comments independently fact-checked against the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)