### PR TITLE
docs(feishu_openapi): comment WS/event/card-action layer

### DIFF
--- a/libs/feishu_openapi/lib/feishu_openapi/card_action.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/card_action.ex
@@ -143,6 +143,9 @@ defmodule FeishuOpenAPI.CardAction do
 
   defp verify_challenge_token(%{verification_token: nil}, _decoded), do: :ok
 
+  # For the (unsigned) challenge handshake, the only thing to authenticate is the
+  # token embedded in the body. Non-challenge requests are authenticated later by
+  # the signature instead, so they pass this step.
   defp verify_challenge_token(%{verification_token: token}, decoded) do
     if challenge?(decoded) do
       if Map.get(decoded, "token") == token, do: :ok, else: {:error, :bad_verification_token}
@@ -151,17 +154,22 @@ defmodule FeishuOpenAPI.CardAction do
     end
   end
 
+  # Card-action signing keys on the verification_token (not the encrypt_key that
+  # event webhooks use); with no token configured there's nothing to verify.
   defp verify_signature(%{skip_sign_verify: true}, _body, _headers, _decoded), do: :ok
   defp verify_signature(%{verification_token: nil}, _body, _headers, _decoded), do: :ok
 
   defp verify_signature(%{verification_token: token}, body, headers, decoded) do
     if challenge?(decoded) do
+      # Challenge already authenticated via the body token above; it's unsigned.
       :ok
     else
       ts = header(headers, "x-lark-request-timestamp")
       nonce = header(headers, "x-lark-request-nonce")
       signature = header(headers, "x-lark-signature")
 
+      # Unlike event webhooks, a non-challenge card callback must carry all signing
+      # headers — there's no exemption here.
       cond do
         is_nil(ts) or is_nil(nonce) or is_nil(signature) ->
           {:error, :missing_signature_headers}

--- a/libs/feishu_openapi/lib/feishu_openapi/card_action/handler.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/card_action/handler.ex
@@ -46,6 +46,10 @@ defmodule FeishuOpenAPI.CardAction.Handler do
 
   @new_opts [:verification_token, :encrypt_key, :skip_sign_verify, :handler]
 
+  @doc """
+  Build a card-action handler from options (verification token, encrypt key,
+  and the 1-arity `:handler` callback). Validates option shapes up front.
+  """
   @spec new(keyword()) :: t()
   def new(opts) do
     opts = validate_new_opts!(opts)
@@ -58,6 +62,11 @@ defmodule FeishuOpenAPI.CardAction.Handler do
     }
   end
 
+  @doc """
+  Verify, decode, and run the handler for a card-action callback. Accepts a raw
+  HTTP body (`{:raw, body, headers}`) or an already-decoded payload
+  (`{:decoded, map}`); the latter skips body-signature verification.
+  """
   @spec dispatch(t(), {:raw, binary(), map() | list()} | {:decoded, map()}) ::
           {:ok, term()} | {:challenge, String.t()} | {:error, term()}
   def dispatch(%__MODULE__{} = handler, {:raw, body, headers}) when is_binary(body) do
@@ -80,6 +89,9 @@ defmodule FeishuOpenAPI.CardAction.Handler do
 
   defp invoke_handler(nil, _action), do: {:error, :handler_not_configured}
 
+  # The user callback runs inside the request process, so a raise/throw here would
+  # take down the web handler. Convert it to a tagged error (and a telemetry event)
+  # so the Plug can still send a controlled response.
   defp invoke_handler(handler, %CardAction{} = action) when is_function(handler, 1) do
     try do
       {:ok, handler.(action)}

--- a/libs/feishu_openapi/lib/feishu_openapi/card_action/server.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/card_action/server.ex
@@ -66,6 +66,9 @@ if Code.ensure_loaded?(Plug) do
     defp resolve(fun) when is_function(fun, 0), do: fun.()
     defp resolve(%Handler{} = handler), do: handler
 
+    # Read the full body here (not via a parser) because card-action signature
+    # verification hashes the exact raw bytes. Chunks are prepended then reversed;
+    # the 8 MB read length bounds buffering.
     defp read_all_body(conn, acc \\ []) do
       case Plug.Conn.read_body(conn, length: 8_000_000) do
         {:ok, body, conn} ->

--- a/libs/feishu_openapi/lib/feishu_openapi/event.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/event.ex
@@ -168,6 +168,8 @@ defmodule FeishuOpenAPI.Event do
     }
   end
 
+  # Signature checking is skipped when explicitly disabled (tests) or when no
+  # encrypt_key is configured (the app simply isn't using signed webhooks).
   defp verify_signature(%{skip_sign_verify: true}, _body, _headers, _decoded), do: :ok
   defp verify_signature(%{encrypt_key: nil}, _body, _headers, _decoded), do: :ok
 
@@ -177,6 +179,8 @@ defmodule FeishuOpenAPI.Event do
     signature = header(headers, "x-lark-signature")
 
     cond do
+      # URL-verification challenges are sent unsigned during webhook setup, so a
+      # missing signature is allowed *only* for a challenge; otherwise reject.
       is_nil(ts) or is_nil(nonce) or is_nil(signature) ->
         if Envelope.challenge?(decoded), do: :ok, else: {:error, :missing_signature_headers}
 
@@ -185,6 +189,8 @@ defmodule FeishuOpenAPI.Event do
     end
   end
 
+  # Replay-window check, gated the same way as signature verification (an unsigned
+  # request has no trustworthy timestamp to check anyway).
   defp verify_timestamp(%{skip_sign_verify: true}, _headers, _decoded), do: :ok
   defp verify_timestamp(%{skip_timestamp_check: true}, _headers, _decoded), do: :ok
   defp verify_timestamp(%{encrypt_key: nil}, _headers, _decoded), do: :ok
@@ -215,6 +221,10 @@ defmodule FeishuOpenAPI.Event do
     end
   end
 
+  # Replay defense: reject events whose timestamp is more than `max_skew_seconds`
+  # from now in either direction. `abs/1` also rejects far-future timestamps, not
+  # just stale replays. This runs on top of (not instead of) signature checking —
+  # a captured valid request replayed past the window still fails here.
   defp check_timestamp_skew(ts_binary, max_skew_seconds) do
     case Integer.parse(ts_binary) do
       {ts_seconds, _} ->

--- a/libs/feishu_openapi/lib/feishu_openapi/event/dispatcher.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/event/dispatcher.ex
@@ -150,13 +150,19 @@ defmodule FeishuOpenAPI.Event.Dispatcher do
 
   # --- internals -----------------------------------------------------------
 
+  # verify_*/2 already separated the outcomes; forward challenge/error untouched
+  # and only routing a verified event needs handler lookup.
   defp route_result({:ok, %Event{} = event}, %__MODULE__{} = d), do: route(d, event)
   defp route_result({:challenge, _} = challenge, _d), do: challenge
   defp route_result({:error, _} = err, _d), do: err
 
+  # No type means we couldn't classify the envelope — distinct from "classified but
+  # no handler registered" so callers can tell the two apart.
   defp route(_d, %Event{type: nil}), do: {:ok, :unknown_event}
 
   defp route(%__MODULE__{} = d, %Event{type: event_type} = event) do
+    # Normal event handlers take precedence over callback handlers; both are keyed
+    # by event type. A type with neither registered is an explicit no_handler ack.
     cond do
       handler = Map.get(d.handlers, event_type) ->
         invoke_handler(handler, event_type, event)
@@ -210,6 +216,10 @@ defmodule FeishuOpenAPI.Event.Dispatcher do
     end
   end
 
+  # Normalize a handler's return so the transport can serialize it consistently:
+  #   {:error, _}    → tagged handler_failed (becomes a 500-class ack)
+  #   {:ok, _}       → collapsed to :ok (the inner value isn't part of the contract)
+  #   anything else  → passed through as the response body (e.g. a card update map)
   defp handler_result({:error, reason}), do: {:error, {:handler_failed, reason}}
   defp handler_result({:ok, _result}), do: {:ok, :ok}
   defp handler_result(result), do: {:ok, result}
@@ -232,6 +242,8 @@ defmodule FeishuOpenAPI.Event.Dispatcher do
     end)
   end
 
+  # The ticket lives under `event` in P2 but at the top level in some P1 shapes,
+  # so check the normalized content first, then fall back to the raw envelope.
   defp extract_app_ticket(%Event{content: content, raw: raw}) do
     with :error <- fetch_string(content || %{}, "app_ticket"),
          :error <- fetch_string(raw, "app_ticket") do

--- a/libs/feishu_openapi/lib/feishu_openapi/event/envelope.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/event/envelope.ex
@@ -55,6 +55,9 @@ defmodule FeishuOpenAPI.Event.Envelope do
 
   def event_type(%{"type" => t}) when is_binary(t), do: t
 
+  # Card-action callbacks carry no `event_type`/`type`; they're identified by an
+  # `action` map plus message/chat context. Synthesize a stable type so they can
+  # be routed like any other event.
   def event_type(%{"action" => action} = payload) when is_map(action) do
     case card_action_payload?(payload) do
       true -> "card.action.trigger"
@@ -64,6 +67,8 @@ defmodule FeishuOpenAPI.Event.Envelope do
 
   def event_type(_), do: nil
 
+  # Require a non-empty message or chat id so an unrelated payload that merely has
+  # an "action" key isn't misclassified as a card action.
   defp card_action_payload?(%{"open_message_id" => id}) when is_binary(id) and id != "",
     do: true
 

--- a/libs/feishu_openapi/lib/feishu_openapi/event/server.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/event/server.ex
@@ -55,6 +55,8 @@ if Code.ensure_loaded?(Plug) do
 
     defp reply({:ok, _}, conn), do: respond(conn, 200, %{"msg" => "success"})
 
+    # Handler reached but failed/crashed → 5xx so Feishu retries delivery, and the
+    # reason is kept off the wire to avoid leaking internals.
     defp reply({:error, {:handler_failed, _reason}}, conn) do
       respond(conn, 500, %{"msg" => "handler failed"})
     end
@@ -63,6 +65,8 @@ if Code.ensure_loaded?(Plug) do
       respond(conn, 500, %{"msg" => "handler failed"})
     end
 
+    # Verification/decode failures are client-side (bad signature, malformed body)
+    # → 400; retrying won't help, so we don't ask Feishu to.
     defp reply({:error, reason}, conn) do
       respond(conn, 400, %{"msg" => "invalid webhook: #{inspect(reason)}"})
     end
@@ -77,6 +81,9 @@ if Code.ensure_loaded?(Plug) do
     defp resolve(fun) when is_function(fun, 0), do: fun.()
     defp resolve(%Dispatcher{} = d), do: d
 
+    # Read the whole body ourselves (chunks prepended for O(1), reversed at the
+    # end) rather than trusting an upstream parser: signature verification needs
+    # the exact raw bytes, byte-for-byte. The 8 MB read length bounds buffering.
     defp read_all_body(conn, acc \\ []) do
       case Plug.Conn.read_body(conn, length: 8_000_000) do
         {:ok, body, conn} ->

--- a/libs/feishu_openapi/lib/feishu_openapi/ws/client.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/ws/client.ex
@@ -34,10 +34,25 @@ defmodule FeishuOpenAPI.WS.Client do
 
   @default_ping_interval_s 120
   @default_reconnect_interval_s 120
+  # First reconnect after a clean close waits a random 0..nonce seconds so a fleet
+  # of clients dropped together doesn't reconnect in lockstep (thundering herd).
   @default_reconnect_nonce_s 30
+  # Endpoint-discovery error codes that mean the app is misconfigured: retrying
+  # can't fix them, so they stop the client instead of reconnecting.
   @fatal_codes [514, 403, 1_000_040_350]
+  # Partial fragment sets are evicted 5s after the first fragment arrives. A
+  # broken connection can leave fragments that never complete; this bounds the
+  # `fragments` map instead of letting it grow unbounded.
   @fragment_ttl_ms :timer.seconds(5)
 
+  # Field notes for the non-obvious ones:
+  #   service_id        — parsed from the WS URL, echoed back in every frame
+  #   reconnect_attempt — count since the last successful connect; resets to 0 on
+  #                       connect and drives the nonce-vs-interval delay choice
+  #   reconnect_count   — max attempts before giving up; -1 means "unlimited"
+  #   fragments         — message_id => partial fragment set, evicted after TTL
+  #   dispatch_tasks    — Task ref => {frame, event_type, start_ms} for in-flight
+  #                       user handlers awaiting an ack
   defstruct client: nil,
             dispatcher: nil,
             task_supervisor: nil,
@@ -138,6 +153,8 @@ defmodule FeishuOpenAPI.WS.Client do
   end
 
   @impl true
+  # Already connected: ignore a stray `:connect` (e.g. a queued reconnect that
+  # raced an explicit one) so we never open two sockets.
   def handle_info(:connect, %{conn: conn} = state) when not is_nil(conn), do: {:noreply, state}
 
   def handle_info(:connect, state) do
@@ -150,6 +167,8 @@ defmodule FeishuOpenAPI.WS.Client do
       {:error, reason, fatal?} ->
         Logger.error("feishu_openapi ws connect failed: #{inspect(reason)} fatal?=#{fatal?}")
 
+        # Fatal = misconfiguration; stop so the supervisor surfaces it instead of
+        # restarting into the same failure. Recoverable errors back off and retry.
         if fatal? do
           {:stop, {:shutdown, reason}, state}
         else
@@ -175,18 +194,26 @@ defmodule FeishuOpenAPI.WS.Client do
     {:noreply, state}
   end
 
+  # Reconnect logic asked to give up (e.g. attempts exhausted); turn that into a
+  # GenServer stop on the main loop.
   def handle_info({:shutdown_ws, reason}, state), do: {:stop, {:shutdown, reason}, state}
 
+  # TTL fired for a fragment set that never completed — drop it. Harmless no-op if
+  # the set already completed and was deleted.
   def handle_info({:cleanup_fragment, mid}, state) do
     {:noreply, %{state | fragments: Map.delete(state.fragments, mid)}}
   end
 
+  # A dispatch Task finished. `{ref, result}` is the Task's reply; match it back to
+  # the frame awaiting an ack. An unknown ref is a late reply for a task we already
+  # cleaned up (e.g. after a reconnect), so ignore it.
   def handle_info({ref, result}, %{dispatch_tasks: tasks} = state) when is_reference(ref) do
     case Map.pop(tasks, ref) do
       {nil, _} ->
         {:noreply, state}
 
       {{frame, event_type, start_ms}, rest} ->
+        # Reply already arrived, so the matching :DOWN is noise — flush it.
         Process.demonitor(ref, [:flush])
         duration_ms = System.monotonic_time(:millisecond) - start_ms
         state = %{state | dispatch_tasks: rest}
@@ -198,6 +225,9 @@ defmodule FeishuOpenAPI.WS.Client do
     end
   end
 
+  # A dispatch Task crashed without replying (async_nolink, so it can't take the
+  # WS process down). Still send the provider a 500 ack so the event isn't left
+  # hanging, then forget the task.
   def handle_info({:DOWN, ref, :process, _pid, reason}, %{dispatch_tasks: tasks} = state)
       when is_reference(ref) do
     case Map.pop(tasks, ref) do
@@ -219,8 +249,11 @@ defmodule FeishuOpenAPI.WS.Client do
     end
   end
 
+  # No live connection: any leftover socket/timer message is stale, drop it.
   def handle_info(_message, %{conn: nil} = state), do: {:noreply, state}
 
+  # Catch-all for raw transport messages (TCP/SSL data, closes). Hand them to Mint
+  # to turn into decoded WS responses; a stream error tears down and reconnects.
   def handle_info(message, state) do
     case Mint.WebSocket.stream(state.conn, message) do
       {:ok, conn, responses} ->
@@ -231,12 +264,14 @@ defmodule FeishuOpenAPI.WS.Client do
         state = %{state | conn: conn} |> drop_conn()
         maybe_schedule_reconnect(state, reason)
 
+      # Message wasn't for this connection (e.g. another socket) — ignore.
       :unknown ->
         {:noreply, state}
     end
   end
 
   @impl true
+  # Best-effort socket close on shutdown so we don't leak the TCP connection.
   def terminate(_reason, state) do
     drop_conn(state)
     :ok
@@ -266,12 +301,16 @@ defmodule FeishuOpenAPI.WS.Client do
            status: :upgrading
        }}
     else
+      # Endpoint discovery rejected us with a known misconfiguration code → fatal.
       {:error, %FeishuOpenAPI.Error{code: code} = err} when code in @fatal_codes ->
         {:error, err, true}
 
+      # Everything else (network, DNS, transient HTTP) is recoverable → retry.
       {:error, reason} ->
         {:error, reason, false}
 
+      # Mint connect/upgrade errors carry the conn as the middle element; discard
+      # it (the half-open conn is unusable) and treat as recoverable.
       {:error, _conn, reason} ->
         {:error, reason, false}
     end
@@ -351,6 +390,9 @@ defmodule FeishuOpenAPI.WS.Client do
 
   defp handle_responses([], state), do: {:noreply, state}
 
+  # The HTTP upgrade response streams in as separate status/headers/done events.
+  # Stash status and headers in transient keys until `:done`, where they're
+  # consumed to complete the WebSocket handshake.
   defp handle_responses([{:status, ref, status} | rest], %{request_ref: ref} = state) do
     handle_responses(rest, Map.put(state, :_upgrade_status, status))
   end
@@ -363,6 +405,7 @@ defmodule FeishuOpenAPI.WS.Client do
     upgrade_status = Map.get(state, :_upgrade_status)
     upgrade_headers = Map.get(state, :_upgrade_headers)
 
+    # Promote the bare HTTP connection to a WebSocket using the upgrade response.
     case Mint.WebSocket.new(
            state.conn,
            ref,
@@ -419,6 +462,8 @@ defmodule FeishuOpenAPI.WS.Client do
   end
 
   defp handle_ws_frame({:close, code, reason}, state) do
+    # Peer-initiated close is a recoverable event (e.g. server rotation), so drop
+    # the dead connection and let backoff bring up a fresh one.
     Logger.warning(
       "feishu_openapi ws closed by peer app_id=#{state.client.app_id} close_code=#{inspect(code)} close_reason=#{inspect(reason)}"
     )
@@ -437,6 +482,9 @@ defmodule FeishuOpenAPI.WS.Client do
     end
   end
 
+  # Route a fully-reassembled frame by its `type` header. event/card both go to a
+  # user handler; ping/pong are protocol housekeeping (reply / absorb config);
+  # anything else is ignored.
   defp do_route(frame, state) do
     case Frame.type(frame) do
       "event" ->
@@ -445,9 +493,11 @@ defmodule FeishuOpenAPI.WS.Client do
       "card" ->
         dispatch_event(frame, state)
 
+      # Server's reply to our ping may carry updated tuning config.
       "pong" ->
         apply_pong_config(frame, state)
 
+      # Server-initiated ping; reply with a pong echoing its identity.
       "ping" ->
         handle_send_result(send_pong_for(frame, state), state, "pong")
 
@@ -464,6 +514,8 @@ defmodule FeishuOpenAPI.WS.Client do
         start_task_for(frame, event_type, decoded, state)
 
       {:error, reason} ->
+        # Couldn't even parse the payload JSON; ack with a 500 so the provider
+        # stops resending this frame rather than retrying a poison message.
         Logger.warning("feishu_openapi ws payload decode error: #{inspect(reason)}")
         send_dispatch_response(frame, {:error, {:payload_decode_error, reason}}, 0, state)
     end
@@ -486,6 +538,10 @@ defmodule FeishuOpenAPI.WS.Client do
 
     # The dispatcher may call user code. Running it in a task protects ping,
     # reconnect, and frame parsing from slow or crashing handlers.
+    #
+    # `:trusted_decoded` skips the webhook signature/token checks: the long
+    # connection already authenticated at handshake, so per-frame verification
+    # would be redundant (and the frames carry no webhook signature anyway).
     task =
       Task.Supervisor.async_nolink(state.task_supervisor, fn ->
         Dispatcher.dispatch(dispatcher, {:trusted_decoded, decoded})
@@ -497,6 +553,8 @@ defmodule FeishuOpenAPI.WS.Client do
     }
   end
 
+  # If the connection dropped while a handler was running, there's nowhere to send
+  # the ack — discard it. The provider will redeliver after reconnect.
   defp send_dispatch_response(_frame, _dispatch_result, _duration_ms, %{conn: nil} = state),
     do: state
 
@@ -558,6 +616,8 @@ defmodule FeishuOpenAPI.WS.Client do
 
   # Fragmentation ------------------------------------------------------
 
+  # A frame is whole unless its headers say it's 1-of-`sum`. `sum <= 1` (and the
+  # no-headers case) means a single self-contained frame — route immediately.
   defp reassemble(%Frame{} = frame, state) do
     case Frame.fragmentation(frame) do
       nil -> {:ok, frame, state}
@@ -566,6 +626,8 @@ defmodule FeishuOpenAPI.WS.Client do
     end
   end
 
+  # Defensive: a `seq` outside `0..sum-1` is a malformed/hostile frame. Drop it
+  # rather than risk a bad index in `combine_fragments` or a never-completing set.
   defp fold_fragment(frame, sum, seq, state) when seq < 0 or seq >= sum do
     Logger.warning(
       "feishu_openapi ws invalid fragment indexes: #{inspect(%{message_id: Frame.message_id(frame), sum: sum, seq: seq})}"
@@ -575,6 +637,9 @@ defmodule FeishuOpenAPI.WS.Client do
   end
 
   defp fold_fragment(frame, sum, seq, state) do
+    # All fragments of one message share a `message_id`; group by it. The anonymous
+    # fallback should not happen in practice but keeps a missing header from
+    # crashing reassembly.
     mid = Frame.message_id(frame) || "(anonymous)"
 
     entry =
@@ -588,8 +653,10 @@ defmodule FeishuOpenAPI.WS.Client do
         {:ok, combined, %{state | fragments: Map.delete(state.fragments, mid)}}
 
       true ->
-        # Incomplete fragments are kept only briefly. Dropping old fragments is
-        # better than allowing an unbounded map from a broken connection.
+        # Arm the TTL eviction only when this message_id is first seen, so the 5s
+        # window starts at the first fragment and isn't reset by later ones.
+        # Dropping a stale partial set is better than an unbounded map from a
+        # broken connection.
         unless Map.has_key?(state.fragments, mid),
           do: Process.send_after(self(), {:cleanup_fragment, mid}, @fragment_ttl_ms)
 
@@ -597,6 +664,8 @@ defmodule FeishuOpenAPI.WS.Client do
     end
   end
 
+  # Reassemble in seq order (0..sum-1) and concatenate payloads. `template` is the
+  # last fragment, reused for the frame metadata (headers/ids) of the whole.
   defp combine_fragments(sum, parts, template) do
     payload =
       0..(sum - 1)
@@ -614,6 +683,9 @@ defmodule FeishuOpenAPI.WS.Client do
 
   defp send_ping(%{websocket: nil} = state), do: {:error, :not_connected, state}
 
+  # Application-level keepalive (distinct from a WS control ping): a control frame
+  # (`method: 0`) tagged `type: ping`. Keeps the connection from idling out and
+  # lets the server piggyback updated config on its pong.
   defp send_ping(state) do
     frame = %Frame{method: 0, service: state.service_id, headers: [{"type", "ping"}]}
     send_ws_frame(frame, state)
@@ -659,18 +731,24 @@ defmodule FeishuOpenAPI.WS.Client do
 
   defp schedule_ping(state), do: state
 
+  # Decides the next reconnect step. Pure w.r.t. timers it sets, so both the
+  # callback-returning and state-returning callers can share it.
   defp reconnect_action(state, reason) do
     cond do
       not state.auto_reconnect ->
         {:stop, reason, state}
 
+      # A reconnect is already pending; don't stack a second timer.
       state.reconnect_timer ->
         {:schedule, state}
 
+      # Hit the configured attempt cap (count < 0 means unlimited) — give up.
       state.reconnect_count >= 0 and state.reconnect_attempt >= state.reconnect_count ->
         {:stop, {:reconnect_exhausted, reason}, state}
 
       true ->
+        # First retry uses a random 0..nonce delay to de-sync a fleet reconnecting
+        # together; subsequent retries use the fixed provider-supplied interval.
         delay =
           if state.reconnect_attempt == 0 do
             :timer.seconds(:rand.uniform(max(state.reconnect_nonce_s, 1)))
@@ -689,6 +767,8 @@ defmodule FeishuOpenAPI.WS.Client do
     end
   end
 
+  # Used from a GenServer callback: returns a `{:noreply, _}` / `{:stop, _}` tuple
+  # directly.
   defp maybe_schedule_reconnect(state, reason) do
     case reconnect_action(state, reason) do
       {:schedule, state} ->
@@ -699,6 +779,8 @@ defmodule FeishuOpenAPI.WS.Client do
     end
   end
 
+  # Used from deep inside a fold over frames, where we can only return new state.
+  # To stop, it self-sends `:shutdown_ws` so the stop happens on the next loop.
   defp schedule_reconnect_async(state, reason) do
     case reconnect_action(state, reason) do
       {:schedule, state} ->
@@ -717,6 +799,8 @@ defmodule FeishuOpenAPI.WS.Client do
 
   defp handle_send_result({:ok, state}, _old_state, _kind), do: state
 
+  # Any outbound write failure (ping, pong, or ack) means the socket is gone; tear
+  # it down and reconnect rather than keep using a half-dead connection.
   defp handle_send_result({:error, reason, send_state}, _old_state, kind) do
     Logger.warning("feishu_openapi ws #{kind} send failed: #{inspect(reason)}")
 
@@ -739,6 +823,8 @@ defmodule FeishuOpenAPI.WS.Client do
       {:ok, config} ->
         state = apply_client_config(state, config)
 
+        # Only re-arm the ping timer if the server actually changed the interval;
+        # otherwise the existing schedule is still correct.
         if Map.has_key?(config, :ping_interval_s) do
           schedule_ping(state)
         else
@@ -751,6 +837,10 @@ defmodule FeishuOpenAPI.WS.Client do
     end
   end
 
+  # Full connection teardown, reused by every disconnect path. Cancels the ping
+  # timer, closes the socket, and demonitors in-flight dispatch tasks (their late
+  # replies/:DOWNs will then be ignored). Resets all connection-scoped fields but
+  # preserves reconnect bookkeeping, which lives outside this struct slice.
   defp drop_conn(state) do
     if state.ping_timer, do: Process.cancel_timer(state.ping_timer)
 

--- a/libs/feishu_openapi/lib/feishu_openapi/ws/frame.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/ws/frame.ex
@@ -50,6 +50,9 @@ defmodule FeishuOpenAPI.WS.Frame do
   @doc "Encode a `%Frame{}` into its wire binary form."
   @spec encode(t()) :: binary()
   def encode(%__MODULE__{} = f) do
+    # Protobuf omits scalar fields whose value equals the default (0 / ""), so we
+    # skip them here. `method` is emitted unconditionally because 0 is its
+    # meaningful "control frame" value, not an absent field.
     [
       if(f.seq_id != 0, do: varint_field(1, f.seq_id), else: []),
       if(f.log_id != 0, do: varint_field(2, f.log_id), else: []),
@@ -67,8 +70,14 @@ defmodule FeishuOpenAPI.WS.Frame do
   @doc "Decode a binary frame. Returns `{:ok, %Frame{}}` or `{:error, reason}`."
   @spec decode(binary()) :: {:ok, t()} | {:error, term()}
   def decode(bin) when is_binary(bin) do
+    # Frames arrive off an untrusted socket, so malformed wire data is expected,
+    # not a bug. `rescue`/`catch` turn binary-match failures and the explicit
+    # `{:decode_error, _}` throws (truncated varints/bytes, unknown wire types)
+    # into a tagged error tuple instead of crashing the WS GenServer.
     try do
       frame = decode_fields(bin, %__MODULE__{})
+      # Headers were prepended during the single forward pass, so restore
+      # provider order; `get_header/2` returns the first match and order matters.
       {:ok, %{frame | headers: Enum.reverse(frame.headers)}}
     rescue
       e -> {:error, e}
@@ -93,7 +102,14 @@ defmodule FeishuOpenAPI.WS.Frame do
   @spec message_id(t()) :: String.t() | nil
   def message_id(frame), do: get_header(frame, "message_id")
 
-  @doc "Convenience: fragmentation count (headers `sum` and `seq`)."
+  @doc """
+  Convenience: fragmentation count (headers `sum` and `seq`).
+
+  Large payloads are split by the provider into `sum` frames sharing one
+  `message_id`, each tagged with its 0-based `seq`. Returns `nil` when the
+  headers are missing or non-numeric, which the client treats as "not
+  fragmented" (a single self-contained frame).
+  """
   @spec fragmentation(t()) :: {integer(), integer()} | nil
   def fragmentation(frame) do
     with sum when is_binary(sum) <- get_header(frame, "sum"),
@@ -118,6 +134,9 @@ defmodule FeishuOpenAPI.WS.Frame do
     decode_fields(rest, apply_field(frame, field_num, value))
   end
 
+  # Dispatch on protobuf field number. `service`/`method` are declared int32 but
+  # arrive as unsigned varints, so they need sign reinterpretation; the uint64
+  # `seq_id`/`log_id` do not.
   defp apply_field(f, 1, {:varint, v}), do: %{f | seq_id: v}
   defp apply_field(f, 2, {:varint, v}), do: %{f | log_id: v}
   defp apply_field(f, 3, {:varint, v}), do: %{f | service: to_int32(v)}
@@ -132,6 +151,8 @@ defmodule FeishuOpenAPI.WS.Frame do
   defp apply_field(f, 7, {:bytes, data}), do: %{f | payload_type: data}
   defp apply_field(f, 8, {:bytes, data}), do: %{f | payload: data}
   defp apply_field(f, 9, {:bytes, data}), do: %{f | log_id_new: data}
+  # Forward-compat: silently drop fields this client doesn't model so a newer
+  # provider schema can't break decoding.
   defp apply_field(f, _num, _value), do: f
 
   defp decode_header_message(bin), do: decode_header_fields(bin, "", "")
@@ -154,6 +175,8 @@ defmodule FeishuOpenAPI.WS.Frame do
   defp read_value(@varint, bin), do: {varint_tagged(bin), elem(read_varint(bin), 1)}
 
   defp read_value(@bytes, bin) do
+    # Length-delimited field: a varint length prefix followed by exactly that
+    # many bytes. A short buffer means the frame was cut off mid-field.
     {len, rest} = read_varint(bin)
 
     case rest do
@@ -164,6 +187,8 @@ defmodule FeishuOpenAPI.WS.Frame do
 
   defp read_value(@fixed64, <<v::little-64, rest::binary>>), do: {{:fixed64, v}, rest}
   defp read_value(@fixed32, <<v::little-32, rest::binary>>), do: {{:fixed32, v}, rest}
+  # Wire type we don't recognize: we can't know the field length, so we can't
+  # safely skip it — abort the whole decode rather than misalign the byte stream.
   defp read_value(wt, _), do: throw({:decode_error, {:unknown_wire_type, wt}})
 
   defp varint_tagged(bin) do
@@ -173,6 +198,8 @@ defmodule FeishuOpenAPI.WS.Frame do
 
   defp read_varint(bin), do: read_varint(bin, 0, 0)
 
+  # Protobuf varints store 7 bits per byte, little-endian. The high (continuation)
+  # bit means "more bytes follow"; clear means this is the last byte.
   defp read_varint(<<1::1, chunk::7, rest::binary>>, shift, acc) do
     read_varint(rest, shift + 7, acc ||| chunk <<< shift)
   end
@@ -181,6 +208,7 @@ defmodule FeishuOpenAPI.WS.Frame do
     {acc ||| chunk <<< shift, rest}
   end
 
+  # Ran out of bytes mid-varint — the frame was truncated on the wire.
   defp read_varint(<<>>, _shift, _acc), do: throw({:decode_error, :truncated_varint})
 
   # --- encode internals ---------------------------------------------------
@@ -216,6 +244,8 @@ defmodule FeishuOpenAPI.WS.Frame do
     <<1::1, v &&& 0x7F::7>> <> encode_varint(v >>> 7)
   end
 
+  # Wire varints are unsigned; reinterpret values with the top 32-bit set as a
+  # negative two's-complement int32 (matches protobuf int32 semantics).
   defp to_int32(v) when v >= 0x80000000, do: v - 0x100000000
   defp to_int32(v), do: v
 end

--- a/libs/feishu_openapi/lib/feishu_openapi/ws/protocol.ex
+++ b/libs/feishu_openapi/lib/feishu_openapi/ws/protocol.ex
@@ -14,8 +14,17 @@ defmodule FeishuOpenAPI.WS.Protocol do
   @header_handshake_msg "handshake-msg"
   @header_handshake_autherrcode "handshake-autherrcode"
 
+  # Provider codes that mean the connection will never succeed as configured:
+  # 403 (forbidden), 514, and 1_000_040_350 (bad app credentials). Retrying these
+  # just hammers the endpoint, so they are treated as fatal and stop the client.
   @fatal_handshake_codes [403, 514, 1_000_040_350]
 
+  @doc """
+  Parse the `service_id` query param Feishu embeds in the WS URL.
+
+  Frames echo this id back to the provider, so we extract it once at connect
+  time. Defaults to `0` for any malformed or missing value.
+  """
   @spec service_id_from_url(String.t()) :: integer()
   def service_id_from_url(url) when is_binary(url) do
     uri = URI.parse(url)
@@ -31,6 +40,15 @@ defmodule FeishuOpenAPI.WS.Protocol do
 
   def service_id_from_url(_), do: 0
 
+  @doc """
+  Pull connection-tuning knobs out of a server config map into our atom-keyed
+  shape, ignoring keys we don't recognize.
+
+  Each setting accepts two spellings because the endpoint-discovery response and
+  the in-band `pong` payload disagree on casing (e.g. `PingInterval` vs
+  `ping_interval`). Absent keys are simply left out so the client keeps its
+  current/default value.
+  """
   @spec config_from_map(map()) :: map()
   def config_from_map(map) when is_map(map) do
     %{}
@@ -42,7 +60,13 @@ defmodule FeishuOpenAPI.WS.Protocol do
 
   def config_from_map(_), do: %{}
 
+  @doc """
+  Decode a `pong` frame payload into a config map. The provider can revise ping
+  interval and reconnect parameters at runtime by attaching JSON to a pong.
+  """
   @spec config_from_payload(binary()) :: {:ok, map()} | {:error, term()}
+  # Empty pong payload is the common case (a bare heartbeat ack), so short-circuit
+  # before attempting a JSON decode.
   def config_from_payload(payload) when is_binary(payload) and byte_size(payload) == 0,
     do: {:ok, %{}}
 
@@ -52,6 +76,12 @@ defmodule FeishuOpenAPI.WS.Protocol do
     end
   end
 
+  @doc """
+  Upsert a header by key, replacing any existing entry and appending at the end.
+
+  Re-appending (rather than updating in place) keeps the provider's expected
+  header ordering, with our added headers last.
+  """
   @spec put_header([{String.t(), String.t()}], String.t(), String.t()) :: [
           {String.t(), String.t()}
         ]
@@ -63,11 +93,25 @@ defmodule FeishuOpenAPI.WS.Protocol do
     end) ++ [{key, value}]
   end
 
+  @doc """
+  Stamp the `biz_rt` (business response time) header on a response frame.
+
+  Feishu reads this back as the handler's processing time in milliseconds for
+  its own latency monitoring. Clamped to non-negative to guard against clock
+  jitter producing a negative duration.
+  """
   @spec add_biz_rt([{String.t(), String.t()}], integer()) :: [{String.t(), String.t()}]
   def add_biz_rt(headers, duration_ms) when is_list(headers) and is_integer(duration_ms) do
     put_header(headers, @header_biz_rt, Integer.to_string(max(duration_ms, 0)))
   end
 
+  @doc """
+  Build the JSON payload Feishu expects in the ack frame for an event/card.
+
+  Maps a dispatcher result to the provider's `{code, data}` envelope: success →
+  200, a URL-verification challenge → 200 with the echo, any error → 500. See
+  `response_map/1` for how each shape is rendered.
+  """
   @spec encode_ws_response({:ok, term()} | {:challenge, String.t()} | {:error, term()}) ::
           {:ok, binary()} | {:error, term()}
   def encode_ws_response(dispatch_result) do
@@ -77,8 +121,20 @@ defmodule FeishuOpenAPI.WS.Protocol do
     end
   end
 
+  @doc """
+  Decide whether a failed WS upgrade is permanent (`:fatal`) or worth retrying
+  (`:retry`).
+
+  Mint's generic upgrade error rarely says *why* the provider refused, so we
+  prefer Feishu's own `handshake-*` headers when present. The 514 + auth-error
+  pairing and the bare fatal codes mean a misconfigured app (wrong
+  credentials/permissions): retrying would loop forever, so we stop. Anything
+  else is assumed transient and reconnect is scheduled.
+  """
   @spec classify_handshake(integer() | nil, map() | list(), term()) :: {:fatal | :retry, term()}
   def classify_handshake(status, headers, fallback_reason) do
+    # Feishu's own handshake-status header is authoritative; fall back to the raw
+    # HTTP status only when it's absent.
     handshake_status = header_int(headers, @header_handshake_status) || status
     handshake_msg = header(headers, @header_handshake_msg)
     auth_err_code = header_int(headers, @header_handshake_autherrcode)
@@ -86,6 +142,9 @@ defmodule FeishuOpenAPI.WS.Protocol do
     reason = {:handshake_error, handshake_status || status, handshake_msg || fallback_reason}
 
     cond do
+      # Spells out the canonical "bad credentials" signal (514 + auth-error code)
+      # for clarity; note 514 is already in @fatal_handshake_codes below, so any
+      # 514 is fatal regardless of the auth-error code.
       handshake_status == 514 and auth_err_code == 1_000_040_350 ->
         {:fatal, reason}
 
@@ -102,6 +161,8 @@ defmodule FeishuOpenAPI.WS.Protocol do
   end
 
   defp response_map({:challenge, challenge}) do
+    # The WS `data` field carries a base64'd JSON blob, so even the challenge echo
+    # is double-encoded: JSON-encode `{"challenge": ...}`, then base64 it.
     case Torque.encode(%{"challenge" => challenge}) do
       {:ok, data} ->
         {:ok, %{"code" => 200, "data" => Base.encode64(data)}}
@@ -112,16 +173,21 @@ defmodule FeishuOpenAPI.WS.Protocol do
   end
 
   defp response_map({:error, _reason}) do
+    # Provider only inspects the code for non-2xx; no body needed.
     {:ok, %{"code" => 500}}
   end
 
   defp maybe_put_data(map, nil), do: map
   defp maybe_put_data(map, data) when is_binary(data), do: Map.put(map, "data", data)
 
+  # Acks that carry no meaningful return value omit `data` entirely; the bare
+  # `{"code": 200}` is enough to satisfy the provider.
   defp encode_response_data(result) when result in [nil, :ok, :no_handler, :unknown_event],
     do: nil
 
   defp encode_response_data(result) do
+    # `data` is base64'd JSON (see the challenge case). On encode failure we drop
+    # the body rather than fail the whole ack — a 200 with no data still acks.
     case Torque.encode(result) do
       {:ok, encoded} -> Base.encode64(encoded)
       {:error, _} -> nil
@@ -158,6 +224,9 @@ defmodule FeishuOpenAPI.WS.Protocol do
 
   defp parse_int(_), do: :error
 
+  # Case-insensitive header lookup over either a map or a `[{k, v}]` list, since
+  # the upgrade-response headers reach us in different shapes. `target` is assumed
+  # already-lowercase.
   defp header(headers, target) when is_map(headers) do
     Enum.find_value(headers, fn {k, v} ->
       if String.downcase(to_string(k)) == target, do: normalize_header_value(v)


### PR DESCRIPTION
## What

Adds intent-focused code comments to the `libs/feishu_openapi` real-time **protocol layer** — the long-connection WebSocket client, frame codec, event envelope decode/dispatch, and interactive card-action callbacks. Aimed at a senior engineer reading Ankole for the first time.

**Comment-only.** No code, logic, control flow, names, or ordering changed (`git diff` is added comments plus formatter whitespace only).

## Files

- `ws/client.ex` — GenServer lifecycle, fragment reassembly + 5s TTL, ping/pong config, backoff reconnect, dispatch-task isolation
- `ws/frame.ex` — protobuf varint/int32 wire details, truncation failure modes
- `ws/protocol.ex` — handshake fatal-vs-retry classification, config extraction, base64'd-JSON response envelope
- `event/dispatcher.ex`, `event/envelope.ex`, `event/server.ex`, `event.ex` — raw/decoded/trusted routing, signature verification, timestamp replay-window check
- `card_action/handler.ex`, `card_action/server.ex`, `card_action.ex` — card signing (keys on `verification_token`), handler crash isolation

## Why these spots

Prioritized the non-obvious: the ~5s fragment TTL window, nonce-first reconnect backoff, the `:trusted_decoded` trust decision (skips per-frame verification because the long connection authenticates at handshake), and the replay-window check layered on top of signature verification.

## Verification

- `mix format`
- `MIX_ENV=test mix compile --warnings-as-errors` — clean
- `MIX_ENV=test mix test` — 128 passed
- Comments fact-checked against the code (one inaccurate draft comment about 514 handshake classification was corrected before commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)