### PR TITLE
docs(ankole_web): comment controllers/router/session/assets

### DIFF
--- a/app/control_plane/lib/ankole_web/ankole_web.ex
+++ b/app/control_plane/lib/ankole_web/ankole_web.ex
@@ -17,6 +17,10 @@ defmodule AnkoleWeb do
   those modules here.
   """
 
+  # The only top-level paths served straight from priv/static. Used both by the
+  # endpoint's Plug.Static and by verified routes (so `~p` knows these are static
+  # files, not router paths). Note there are no LiveView/layout helpers in this
+  # module: Phoenix here only renders the thin SPA shell, so the surface is small.
   def static_paths, do: ~w(assets fonts images favicon.ico robots.txt)
 
   def router do
@@ -62,6 +66,8 @@ defmodule AnkoleWeb do
     quote do
       # HTML escaping functionality
       import Phoenix.HTML
+      # Makes `t/1..3`, `lang/0`, `dir/0` available in shells without Gettext —
+      # Ankole renders server HTML in the installation default locale.
       import AnkoleWeb.I18n.HTML
 
       # Routes generation with the ~p sigil

--- a/app/control_plane/lib/ankole_web/api_spec.ex
+++ b/app/control_plane/lib/ankole_web/api_spec.ex
@@ -15,6 +15,9 @@ defmodule AnkoleWeb.ApiSpec do
 
   @impl OpenApiSpex.OpenApi
   def spec do
+    # Paths are derived from the router's `operation/2` specs, so the document
+    # always tracks the actual console routes. `version` is date-stamped rather
+    # than semver — the console API is versioned by calendar date.
     %OpenApi{
       servers: [Server.from_endpoint(AnkoleWeb.Endpoint)],
       info: %Info{
@@ -22,6 +25,8 @@ defmodule AnkoleWeb.ApiSpec do
         version: "2026-06-24"
       },
       paths: Paths.from_router(AnkoleWeb.Router),
+      # The documented `consoleBearer` scheme is the spec-side mirror of
+      # RequireConsoleAccessToken; controllers reference it via `security/1`.
       components: %Components{
         securitySchemes: %{
           "consoleBearer" => %SecurityScheme{

--- a/app/control_plane/lib/ankole_web/assets.ex
+++ b/app/control_plane/lib/ankole_web/assets.ex
@@ -1,8 +1,19 @@
 defmodule AnkoleWeb.Assets do
   @moduledoc """
   Resolves Vite-managed SPA entry assets for Phoenix-rendered shells.
+
+  Two modes, decided by the `:dev_server` config key:
+
+    * Dev — point `<script>` tags straight at the running Vite dev server so HMR
+      and React Fast Refresh work.
+    * Prod — read the build manifest written by `vite build` and emit the
+      hashed, cache-busted asset URLs (plus their CSS and preloads).
+
+  The shell HTML never hardcodes asset paths; it always asks here.
   """
 
+  # The three SPA bundles the shell can mount. `entry` is a build identity, not
+  # user input, so an unknown value is a programmer error (it raises below).
   @valid_entries ~w(auth console setup)
 
   @doc "Returns stylesheet and script tags for a named webapp entry."
@@ -17,6 +28,9 @@ defmodule AnkoleWeb.Assets do
   defp dev_entry_tags(base_url, entry) do
     base_url = String.trim_trailing(base_url, "/")
 
+    # Order is load-bearing: React Fast Refresh requires the refresh runtime
+    # preamble to install its global hooks BEFORE the Vite client and the entry
+    # module load. Reordering these breaks Fast Refresh (or crashes the entry).
     [
       react_refresh_preamble_tag(base_url),
       module_script_tag("#{base_url}/@vite/client"),
@@ -27,6 +41,9 @@ defmodule AnkoleWeb.Assets do
   defp manifest_entry_tags(entry) do
     manifest = read_manifest()
 
+    # A production entry needs its own hashed JS plus the CSS and shared chunks
+    # Vite split out of it. We walk the manifest's `imports` graph to gather both
+    # so the first paint isn't missing styles or blocked on lazily-discovered chunks.
     case manifest_entry(manifest, entry) do
       %{"file" => file} = chunk ->
         [
@@ -35,6 +52,8 @@ defmodule AnkoleWeb.Assets do
           module_script_tag(asset_path(file))
         ]
 
+      # A missing entry means the JS build is stale or never ran — fail loudly at
+      # render time rather than serving a blank shell.
       _ ->
         raise ArgumentError, "Vite manifest does not contain entry #{inspect(entry)}"
     end
@@ -52,6 +71,9 @@ defmodule AnkoleWeb.Assets do
     end
   end
 
+  # Vite keys entries by source path, but that path can vary across Vite versions
+  # and configs. Try the well-known keys first, then fall back to scanning for the
+  # entry chunk whose `name` matches — so the lookup survives manifest layout drift.
   defp manifest_entry(manifest, entry) do
     direct_keys = [entry, "entrypoints/#{entry}.tsx"]
 
@@ -74,6 +96,9 @@ defmodule AnkoleWeb.Assets do
     Enum.map(files, &asset_path/1)
   end
 
+  # Recurse the import graph collecting every chunk's CSS. `seen` guards against
+  # the cycles Vite chunk graphs can contain (A imports B imports A) so this
+  # terminates; results are de-duped at the end.
   defp collect_manifest_css(chunk, manifest, seen) do
     chunk
     |> Map.get("imports", [])
@@ -90,6 +115,8 @@ defmodule AnkoleWeb.Assets do
     |> then(fn {css, seen} -> {Enum.uniq(css), seen} end)
   end
 
+  # Same cycle-guarded walk, but collecting the JS files of imported chunks so
+  # they can be `modulepreload`-ed alongside the entry.
   defp collect_manifest_import_files(chunk, manifest, seen) do
     chunk
     |> Map.get("imports", [])
@@ -125,6 +152,9 @@ defmodule AnkoleWeb.Assets do
 
   defp asset_path(path), do: ["/assets/", path]
 
+  # Hand-rolled copy of the preamble `@vitejs/plugin-react` normally injects into
+  # the HTML. Because Phoenix renders the shell (not Vite's index.html), we must
+  # emit it ourselves; without it React Fast Refresh has no global hooks to call.
   defp react_refresh_preamble_tag(base_url) do
     [
       ~s(<script type="module">\n),

--- a/app/control_plane/lib/ankole_web/console_policy.ex
+++ b/app/control_plane/lib/ankole_web/console_policy.ex
@@ -24,5 +24,7 @@ defmodule AnkoleWeb.ConsolePolicy do
     end
   end
 
+  # Fail closed: without a `current_principal_uid` assign (set only by the bearer
+  # plug on success) there is no authenticated principal, so deny.
   def authorize(_conn, _resource, _action), do: {:error, :forbidden}
 end

--- a/app/control_plane/lib/ankole_web/console_tokens.ex
+++ b/app/control_plane/lib/ankole_web/console_tokens.ex
@@ -119,6 +119,9 @@ defmodule AnkoleWeb.ConsoleTokens do
     end
   end
 
+  # `expires_at` is already capped to the session expiry by the callers, so a
+  # non-positive ttl means the underlying browser session has lapsed — refuse to
+  # mint rather than issue an already-dead token.
   defp sign_token(token_use, principal_uid, sid_hash, now, expires_at) do
     ttl = expires_at - now
 
@@ -151,6 +154,9 @@ defmodule AnkoleWeb.ConsoleTokens do
     end
   end
 
+  # Access and refresh tokens are signed under different derived keys, so a
+  # refresh token can never be presented (or mistaken) as an access token even
+  # though both are HS256 over the same root secret.
   defp signing_key(@access_token_use), do: signing_key(:access)
   defp signing_key(@refresh_token_use), do: signing_key(:refresh)
 
@@ -179,6 +185,11 @@ defmodule AnkoleWeb.ConsoleTokens do
     }
   end
 
+  # Binds a token to the exact admin session that produced it. The hash covers the
+  # session's identifying fields; on refresh we recompute it and require a match,
+  # so a token stops working the moment the session is renewed or replaced (e.g.
+  # after a re-login), even if the principal is the same. Keys are sorted so the
+  # hash is stable regardless of map ordering.
   defp sid_hash(session) do
     payload =
       session
@@ -203,6 +214,8 @@ defmodule AnkoleWeb.ConsoleTokens do
     end
   end
 
+  # Token lifetime is the lesser of its own TTL and the remaining browser session
+  # — a console token can never outlive the cookie session it was derived from.
   defp access_expires_at(now, session_exp), do: min(now + @access_ttl_seconds, session_exp)
   defp refresh_expires_at(now, session_exp), do: min(now + @refresh_ttl_seconds, session_exp)
 
@@ -212,6 +225,9 @@ defmodule AnkoleWeb.ConsoleTokens do
 
   defp session_expires_at(_session), do: {:error, :invalid_admin_session_expiry}
 
+  # Reads the endpoint secret straight from config (not from a conn) because
+  # signing/verifying tokens is not always inside a request. All JWT keys derive
+  # from this one root secret via distinct sub-key ids.
   defp root_secret do
     :ankole
     |> Application.get_env(AnkoleWeb.Endpoint, [])

--- a/app/control_plane/lib/ankole_web/controllers/app_configuration_controller.ex
+++ b/app/control_plane/lib/ankole_web/controllers/app_configuration_controller.ex
@@ -1,6 +1,16 @@
 defmodule AnkoleWeb.AppConfigurationController do
   @moduledoc """
   Console REST API for registry-backed AppConfigure values.
+
+  AppConfigure is Ankole's runtime settings registry: a known set of keys, each
+  with its own schema, default, and whether it is encrypted or console-editable.
+  This controller is the bearer-token surface the console UI uses to list, read,
+  set, reset, and (for secrets) reveal those values.
+
+  Every action follows the same shape: authorize the principal for this exact
+  resource/action via `ConsolePolicy`, then call the AppConfigure context, then
+  map any domain error onto the console error envelope. The `with` chains keep
+  authorization first so a forbidden caller never touches the value.
   """
 
   use AnkoleWeb, :controller
@@ -17,6 +27,9 @@ defmodule AnkoleWeb.AppConfigurationController do
   tags(["AppConfigure"])
   security([%{"consoleBearer" => []}])
 
+  # Casts and validates params/body against the `operation/2` specs below before
+  # any action runs; on a schema mismatch it short-circuits with a 422 rendered in
+  # our console error envelope instead of the OpenApiSpex default JSON.
   plug OpenApiSpex.Plug.CastAndValidate,
     render_error: AnkoleWeb.OpenApiValidationErrorRenderer
 
@@ -79,6 +92,12 @@ defmodule AnkoleWeb.AppConfigurationController do
     ]
   )
 
+  @doc """
+  Lists every AppConfigure entry the console is allowed to surface.
+
+  Only console-visible entries are returned (the context filters internal-only
+  keys), and encrypted values come back masked — `decrypt/2` reveals them.
+  """
   def index(conn, _params) do
     with :ok <- ConsolePolicy.authorize(conn, "app_configurations", "read"),
          {:ok, items} <- AppConfigure.list_console_items() do
@@ -88,6 +107,9 @@ defmodule AnkoleWeb.AppConfigurationController do
     end
   end
 
+  @doc """
+  Reads one entry by key. Authorization is scoped to that specific key.
+  """
   def show(conn, params) do
     with {:ok, key} <- key_param(params),
          :ok <- ConsolePolicy.authorize(conn, "app_configuration:#{key}", "read"),
@@ -98,6 +120,12 @@ defmodule AnkoleWeb.AppConfigurationController do
     end
   end
 
+  @doc """
+  Sets the global value for one key (the installation-wide override).
+
+  Writes the "global" layer of AppConfigure, on top of the compiled-in default.
+  The value is validated against the key's own schema downstream in the context.
+  """
   def update(conn, params) do
     with {:ok, key} <- key_param(params),
          :ok <- ConsolePolicy.authorize(conn, "app_configuration:#{key}", "update"),
@@ -109,6 +137,12 @@ defmodule AnkoleWeb.AppConfigurationController do
     end
   end
 
+  @doc """
+  Resets one key by removing its global override, falling back to the default.
+
+  This deletes the override layer, not the key — the entry remains and reverts to
+  its compiled-in default. Authorized under the distinct `"reset"` action.
+  """
   def delete(conn, params) do
     with {:ok, key} <- key_param(params),
          :ok <- ConsolePolicy.authorize(conn, "app_configuration:#{key}", "reset"),
@@ -119,6 +153,13 @@ defmodule AnkoleWeb.AppConfigurationController do
     end
   end
 
+  @doc """
+  Reveals an encrypted value on demand.
+
+  Decryption is a separate, separately-authorized action (`"decrypt"`) precisely
+  so that listing/reading config does not expose secrets — a principal can browse
+  config without being able to read the secret material behind it.
+  """
   def decrypt(conn, params) do
     with {:ok, key} <- key_param(params),
          :ok <- ConsolePolicy.authorize(conn, "app_configuration:#{key}", "decrypt"),
@@ -137,6 +178,10 @@ defmodule AnkoleWeb.AppConfigurationController do
   defp request_value(%{value: value}), do: {:ok, value}
   defp request_value(_body), do: {:error, :missing_value}
 
+  # Translates AppConfigure context errors into the console error envelope with a
+  # stable machine `code`. The `ambiguous_key`/`pattern_key_not_editable` cases
+  # come from AppConfigure's pattern keys (e.g. wildcard keys that must be
+  # materialized globally before they can be edited per-instance).
   defp error(conn, :forbidden), do: error(conn, 403, "forbidden", "access denied")
 
   defp error(conn, {:unknown_key, _key}) do

--- a/app/control_plane/lib/ankole_web/controllers/auth_controller.ex
+++ b/app/control_plane/lib/ankole_web/controllers/auth_controller.ex
@@ -46,6 +46,12 @@ defmodule AnkoleWeb.AuthController do
 
   @doc """
   Exchanges the browser admin session or refresh token for console bearer tokens.
+
+  This is the bridge from the cookie world to the stateless console API. The
+  custom `browser-session` grant lets the already-authenticated SPA trade its
+  session cookie for short-lived JWTs (see `AnkoleWeb.ConsoleTokens`), so console
+  XHRs can use Bearer auth without re-running OIDC. Multiple `oauth_token/2`
+  clauses below dispatch on `grant_type`, mirroring the OAuth token endpoint shape.
   """
   def oauth_token(conn, %{"grant_type" => "urn:ankole:params:oauth:grant-type:browser-session"}) do
     with {:ok, session} <- active_admin_session(conn),
@@ -57,6 +63,8 @@ defmodule AnkoleWeb.AuthController do
     end
   end
 
+  # Refresh still requires a live browser session: console tokens are leashed to
+  # the cookie session, so signing out of the browser also kills token refresh.
   def oauth_token(conn, %{"grant_type" => "refresh_token", "refresh_token" => refresh_token})
       when is_binary(refresh_token) do
     with {:ok, session} <- active_admin_session(conn),
@@ -131,6 +139,12 @@ defmodule AnkoleWeb.AuthController do
 
   @doc """
   Completes setup or normal admin OIDC login depending on the session state.
+
+  One callback URL serves both flows. We don't trust the URL to say which flow it
+  is; instead the `state` param must match a `state` we previously stashed in the
+  session (setup vs admin namespace). That match is the CSRF/replay defense — a
+  forged or stale `state`, or one bound to the wrong flow, falls through to the
+  final clause and is rejected.
   """
   def oidc_callback(conn, %{"provider_id" => provider_id} = params) do
     code = params["code"]
@@ -178,6 +192,9 @@ defmodule AnkoleWeb.AuthController do
     end
   end
 
+  # Unlike setup, this flow never provisions an admin. The OIDC identity must
+  # already resolve to an active human admin, otherwise login is refused (403) —
+  # a valid external login is not by itself authorization to reach the console.
   defp complete_admin_oidc(conn, provider_id, code, _state) do
     oidc_state = WebSession.admin_oidc_state(conn)
 
@@ -213,6 +230,8 @@ defmodule AnkoleWeb.AuthController do
     end
   end
 
+  # Both the provider and the opaque state must match what we stored, pinned — the
+  # callback is only honored for the exact provider/state pair this session began.
   defp setup_state_matches?(conn, provider_id, state) do
     case WebSession.setup_oidc_state(conn) do
       %{"provider_id" => ^provider_id, "state" => ^state} -> true
@@ -227,6 +246,9 @@ defmodule AnkoleWeb.AuthController do
     end
   end
 
+  # OIDC redirect URIs must be absolute, so we rebuild this request's origin from
+  # the conn. This trusts the incoming scheme/host/port — fine because the
+  # endpoint sits behind a trusted proxy that normalizes them.
   defp public_base_url(conn) do
     uri = %URI{scheme: Atom.to_string(conn.scheme), host: conn.host, port: conn.port}
     URI.to_string(uri)

--- a/app/control_plane/lib/ankole_web/controllers/setup_controller.ex
+++ b/app/control_plane/lib/ankole_web/controllers/setup_controller.ex
@@ -21,6 +21,9 @@ defmodule AnkoleWeb.SetupController do
   def state(conn, _params) do
     with {:ok, completed?} <- SetupConfig.completed?(),
          {:ok, current_locale} <- Ankole.I18n.Config.default_locale() do
+      # `authenticated` is meaningful only while setup is incomplete: once setup is
+      # done there is no setup session to hold, so it collapses to false and the
+      # SPA stops offering setup steps.
       json(conn, %{
         completed: completed?,
         authenticated: not completed? and WebSession.setup_session_active?(conn),
@@ -34,6 +37,11 @@ defmodule AnkoleWeb.SetupController do
 
   @doc """
   Exchanges the bootstrap activation code for a 24-hour setup session.
+
+  The activation code is the only credential that exists before the first admin —
+  it gates who may run setup. A successful constant-time match opens a setup
+  session; a wrong code also clears any partial setup session so a failed attempt
+  can't leave a usable one behind.
   """
   def create_session(conn, params) do
     with {:ok, false} <- SetupConfig.completed?(),
@@ -171,6 +179,10 @@ defmodule AnkoleWeb.SetupController do
     end
   end
 
+  # Shared gate for every setup-mutating endpoint. Two conditions, both required:
+  # setup must not already be complete (409 if it is — bootstrap can't run twice),
+  # and the caller must hold an active setup session (401 otherwise). Returns a
+  # `{:error, status, reason}` triple the actions render directly.
   defp require_setup_session(conn) do
     with {:ok, false} <- SetupConfig.completed?() do
       case WebSession.setup_session_active?(conn) do
@@ -259,6 +271,8 @@ defmodule AnkoleWeb.SetupController do
     }
   end
 
+  # Rebuilds this request's origin so the OIDC redirect URI is absolute (same
+  # approach as AuthController; trusts the proxy-normalized scheme/host/port).
   defp public_base_url(conn) do
     uri = %URI{scheme: Atom.to_string(conn.scheme), host: conn.host, port: conn.port}
     URI.to_string(uri)

--- a/app/control_plane/lib/ankole_web/controllers/spa_controller.ex
+++ b/app/control_plane/lib/ankole_web/controllers/spa_controller.ex
@@ -13,6 +13,9 @@ defmodule AnkoleWeb.SpaController do
   alias AnkoleWeb.Session, as: WebSession
   alias AnkoleWeb.Assets
 
+  # Maps each logical screen to its Vite entry bundle and document <title>. Note
+  # the `:sessions` screen mounts the `auth` bundle — the route name and the
+  # frontend entry name differ.
   @spas %{
     console: %{entry: "console", title: "Ankole Console"},
     sessions: %{entry: "auth", title: "Ankole Sign In"},
@@ -21,6 +24,9 @@ defmodule AnkoleWeb.SpaController do
 
   @doc """
   Sends the operator to the only valid first screen for the installation state.
+
+  Before setup completes the only legitimate destination is `/setup`; afterwards
+  it is the sign-in screen. `/` itself never renders a shell — it only redirects.
   """
   def home(conn, _params) do
     case setup_completed?() do
@@ -31,6 +37,10 @@ defmodule AnkoleWeb.SpaController do
 
   @doc """
   Serves the sign-in SPA only after setup is complete and no admin is signed in.
+
+  The `cond` clauses are an ordered server-side gate: un-setup installs go to
+  setup, already-signed-in admins skip straight to the console, and only the
+  remaining case (setup done, not signed in) actually renders the sign-in shell.
   """
   def sessions_new(conn, _params) do
     cond do
@@ -57,6 +67,11 @@ defmodule AnkoleWeb.SpaController do
 
   @doc """
   Serves the console SPA only for active human admins.
+
+  This is the server-side authentication gate for the console — it is enforced
+  on the shell request itself, so the React app is never even delivered to an
+  unauthenticated visitor. When not signed in, redirect to sign-in carrying a
+  `return_to` so the operator lands back on the page they wanted post-login.
   """
   def console(conn, _params) do
     cond do
@@ -95,7 +110,9 @@ defmodule AnkoleWeb.SpaController do
 
     # The shell is built as iodata so Phoenix can send it without a separate
     # template layer. That keeps Phoenix as a thin HTML boundary while Vite
-    # still owns the SPA assets.
+    # still owns the SPA assets. The `csrf-token` <meta> is how the SPA picks up
+    # the token to send back to the session_api endpoints; `<div id="ankole-app">`
+    # is the mount point every entry bundle expects.
     [
       "<!DOCTYPE html>\n",
       "<html lang=\"",
@@ -128,6 +145,10 @@ defmodule AnkoleWeb.SpaController do
     end
   end
 
+  # A cookie session is necessary but not sufficient: the principal it names must
+  # still be an active human admin right now. Re-checking against AdminAuth means
+  # a revoked/disabled admin loses console access immediately, without waiting
+  # for the session cookie to expire.
   defp active_admin_session?(conn) do
     case WebSession.admin_session(conn) do
       %{"principal_uid" => principal_uid} -> AdminAuth.active_human_admin?(principal_uid)
@@ -147,6 +168,9 @@ defmodule AnkoleWeb.SpaController do
   defp current_console_return_to(%Plug.Conn{query_string: query_string} = conn),
     do: conn.request_path <> "?" <> query_string
 
+  # Sets the shell's `<html lang>`. If the installation locale can't be read we
+  # still must emit a valid document, so fall back to a sane default rather than
+  # failing the whole shell render over a presentation attribute.
   defp app_locale do
     case Ankole.I18n.Config.default_locale() do
       {:ok, locale} -> locale

--- a/app/control_plane/lib/ankole_web/endpoint.ex
+++ b/app/control_plane/lib/ankole_web/endpoint.ex
@@ -11,6 +11,10 @@ defmodule AnkoleWeb.Endpoint do
 
   # The session payload is stored in the cookie and sealed with Ankole Kernel
   # AEAD. The browser carries the payload but cannot read or tamper with it.
+  # `key_context` is threaded down to SessionCookieStore so the cookie's key is
+  # derived under a named context, isolating it from other Kernel-derived keys.
+  # `secure` is a compile-time flag (off by default for local HTTP dev, on in
+  # production behind TLS) — it must be a literal here, so it cannot be runtime-tuned.
   @session_options [
     store: AnkoleWeb.SessionCookieStore,
     key: "_ankole_key",

--- a/app/control_plane/lib/ankole_web/open_api_validation_error_renderer.ex
+++ b/app/control_plane/lib/ankole_web/open_api_validation_error_renderer.ex
@@ -11,6 +11,10 @@ defmodule AnkoleWeb.OpenApiValidationErrorRenderer do
   def init(errors), do: errors
 
   @impl Plug
+  # Reshapes OpenApiSpex's validation errors into the same `%{error: %{code,
+  # message, details}}` envelope the controllers emit by hand, so clients get one
+  # consistent error shape whether a request fails schema validation or business
+  # logic. Always responds 422.
   def call(conn, errors) do
     details =
       errors

--- a/app/control_plane/lib/ankole_web/plugs/require_console_access_token.ex
+++ b/app/control_plane/lib/ankole_web/plugs/require_console_access_token.ex
@@ -1,6 +1,12 @@
 defmodule AnkoleWeb.Plugs.RequireConsoleAccessToken do
   @moduledoc """
   Authenticates console REST API requests with a Bearer access token.
+
+  This is the gate for the stateless `console_api` pipeline. It does the work that
+  session+CSRF do for the browser surfaces, but per-request and cookie-free: prove
+  a valid console JWT, then re-confirm the principal is still an active admin.
+  On success it stashes the principal/claims as assigns for downstream policy
+  checks; any failure halts with a 401.
   """
 
   import Plug.Conn
@@ -16,6 +22,9 @@ defmodule AnkoleWeb.Plugs.RequireConsoleAccessToken do
 
   @impl Plug
   def call(conn, _opts) do
+    # Three independent checks, all required: a well-formed bearer header, a JWT
+    # that verifies as a console access token, and a subject that is an active
+    # human admin *right now* — so a revoked admin's still-valid token is refused.
     with {:ok, token} <- bearer_token(conn),
          {:ok, %{"sub" => principal_uid} = claims} <- ConsoleTokens.verify_access_token(token),
          true <- AdminAuth.active_human_admin?(principal_uid) do
@@ -34,6 +43,8 @@ defmodule AnkoleWeb.Plugs.RequireConsoleAccessToken do
     end
   end
 
+  # Accept only the exact `Bearer <token>` form with a non-empty token; anything
+  # else is treated as no credential at all.
   defp bearer_token(conn) do
     case get_req_header(conn, "authorization") do
       ["Bearer " <> token] when token != "" -> {:ok, token}

--- a/app/control_plane/lib/ankole_web/router.ex
+++ b/app/control_plane/lib/ankole_web/router.ex
@@ -8,6 +8,15 @@ defmodule AnkoleWeb.Router do
 
   use AnkoleWeb, :router
 
+  # Four request surfaces, each with its own protection profile:
+  #
+  #   :browser     — the HTML shells that boot the React SPAs. Full browser
+  #                  hardening (session, flash, CSRF, secure headers).
+  #   :session_api — setup/auth JSON that mutates server state. Deliberately
+  #                  keeps the browser session + CSRF rather than going
+  #                  stateless, because only the same-origin SPAs call it.
+  #   :openapi     — serves the spec document itself.
+  #   :console_api — the stateless bearer-token REST API for the console.
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
@@ -16,6 +25,7 @@ defmodule AnkoleWeb.Router do
     plug :put_secure_browser_headers
   end
 
+  # Unused by any scope today, but kept as the conventional JSON entry pipeline.
   pipeline :api do
     plug :accepts, ["json"]
   end
@@ -27,7 +37,9 @@ defmodule AnkoleWeb.Router do
 
   pipeline :session_api do
     # JSON endpoints that mutate setup or auth state still use the browser
-    # session and CSRF protection. They are API-shaped, not public stateless APIs.
+    # session and CSRF protection. They are API-shaped, not public stateless APIs:
+    # the setup wizard and sign-in SPA call them from the same origin, so the
+    # sealed session cookie carries the auth state and CSRF blocks cross-site POSTs.
     plug :accepts, ["json"]
     plug :fetch_session
     plug :protect_from_forgery
@@ -35,11 +47,15 @@ defmodule AnkoleWeb.Router do
   end
 
   pipeline :console_api do
+    # No session/CSRF here. Each request must present its own bearer token, which
+    # RequireConsoleAccessToken verifies and resolves to an active human admin.
     plug :accepts, ["json"]
     plug OpenApiSpex.Plug.PutApiSpec, module: AnkoleWeb.ApiSpec
     plug AnkoleWeb.Plugs.RequireConsoleAccessToken
   end
 
+  # `/.internal-apis` is the private contract between the SPAs and the server —
+  # the setup wizard and sign-in app drive these; they are not a public API.
   scope "/.internal-apis", AnkoleWeb do
     pipe_through :session_api
 
@@ -65,6 +81,8 @@ defmodule AnkoleWeb.Router do
          :oidc_authorization
   end
 
+  # The spec document is public (no bearer token) so tooling can read it without
+  # credentials; the API endpoints it describes still require one below.
   scope "/api" do
     pipe_through :openapi
 
@@ -81,11 +99,18 @@ defmodule AnkoleWeb.Router do
     post "/app-configurations/:key/decryptions", AppConfigurationController, :decrypt
   end
 
+  # Browser-facing HTML. The `*path` catch-alls let each SPA own its own
+  # client-side routing: any deep link under /console, /setup, or /auth returns
+  # the same shell, and the React router takes over. SpaController re-checks
+  # setup/auth state on every shell request, so the access gate stays
+  # server-side rather than trusting the SPA to redirect.
   scope "/", AnkoleWeb do
     pipe_through :browser
 
     get "/", SpaController, :home
     get "/sessions/new", SpaController, :sessions_new
+    # The OIDC redirect lands here as a top-level browser navigation (not via the
+    # SPA), so it carries the session cookie holding the pending OIDC state.
     get "/sessions/oidc/:provider_id/callback", AuthController, :oidc_callback
     get "/auth", SpaController, :auth_redirect
     get "/auth/*path", SpaController, :auth_redirect

--- a/app/control_plane/lib/ankole_web/schemas/console_api.ex
+++ b/app/control_plane/lib/ankole_web/schemas/console_api.ex
@@ -12,6 +12,9 @@ defmodule AnkoleWeb.Schemas.ConsoleApi do
 
     @behaviour OpenApiSpex.Schema
 
+    # Deliberately untyped: each AppConfigure key has its own value schema, which
+    # the context enforces. Constraining the type here would force a single shape
+    # across every key, so the wire schema stays open and validation lives downstream.
     @impl OpenApiSpex.Schema
     def schema do
       %Schema{
@@ -86,6 +89,11 @@ defmodule AnkoleWeb.Schemas.ConsoleApi do
 
     require OpenApiSpex
 
+    # One AppConfigure entry as the console sees it. The shape reflects the
+    # registry model: `kind` distinguishes exact keys from pattern keys and their
+    # materialized instances; `source`/`overridden`/`default_present` describe
+    # whether the effective value comes from the compiled default or a global
+    # override; `encrypted`/`editable` drive what the UI may show or change.
     OpenApiSpex.schema(
       %{
         title: "AppConfigurationItem",

--- a/app/control_plane/lib/ankole_web/session.ex
+++ b/app/control_plane/lib/ankole_web/session.ex
@@ -1,6 +1,20 @@
 defmodule AnkoleWeb.Session do
   @moduledoc """
   Cookie-session helpers for setup, OIDC state, and admin login.
+
+  Four independent namespaces share the one sealed session cookie, kept apart on
+  purpose:
+
+    * `setup_session` / `setup_oidc_state` — the one-time bootstrap flow.
+    * `admin_session` / `admin_oidc_state` — normal admin login.
+
+  Keeping the bootstrap and admin OIDC states under different keys is a security
+  boundary: a setup-time OIDC round-trip can never be replayed to satisfy a later
+  admin login (and vice versa).
+
+  Every entry stamps its own `issued_at`/`expires_at` into the payload, so expiry
+  is enforced on read here rather than relying solely on the cookie `max_age` —
+  short-lived OIDC state can expire well before the 24h cookie does.
   """
 
   import Plug.Conn
@@ -12,6 +26,7 @@ defmodule AnkoleWeb.Session do
 
   @setup_ttl_seconds 24 * 60 * 60
   @admin_ttl_seconds 24 * 60 * 60
+  # OIDC state lives only long enough to complete one provider round-trip.
   @oidc_state_ttl_seconds 10 * 60
 
   @doc """
@@ -77,6 +92,10 @@ defmodule AnkoleWeb.Session do
 
   @doc """
   Stores an admin session and renews the cookie session id.
+
+  Dropping the CSRF token and renewing the session on login is the standard
+  fixation defense: any token or session id an attacker primed before login is
+  discarded, so the post-login session can't be one they planted.
   """
   @spec put_admin_session(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def put_admin_session(conn, attrs) do
@@ -116,6 +135,11 @@ defmodule AnkoleWeb.Session do
 
   @doc """
   Keeps post-login redirects inside this installation.
+
+  Open-redirect guard for the `return_to` parameter: only same-origin absolute
+  paths pass. `//host` and `/\\host` are rejected because browsers treat them as
+  protocol-relative/scheme links to another origin; anything else falls back to
+  the console.
   """
   @spec safe_return_to(term()) :: String.t()
   def safe_return_to(value) when is_binary(value) do
@@ -128,6 +152,9 @@ defmodule AnkoleWeb.Session do
 
   def safe_return_to(_value), do: "/console"
 
+  # Keys are stringified before storage because the payload survives a
+  # serialize/deserialize round-trip through the cookie, where atom keys would
+  # not safely come back. The TTL is baked into the payload so reads can expire it.
   defp put_expiring_session(conn, key, attrs, ttl_seconds) do
     now = now_seconds()
 
@@ -142,6 +169,8 @@ defmodule AnkoleWeb.Session do
 
   defp active_session?(payload), do: not is_nil(active_payload(payload))
 
+  # An expired or malformed payload reads as absent (`nil`), so a stale cookie is
+  # treated exactly like no session.
   defp active_payload(%{"expires_at" => expires_at} = payload) when is_integer(expires_at) do
     case expires_at > now_seconds() do
       true -> payload

--- a/app/control_plane/lib/ankole_web/session_cookie_store.ex
+++ b/app/control_plane/lib/ankole_web/session_cookie_store.ex
@@ -24,6 +24,9 @@ defmodule AnkoleWeb.SessionCookieStore do
   end
 
   @impl true
+  # Any failure to decrypt/decode an incoming cookie degrades to an empty session
+  # rather than an error: a tampered, stale, or wrong-key cookie simply logs the
+  # user out instead of 500-ing the request. The failure is logged for operators.
   def get(conn, raw_cookie, opts) when is_binary(raw_cookie) do
     with {:ok, key} <- encryption_key(conn, opts),
          {:ok, plaintext} <- decrypt(raw_cookie, key),
@@ -39,6 +42,8 @@ defmodule AnkoleWeb.SessionCookieStore do
   def get(_conn, _raw_cookie, _opts), do: {nil, %{}}
 
   @impl true
+  # Encryption failure on write, by contrast, raises: silently dropping a session
+  # would let an operator believe they were logged in when nothing was persisted.
   def put(conn, _sid, term, opts) do
     binary = :erlang.term_to_binary(term)
 
@@ -55,8 +60,14 @@ defmodule AnkoleWeb.SessionCookieStore do
   end
 
   @impl true
+  # Nothing to delete server-side — the whole session is the cookie. Expiring the
+  # cookie (done by Plug.Session) is the entire delete; we just acknowledge.
   def delete(_conn, _sid, _opts), do: :ok
 
+  # The per-cookie AEAD key is derived from the endpoint secret under a fixed
+  # sub-key id and the configured key context, so the session cookie never uses
+  # the raw secret directly and is namespaced apart from other Kernel keys. The
+  # 64-byte minimum guards against a too-short/misconfigured secret.
   defp encryption_key(%Plug.Conn{secret_key_base: secret_key_base}, opts)
        when is_binary(secret_key_base) and byte_size(secret_key_base) >= 64 do
     case NativeKernel.derive_key(secret_key_base, @sub_key_id, opts.key_context) do
@@ -80,6 +91,9 @@ defmodule AnkoleWeb.SessionCookieStore do
     end
   end
 
+  # Decode with `non_executable_binary_to_term` even though the payload is already
+  # authenticated by AEAD: it's defense in depth, refusing to materialize function
+  # or pid terms that a forged binary could otherwise smuggle in.
   defp decode(binary) do
     case Plug.Crypto.non_executable_binary_to_term(binary) do
       session when is_map(session) -> {:ok, session}


### PR DESCRIPTION
Comment-only documentation pass over the Phoenix web layer (`AnkoleWeb`), part of the codebase commenting initiative. Covers 16 files: controllers, router pipelines, endpoint, session/cookie store, asset resolver, console-token plug, and the console_api schema. Diff is strictly additive comments (2 deletions are replaced doc text). No behavior changes.