### PR TITLE
docs(signals_gateway): add intent-focused comments

### DIFF
--- a/app/control_plane/lib/ankole/signals_gateway.ex
+++ b/app/control_plane/lib/ankole/signals_gateway.ex
@@ -1,6 +1,32 @@
 defmodule Ankole.SignalsGateway do
   @moduledoc """
   Boundary between signal ingress, actor input handoff, and provider outbox.
+
+  This is the provider-ingress layer described in the README: external chats,
+  webhooks, and provider events arrive through the `emit_*` functions, become
+  normalized "signal" facts, and turn into actor input — while the channel/entry
+  mirror preserves the external source fact separately from agent execution.
+  LLM-committed side effects flow back out as outbox entries.
+
+  Three responsibilities live here, each with its own contract:
+
+    * Ingress (`emit_entry`/`emit_reaction`/`emit_action`/`emit_internal`/the
+      delete & recall lifecycle): construct a fact, apply binding filters, then
+      do the channel/entry mirror + actor-input append inside ONE Repo
+      transaction. There is deliberately no stored ingress plan and no second
+      queue — admission and effect happen in the request that received the
+      signal, so a signal either fully lands or leaves no trace.
+
+    * Tombstones: a short-lived guard (`InputTombstone`) so a late re-delivered
+      receive can't resurrect a message the human already deleted/recalled.
+
+    * Outbox (`commit_outbox`/`dispatch_outbox`/`dispatch_due_outbox`): the
+      durable, idempotent, retried path that actually performs provider-visible
+      operations and mirrors the result back into the entry table.
+
+  Most functions take an explicit `now` (via `options[:now]`) so timing-sensitive
+  behavior — batch windows, tombstone expiry, retry schedules — is testable
+  without a clock.
   """
 
   import Ecto.Query, warn: false
@@ -24,12 +50,35 @@ defmodule Ankole.SignalsGateway do
   alias Ankole.SignalsGateway.SignalChannel
   alias Ankole.SignalsGateway.SignalEntry
 
+  # How long a delete/recall blocks a re-delivered receive for the same entry.
+  # 24h comfortably outlives any provider's redelivery/retry window while keeping
+  # the guard transient — long enough that a straggler receive is caught, short
+  # enough that the cleanup job keeps the table from growing without bound. It is
+  # an ordering guard, not a permanent record of the deletion.
   @tombstone_ttl_seconds 24 * 60 * 60
+
+  # Absolute ceiling on how long an ambient ("may_intervene") batch may keep
+  # sliding before the worker is forced to look. The 1.5s batch window slides
+  # forward on every new room message (see ambient_due_at/2); without a cap a
+  # continuously busy room could postpone recognition forever. 60s bounds the
+  # worst case: the agent will react to an active conversation within a minute
+  # even if people never stop typing. Paired with the AIAgent message-context
+  # budget, which is what consumes the observed-messages snapshot.
   @ambient_hard_cap_ms 60_000
+
+  # Cap on how many observed messages are pulled into one ambient batch snapshot.
+  # The snapshot is meant to give the agent the recent room scene, not the whole
+  # history; 80 rows is enough scene for a useful decision while bounding both the
+  # recall queries and the size of the payload handed to the worker.
   @ambient_recall_max_rows 80
 
   @type ingress_result :: {:ok, map()} | {:error, term()}
 
+  # Exponential backoff bounds for outbox retries: first retry ~5s out, doubling
+  # each failed attempt, never waiting more than 5 minutes between tries. Small
+  # base so a transient provider blip recovers quickly; 5m cap so a hard outage
+  # doesn't hammer the provider while still retrying often enough to recover
+  # promptly once it heals.
   @outbox_base_retry_seconds 5
   @outbox_max_retry_seconds 5 * 60
 
@@ -49,6 +98,12 @@ defmodule Ankole.SignalsGateway do
 
   @doc """
   Loads an enabled binding by route key.
+
+  Distinguishes three failure modes an adapter cares about: a binding that
+  exists but is operator-flagged unavailable (`{:binding_unavailable, reason}`),
+  one that is explicitly disabled, and one that simply isn't configured. Every
+  `emit_*` call starts here, so an unconfigured/disabled route is rejected before
+  any fact is constructed.
   """
   @spec get_binding(String.t(), String.t()) :: {:ok, SignalBinding.t()} | {:error, term()}
   def get_binding(agent_uid, binding_name) do
@@ -69,6 +124,11 @@ defmodule Ankole.SignalsGateway do
 
   @doc """
   Concrete adapter API for a provider entry receive.
+
+  The main ingress path for an inbound message. Follows the fixed pipeline:
+  resolve binding → construct fact → filter → accept. A filtered signal returns
+  `{:ok, %{status: :filtered}}` (a successful no-op, not an error), and the actor
+  runtime is woken only when the signal actually produced new actor input.
   """
   @spec emit_entry(String.t(), String.t(), map(), keyword()) :: ingress_result()
   def emit_entry(agent_uid, binding_name, input, options \\ []) when is_map(input) do
@@ -105,6 +165,12 @@ defmodule Ankole.SignalsGateway do
 
   @doc """
   Concrete adapter API for reaction changes.
+
+  Reactions only update the mirror — they never create actor input — so this
+  path stays self-contained: lock the entry, fold the add/remove into its
+  reaction map, done. A reaction on an entry we never mirrored is ignored
+  (`:ignored_unknown_entry`) rather than treated as an error, since the gateway
+  has no entry to attach it to.
   """
   @spec emit_reaction(String.t(), String.t(), map(), keyword()) :: ingress_result()
   def emit_reaction(agent_uid, binding_name, input, options \\ []) when is_map(input) do
@@ -115,6 +181,9 @@ defmodule Ankole.SignalsGateway do
            IngressPipeline.construct(:reaction, binding, input, now, &normalize_reaction_fact/3),
          :match <- IngressPipeline.filter(binding, fact) do
       Repo.transact(fn repo ->
+        # Advisory lock on the entry key serializes concurrent reaction folds for
+        # the same message so two simultaneous add/removes can't clobber the
+        # reactions map.
         with :ok <- lock_entry(repo, fact) do
           case repo.get_by(SignalEntry,
                  signal_channel_id: fact.signal_channel_id,
@@ -164,6 +233,11 @@ defmodule Ankole.SignalsGateway do
 
   @doc """
   Appends an internal ActorInput, such as a timer fire, without provider mirroring.
+
+  Internal sources (timers, system-generated events) have no provider channel or
+  entry to mirror, so this path skips the channel/entry write entirely and goes
+  straight to actor input. It is how Ankole feeds itself — e.g. a fired reminder
+  becomes input to the session that scheduled it.
   """
   @spec emit_internal(String.t(), String.t(), map(), keyword()) :: ingress_result()
   def emit_internal(agent_uid, binding_name, input, options \\ []) when is_map(input) do
@@ -188,6 +262,13 @@ defmodule Ankole.SignalsGateway do
 
   @doc """
   Records a provider-visible outbox intent committed by the actor runtime.
+
+  This is the "commit" half of the outbox: the actor declares it wants to do
+  something to the provider, transactionally, without performing it yet. The
+  `on_conflict: :nothing` upsert on `{agent_uid, binding_name, outbound_key}` is
+  the idempotency contract — committing the same `outbound_key` twice yields the
+  same single row (and therefore at most one provider side effect). Actual
+  delivery happens later via `dispatch_outbox`/`dispatch_due_outbox`.
   """
   @spec commit_outbox(map()) :: {:ok, OutboxEntry.t()} | {:error, term()}
   def commit_outbox(attrs) when is_map(attrs) do
@@ -203,6 +284,11 @@ defmodule Ankole.SignalsGateway do
 
   @doc """
   Chooses the provider-visible reply operation for an actor input.
+
+  Decides whether the agent's reply should be a threaded `:reply` to the
+  triggering entry or a top-level `:post`, based on the channel's reply_mode and
+  the adapter's declared capabilities. Falls back to a safe operation when the
+  channel/binding can't be resolved, so a reply is never silently dropped.
   """
   @spec outbox_operation_for_actor_input(ActorInput.t(), module()) :: atom()
   def outbox_operation_for_actor_input(%ActorInput{} = actor_input, repo \\ Repo) do
@@ -224,6 +310,14 @@ defmodule Ankole.SignalsGateway do
 
   @doc """
   Dispatches one outbox row through a concrete adapter runtime.
+
+  The "perform" half of the outbox. `prepare_outbox_dispatch` runs first under a
+  row lock to claim the work and decide the route — a normal `:send`, a
+  `:reconcile` for a row that was mid-send when the node restarted, or an
+  already-terminal row that needs no action — and only then is the adapter
+  called outside any held resources. Splitting prepare (locked, mutates status
+  to `:sending`) from the adapter call avoids holding a DB lock across a network
+  round-trip.
   """
   @spec dispatch_outbox(String.t(), String.t(), String.t(), map(), keyword()) ::
           {:ok, OutboxEntry.t()} | {:error, term()}
@@ -251,6 +345,12 @@ defmodule Ankole.SignalsGateway do
 
   @doc """
   Lists outbox rows that are ready for a dispatch attempt.
+
+  "Due" means either freshly `:created` or `:failed` and past its
+  `next_attempt_at` with retries remaining. Oldest-first and capped by `limit`
+  so a periodic dispatcher drains a bounded, fair batch each tick. Rows in
+  `:sending`/`:succeeded`/`:unsupported`/`:unknown_after_send` are intentionally
+  excluded — they are either in progress or terminal.
   """
   @spec list_due_outbox(DateTime.t(), pos_integer()) :: [OutboxEntry.t()]
   def list_due_outbox(now \\ DateTime.utc_now(:microsecond), limit \\ 50)
@@ -312,6 +412,9 @@ defmodule Ankole.SignalsGateway do
 
   @doc """
   Removes expired SignalsGateway TTL state.
+
+  Deletes tombstones whose guard window has passed. Driven by the cleanup Oban
+  job; safe to run anytime since an expired tombstone no longer affects ingress.
   """
   @spec cleanup_expired_state(DateTime.t()) :: %{tombstones: non_neg_integer()}
   def cleanup_expired_state(now \\ DateTime.utc_now(:microsecond)) do
@@ -329,6 +432,10 @@ defmodule Ankole.SignalsGateway do
   @spec signal_session_id(String.t()) :: String.t()
   def signal_session_id(signal_channel_id), do: "signal-channel:#{signal_channel_id}"
 
+  # Only a result that actually produced new actor input (:accepted) wakes the
+  # runtime. Filtered / recorded / ignored / mirror-only outcomes wrote nothing
+  # the actor needs to run on, so they must NOT cost a wake-up — this is the hook
+  # that keeps ambient mirroring from constantly poking the scheduler.
   defp wake_actor_runtime({:ok, %{status: :accepted}} = result) do
     ActivationManager.wake()
     result
@@ -352,6 +459,11 @@ defmodule Ankole.SignalsGateway do
     end
   end
 
+  # Whole acceptance runs in one transaction behind the per-entry advisory lock,
+  # so concurrent receives for the same message serialize and the
+  # tombstone-check → mirror → actor-input sequence is atomic. The tombstone
+  # check comes first: if the human already deleted/recalled this entry, drop the
+  # late receive before writing anything.
   defp accept_entry(binding, fact, options, now) do
     Repo.transact(fn repo ->
       with :ok <- lock_entry(repo, fact) do
@@ -373,6 +485,13 @@ defmodule Ankole.SignalsGateway do
     fn binding, input, now -> normalize_lifecycle_fact(binding, input, kind, now) end
   end
 
+  # Delete/recall is the inverse of accept and does several things atomically:
+  # 1) drop a tombstone so a re-delivered receive can't resurrect the entry,
+  # 2) remove the mirror row, 3) cancel any still-pending actor input for that
+  # entry (the agent shouldn't act on a retracted message), and 4) for input the
+  # agent ALREADY consumed, append a lifecycle "deleted/recalled" input so the
+  # running session learns the message went away. Steps 3 and 4 are mutually
+  # exclusive per input: cancel what hasn't run, notify about what has.
   defp accept_lifecycle(binding, fact, kind, now) do
     Repo.transact(fn repo ->
       with {:ok, channel} <- upsert_channel(repo, fact, now),
@@ -587,6 +706,17 @@ defmodule Ankole.SignalsGateway do
     end
   end
 
+  # The routing decision: given an accepted entry fact, what should it become?
+  # Order matters — these are tried top to bottom and the first match wins:
+  #   1. mirror_only: caller asked to only record, never wake the agent.
+  #   2. a recognized /slash command in addressed text → command.* input.
+  #   3. an adapter-supplied explicit actor_input_type (non-IM sources).
+  #   4. a DM, or a group message that explicitly @-addresses the agent → a
+  #      normal addressed message.
+  #   5. a group reply to one of the agent's own clarifying questions → also
+  #      treated as addressed (the human is answering us).
+  #   6. an unaddressed group message → defer to the binding's group policy.
+  #   7. otherwise there is no rule that turns this into input → error.
   defp entry_policy(%SignalBinding{} = binding, fact, options) do
     cond do
       fact.mirror_only? ->
@@ -616,10 +746,19 @@ defmodule Ankole.SignalsGateway do
   defp group_policy(:record_only), do: {:ok, :record_only}
   defp group_policy(:may_intervene), do: {:ok, {:actor_input, "im.message.may_intervene", nil}}
 
+  # "Explicit" = the agent is unambiguously being talked to: every DM qualifies,
+  # and a group message qualifies only if it @-mentions the agent. This gates
+  # both command parsing and the default addressed-message path.
   defp explicit_im_entry?(%{channel_kind: :im_dm}), do: true
   defp explicit_im_entry?(%{channel_kind: :im_group, explicit?: true}), do: true
   defp explicit_im_entry?(_fact), do: false
 
+  # Lets a human answer the agent's clarifying question in a group without having
+  # to re-@-mention it. Only relevant for group text messages; the actual "did
+  # the agent recently ask something here" check is injected by the caller as
+  # `clarify_lookup` (kept out of the gateway so this module stays free of
+  # conversation-history queries). Accepts a 1- or 2-arity lookup for caller
+  # convenience.
   defp clarify_reply?(_binding, %{channel_kind: channel_kind}, _options)
        when channel_kind != :im_group,
        do: false
@@ -634,6 +773,9 @@ defmodule Ankole.SignalsGateway do
     end
   end
 
+  # Commands are only honored when the agent is explicitly addressed, so a "/stop"
+  # overheard in an unaddressed group line is not treated as a command. The
+  # leading @-mention is stripped before classification so "@agent /stop" parses.
   defp command_payload(fact) do
     case explicit_im_entry?(fact) do
       true ->
@@ -661,6 +803,10 @@ defmodule Ankole.SignalsGateway do
     end
   end
 
+  # The full accept path: mirror the external fact (channel + entry) AND create
+  # actor input, then refresh batch readiness so this input coalesces with any
+  # sibling messages in the same debounce window. Mirror-before-input ordering
+  # means the actor input can reference a row that already exists.
   defp apply_entry_policy(repo, binding, fact, {:actor_input, type, command_payload}, now) do
     fact = Map.put(fact, :command_payload, command_payload)
 
@@ -708,6 +854,11 @@ defmodule Ankole.SignalsGateway do
     end
   end
 
+  # Different providers send different subsets of channel detail per event, so a
+  # later sparse event must not erase richer data from an earlier one. The merge
+  # rule is "don't overwrite with nothing": a sparse enum (:unknown/:none), a nil
+  # text field, or an empty map all keep the previously stored value.
+  # `first_seen_at` is always preserved since it records the first observation.
   defp merge_channel_attrs(%SignalChannel{} = channel, attrs) do
     %{
       attrs
@@ -722,12 +873,19 @@ defmodule Ankole.SignalsGateway do
     }
   end
 
+  # `sparse_value` is the enum's "no info" member (:unknown / :none); receiving it
+  # means the event carried no channel kind / reply mode, so keep what we had.
   defp preserve_enum(incoming, sparse_value, existing) when incoming == sparse_value, do: existing
   defp preserve_enum(incoming, _sparse_value, _existing), do: incoming
 
   defp preserve_empty_map(map, existing) when map == %{}, do: existing || %{}
   defp preserve_empty_map(map, _existing), do: map
 
+  # Upsert the entry mirror, but never let an out-of-order (older) provider event
+  # overwrite a newer stored state: if the incoming provider_time predates what's
+  # stored, keep the existing row untouched. On a real update, reactions and
+  # raw_reaction_keys are preserved because those are folded in by the reaction
+  # path, not carried on a plain receive.
   defp mirror_receive_entry(repo, fact, now) do
     with :ok <- lock_entry(repo, fact) do
       attrs = receive_entry_attrs(fact, now)
@@ -820,12 +978,21 @@ defmodule Ankole.SignalsGateway do
 
     attrs = Map.put(attrs, :payload, payload)
 
+    # Ambient observation is special: instead of appending a new input per
+    # observed message, fold consecutive observations into a single open batch
+    # input so the agent gets one "here is what's happening in the room" wake-up,
+    # not one per message. Everything else appends a discrete input.
     case type do
       "im.message.may_intervene" -> append_or_merge_ambient_input(attrs, payload, now)
       _type -> Actors.append_actor_input(attrs)
     end
   end
 
+  # Three cases, in order:
+  #   1. We already created an input for this exact ingress_event_id → return it
+  #      (idempotent against duplicate delivery of the same event).
+  #   2. There is an OPEN ambient batch for this room → merge this observation in.
+  #   3. No open batch → start a new one.
   defp append_or_merge_ambient_input(attrs, event_payload, now) do
     case Repo.get_by(ActorInput,
            agent_uid: attrs.agent_uid,
@@ -1304,6 +1471,10 @@ defmodule Ankole.SignalsGateway do
     }
   end
 
+  # When a new addressed message lands, push the whole open batch in this
+  # channel/thread to the latest message's `available_at`. That way a burst of
+  # rapid messages is consumed as one turn keyed to the LAST message, instead of
+  # the agent replying to the first and then again to each follow-up.
   defp refresh_batch_readiness("im.message.addressed", fact, %ActorInput{} = actor_input) do
     ActorInput
     |> where([input], input.agent_uid == ^fact.agent_uid)
@@ -1333,9 +1504,12 @@ defmodule Ankole.SignalsGateway do
 
   defp refresh_batch_readiness(_type, _fact, _actor_input), do: :ok
 
-  # Mirrors BullX's ambient debounce without introducing Redis: every new room
-  # observation slides the PG queue wake forward by the batch window, bounded by
-  # the oldest unprocessed row so a busy room cannot postpone recognition forever.
+  # Ambient debounce implemented entirely in Postgres (no Redis): each new room
+  # observation pushes the wake-up forward by the batch window (sliding), but the
+  # result is clamped so it can never be later than `oldest open input + 60s hard
+  # cap`. Net effect: a quiet room reacts ~1.5s after the last message, a room
+  # that never goes quiet still reacts within 60s of the first unprocessed
+  # message. The hard cap is what stops a busy room from starving recognition.
   defp ambient_due_at(fact, %ActorInput{} = actor_input) do
     oldest_inserted_at =
       ActorInput
@@ -1366,6 +1540,10 @@ defmodule Ankole.SignalsGateway do
     end
   end
 
+  # The payload stored on the ActorInput is a CloudEvents 1.0 envelope so the
+  # worker sees a uniform shape regardless of which provider/source produced it.
+  # `data` is assembled from whichever fact fields are present (nils dropped);
+  # `source`/`subject` encode provenance (see envelope_source/2, envelope_subject/1).
   defp actor_envelope(binding, fact, type, channel, entry, now) do
     data =
       %{
@@ -1463,6 +1641,10 @@ defmodule Ankole.SignalsGateway do
   defp datetime_iso8601(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
   defp datetime_iso8601(_value), do: nil
 
+  # `_kind` (deleted vs recalled) does not change the guard — both block late
+  # redelivery identically — so it's ignored here; the distinction only matters
+  # for the lifecycle actor input. Re-tombstoning an entry simply refreshes the
+  # 24h window from `now`.
   defp upsert_tombstone(repo, fact, _kind, now) do
     attrs = %{
       agent_uid: fact.agent_uid,
@@ -1515,6 +1697,12 @@ defmodule Ankole.SignalsGateway do
     |> repo.delete_all()
   end
 
+  # Notify each session that already CONSUMED the now-deleted entry. We can't undo
+  # what the agent did, but it should know the source message is gone, so we
+  # append a "deleted/recalled" input per affected session, stripped of the
+  # original content (no text/mentions/command) — it's a tombstone notice, not a
+  # re-delivery. Sessions that never consumed the entry had their pending input
+  # cancelled instead (see accept_lifecycle), so there's nothing to notify there.
   defp append_lifecycle_inputs(_binding, _fact, [], _channel, _now), do: {:ok, []}
 
   defp append_lifecycle_inputs(binding, fact, consumed_inputs, channel, now) do
@@ -1620,6 +1808,13 @@ defmodule Ankole.SignalsGateway do
 
   defp stale_provider_time?(_stored_time, _incoming_time), do: false
 
+  # Serialize all gateway work for a single entry without a row to lock (the entry
+  # row may not exist yet on first receive). A transaction-scoped Postgres
+  # advisory lock keyed by hash of `channel|entry` makes concurrent
+  # receive/reaction/lifecycle handlers for the same message take turns, and it
+  # releases automatically at commit/rollback. `hashtext` is acceptable here:
+  # rare collisions only cause two unrelated entries to briefly serialize, which
+  # is harmless.
   defp lock_entry(repo, fact) do
     key =
       Enum.join(
@@ -1631,6 +1826,9 @@ defmodule Ankole.SignalsGateway do
     :ok
   end
 
+  # Fill the status-machine defaults a freshly committed intent needs: starts
+  # :created with zero attempts and a 10-attempt ceiling. `put_new` so a caller
+  # may override (e.g. a custom max_attempts) but normally doesn't have to.
   defp default_outbox_attrs(attrs) do
     attrs
     |> Map.put_new(:status, :created)
@@ -1642,6 +1840,10 @@ defmodule Ankole.SignalsGateway do
     |> normalize_agent_uid_attr()
   end
 
+  # `on_conflict: :nothing` returns a struct with nil fields when the row already
+  # existed (the commit was a duplicate). That's success for an idempotent
+  # commit, so re-read the existing row by its key and return it instead of the
+  # empty conflict struct.
   defp outbox_insert_result({:ok, %OutboxEntry{agent_uid: nil}}, attrs) do
     attrs = default_outbox_attrs(attrs)
 
@@ -1658,6 +1860,10 @@ defmodule Ankole.SignalsGateway do
   defp outbox_insert_result({:ok, %OutboxEntry{} = entry}, _attrs), do: {:ok, entry}
   defp outbox_insert_result({:error, _changeset} = error, _attrs), do: error
 
+  # Channel wants threaded replies and we have an entry to thread under: reply if
+  # the adapter supports threaded replies, otherwise degrade to a top-level post
+  # so the message still gets out. The capability key is the string form because
+  # it comes from plugin declarations.
   defp choose_outbox_operation(
          %SignalChannel{reply_mode: :entry},
          capabilities,
@@ -1752,6 +1958,10 @@ defmodule Ankole.SignalsGateway do
     end
   end
 
+  # Claim a row for a fresh send: confirm it's due, confirm the channel+adapter
+  # can perform the operation, then flip it to :sending (which also stamps
+  # platform_send_started_at and bumps attempt_count). All under the row lock
+  # held by the caller, so two dispatchers can't both claim the same row.
   defp prepare_fresh_outbox_dispatch(repo, outbox, channel, adapter, now) do
     with :ok <- dispatchable_outbox?(outbox, now),
          :ok <- outbox_supported?(outbox, channel, adapter),
@@ -1763,6 +1973,10 @@ defmodule Ankole.SignalsGateway do
     end
   end
 
+  # Guard clauses encode the status machine's "may I attempt this now?" rules:
+  # fresh rows go; failed rows go only if retries remain and the backoff time has
+  # passed; a row already :sending is refused (another dispatcher owns it);
+  # anything terminal is not dispatchable.
   defp dispatchable_outbox?(%OutboxEntry{status: :created}, _now), do: :ok
 
   defp dispatchable_outbox?(
@@ -1868,6 +2082,15 @@ defmodule Ankole.SignalsGateway do
 
   defp require_fallback_text(outbox), do: {:unsupported, outbox}
 
+  # Recovery for a row found in :sending — meaning a previous dispatch told the
+  # adapter to send and the node died before recording the outcome. A blind
+  # resend risks a duplicate provider post, so:
+  #   - if the adapter can reconcile AND we already captured a provider_entry_id,
+  #     reconcile to learn whether the send actually landed;
+  #   - otherwise we cannot safely tell, so park the row as unknown_after_send
+  #     for an operator rather than guess.
+  # (This is the durable counterpart to "streaming is progress; committed work is
+  # truth" — an unconfirmed send is neither, so it is never silently retried.)
   defp in_flight_recovery_action(
          %OutboxEntry{
            status: :sending,
@@ -1885,6 +2108,8 @@ defmodule Ankole.SignalsGateway do
     end
   end
 
+  # Same situation but no provider_entry_id was captured, so even a
+  # reconciliation-capable adapter has nothing to look up → mark unknown.
   defp in_flight_recovery_action(
          %OutboxEntry{status: :sending, platform_send_started_at: %DateTime{}} = outbox,
          _adapter
@@ -1895,6 +2120,7 @@ defmodule Ankole.SignalsGateway do
             "reason" => "provider send started without provider entry id"
           }}
 
+  # Not mid-send → proceed with a normal fresh dispatch.
   defp in_flight_recovery_action(_outbox, _adapter), do: :continue
 
   defp mark_outbox_sending(repo, outbox, now) do
@@ -1919,6 +2145,11 @@ defmodule Ankole.SignalsGateway do
 
   defp call_adapter_reconcile(adapter, outbox), do: OutboxAdapter.reconcile(adapter, outbox)
 
+  # Runs after the adapter call returns (outside the prepare transaction). Re-open
+  # a transaction and re-lock the row before recording the outcome, because the
+  # network call happened with no lock held and the row could have changed.
+  # Outcome → status: ok ⇒ succeeded (+ mirror the posted entry), error ⇒ failed
+  # (schedule retry), :unknown ⇒ unknown_after_send (never auto-retried).
   defp finalize_outbox_send(send_result, outbox, channel, now) do
     Repo.transact(fn repo ->
       with %OutboxEntry{} = current_outbox <- fetch_outbox_for_update(repo, outbox) do
@@ -2011,12 +2242,18 @@ defmodule Ankole.SignalsGateway do
     |> repo.update()
   end
 
+  # Prefer the id the provider returned; fall back to one already on the row.
+  # If the provider gave us nothing (some adapters don't return an id), synthesize
+  # a stable local id so the mirror still has a primary key — only for operations
+  # that create a new entry, since edit/delete/reaction target an existing id.
   defp provider_entry_id_after_success(%OutboxEntry{} = outbox, result) do
     optional_text(result, :provider_entry_id) ||
       outbox.provider_entry_id ||
       stable_local_provider_entry_id(outbox)
   end
 
+  # Derived from the idempotency/outbound key so the same committed intent always
+  # maps to the same local id, keeping the mirror upsert idempotent.
   defp stable_local_provider_entry_id(%OutboxEntry{operation: operation} = outbox)
        when operation in [:post, :reply, :divider, :card] do
     "local-outbox:#{outbox.idempotency_key || outbox.outbound_key}"
@@ -2024,6 +2261,10 @@ defmodule Ankole.SignalsGateway do
 
   defp stable_local_provider_entry_id(%OutboxEntry{}), do: nil
 
+  # Exponential backoff: delay = 5s * 2^(attempt-1), clamped to the 5m ceiling
+  # (so 5s, 10s, 20s, 40s, … capped at 300s). Returning nil once attempts are
+  # exhausted is what makes list_due_outbox stop selecting the row — the retry
+  # loop ends without a separate "give up" flag.
   defp next_outbox_attempt_at(%OutboxEntry{attempt_count: attempts, max_attempts: max}, _now)
        when attempts >= max,
        do: nil
@@ -2038,6 +2279,12 @@ defmodule Ankole.SignalsGateway do
     DateTime.add(now, delay_seconds, :second)
   end
 
+  # After a successful send, write the agent's own output into the SAME entry
+  # mirror humans' messages land in, so the channel history is unified and the
+  # agent can later see what it said. Each operation maps to the matching mirror
+  # mutation: post/reply/card/divider create a row, edit rewrites text, delete
+  # removes the row, reactions fold into the reaction map. Constructs a synthetic
+  # fact authored by the agent and reuses mirror_receive_entry.
   defp mirror_outbox_success(
          repo,
          %OutboxEntry{operation: operation} = outbox,
@@ -2179,6 +2426,10 @@ defmodule Ankole.SignalsGateway do
     end)
   end
 
+  # A "structured" mention is a real provider @-mention entity (not the literal
+  # text "@bot"), which is what makes a group message count as explicitly
+  # addressed. It must target THIS agent: either it names this agent_uid, or it
+  # carries no specific uid (a generic bot mention the binding owns).
   defp structured_mention?(mention, agent_uid) when is_map(mention) do
     structured? =
       truthy?(fetch_value(mention, :structured)) ||
@@ -2237,6 +2488,11 @@ defmodule Ankole.SignalsGateway do
   defp normalize_attachment(attachment),
     do: {:error, {:invalid_attachment_payload, Sanitizer.transport(attachment)}}
 
+  # An attachment is only accepted into durable state once it points at something
+  # that will still resolve later: a provider/blob/storage reference, or a file
+  # already materialized on the Agent Computer workspace. A raw in-memory or
+  # transient attachment is rejected (see normalize_attachment/1) so the mirror
+  # never stores a dangling pointer the agent can't re-fetch.
   defp durable_attachment?(attachment) do
     Enum.any?(
       [
@@ -2288,12 +2544,18 @@ defmodule Ankole.SignalsGateway do
   defp metadata_text_part(value) when is_number(value), do: to_string(value)
   defp metadata_text_part(_value), do: ""
 
+  # Stable, opaque per-entry id derived from its identity (channel + provider
+  # entry). `content_hash` instead digests the entry's *content* so a re-receive
+  # with unchanged content produces the same hash (cheap change detection).
   defp document_id(signal_channel_id, provider_entry_id) do
     "signal-entry:" <> digest([signal_channel_id, provider_entry_id])
   end
 
   defp content_hash(parts), do: digest(parts)
 
+  # term_to_binary → SHA-256 → url-safe base64. Hashing the BEAM term (not a
+  # string) avoids having to define a canonical serialization for the mixed
+  # list of text/maps/lists passed in.
   defp digest(parts) do
     parts
     |> :erlang.term_to_binary()
@@ -2392,15 +2654,21 @@ defmodule Ankole.SignalsGateway do
 
   defp normalize_reaction_action(_value), do: :add
 
+  # A nil thread must match rows where the column IS NULL (not `= NULL`, which is
+  # never true in SQL), so the two clauses generate different WHERE fragments.
   defp where_provider_thread(query, nil),
     do: where(query, [input], is_nil(input.provider_thread_id))
 
   defp where_provider_thread(query, provider_thread_id),
     do: where(query, [input], input.provider_thread_id == ^provider_thread_id)
 
+  # Provider/JSON booleans arrive as strings or ints, so accept the common truthy
+  # encodings rather than only the literal `true`.
   defp truthy?(value) when value in [true, "true", 1, "1"], do: true
   defp truthy?(_value), do: false
 
+  # agent_uid is matched case-insensitively across the gateway, so every lookup
+  # and write funnels through this same trim+downcase to keep keys consistent.
   defp normalize_uid(uid) when is_binary(uid), do: uid |> String.trim() |> String.downcase()
   defp normalize_uid(uid), do: uid
 end

--- a/app/control_plane/lib/ankole/signals_gateway/actor_input_types.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/actor_input_types.ex
@@ -1,14 +1,35 @@
 defmodule Ankole.SignalsGateway.ActorInputTypes do
   @moduledoc """
   Code-defined ActorInput semantics used by SignalsGateway.
+
+  The set of input types and their batching/timing behavior is intentionally
+  defined in code, not in DB config: these are runtime contracts the worker
+  relies on, and they change with the code that consumes them. `readiness/3`
+  produces the `available_at` (when the worker may pick the input up) and the
+  `batch_scope` (which inputs coalesce together).
   """
 
+  # A human typically sends a burst of messages (or one message split across
+  # lines) in quick succession. These windows debounce that burst into a single
+  # actor wake-up instead of one wake per message.
+  #
+  # Addressed messages get a tight 800ms window — the human is talking *to* the
+  # agent and expects a prompt reply, so we only absorb the immediate stutter.
   @batch_window_ms 800
+  # Ambient ("may_intervene") observation is not urgent and benefits from seeing
+  # more of the room before deciding whether to speak, so it gets a longer
+  # 1.5s window. The sliding version of this window in SignalsGateway is what is
+  # ultimately bounded by the 60s ambient hard cap.
   @ambient_batch_window_ms 1_500
 
   @doc """
   Returns the actor consumption path for an ActorInput type.
   """
+  # Buckets an input type into the lane the worker consumes it through. `steer`
+  # rides the addressed-IM lane because steering is an interactive "talk to the
+  # running agent" message, not a generic command. The `binary_part(.., 0, 8)`
+  # guard catches any other `command.*` type; the final clause is the catch-all
+  # direct lane for one-off inputs.
   @spec consumption_path(String.t()) :: atom()
   def consumption_path("im.message.addressed"), do: :addressed_im
   def consumption_path("command.steer"), do: :addressed_im
@@ -40,6 +61,10 @@ defmodule Ankole.SignalsGateway.ActorInputTypes do
     }
   end
 
+  # Ambient inputs have no single human sender (they represent "the room"), so
+  # the sender_key is a synthetic per-room key. That makes all ambient
+  # observations for one channel/thread collapse onto one batch instead of
+  # fanning out per author.
   def readiness("im.message.may_intervene", input, now) do
     available_at = DateTime.add(now, @ambient_batch_window_ms, :millisecond)
 

--- a/app/control_plane/lib/ankole/signals_gateway/adapter_context.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/adapter_context.ex
@@ -29,6 +29,8 @@ defmodule Ankole.SignalsGateway.AdapterContext do
       agent_uid: fetch!(attrs, :agent_uid),
       binding_name: fetch!(attrs, :binding_name),
       adapter: fetch!(attrs, :adapter),
+      # user_name is the human-facing display label; default it to the adapter id
+      # so an adapter that doesn't supply one still has something to show.
       user_name: fetch(attrs, :user_name) || fetch!(attrs, :adapter)
     }
   end

--- a/app/control_plane/lib/ankole/signals_gateway/binding_filters.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/binding_filters.ex
@@ -5,10 +5,24 @@ defmodule Ankole.SignalsGateway.BindingFilters do
   v1 intentionally supports only exact equality over a small allowlist. This
   keeps the user model explicit while leaving one stable place to grow future
   rule routing.
+
+  Why only exact-match over a fixed field allowlist: an operator-authored filter
+  decides whether a provider event even enters the system, so it must be cheap,
+  total, and impossible to misuse. Regex / ranges / arbitrary field paths would
+  invite catastrophic-backtracking, atom exhaustion (see `fetch_field/2`), and
+  filters whose behavior nobody can predict from the binding config. Exact
+  equality on a curated set of normalized fields is auditable and good enough for
+  the v1 routing cases (which adapter, which channel kind, which event_type).
+  Anything richer is a deliberate future expansion that lives here.
   """
 
   import Kernel, except: [match?: 2]
 
+  # The only fields a binding filter may key on. Two prefixes (`metadata.` and
+  # `channel_metadata.`) reach one level into the normalized JSON maps; every
+  # other entry is a top-level IngressFact field. Restricting the set keeps
+  # `String.to_existing_atom/1` in `fetch_field/2` safe and makes filters
+  # operator-auditable.
   @allowed_fields MapSet.new([
                     "adapter",
                     "binding_name",
@@ -35,9 +49,14 @@ defmodule Ankole.SignalsGateway.BindingFilters do
   @spec match?(map() | nil, map()) :: result()
   def match?(filters, fact)
 
+  # No filter (or an empty object) means "accept everything for this binding" —
+  # an operator who configured no rules wants every event from the adapter.
   def match?(nil, _fact), do: :match
   def match?(filters, _fact) when filters == %{}, do: :match
 
+  # v1 grammar is a single `{"eq" => %{field => value}}` envelope (atom or string
+  # key, since filters arrive both from Ecto JSON and from in-code callers).
+  # `map_size == 1` forbids smuggling extra unrecognized top-level operators.
   def match?(%{"eq" => eq_filters} = filters, fact) when map_size(filters) == 1 do
     match_eq(eq_filters, fact)
   end
@@ -46,6 +65,9 @@ defmodule Ankole.SignalsGateway.BindingFilters do
     match_eq(eq_filters, fact)
   end
 
+  # A well-formed map that is not the `eq` envelope is a filter v1 cannot honor;
+  # a non-map is malformed config. Both fail closed (error, not silent match) so
+  # a broken binding is visible instead of quietly admitting everything.
   def match?(%{} = _filters, _fact), do: {:error, :unsupported_binding_filter}
   def match?(_filters, _fact), do: {:error, :invalid_binding_filter}
 
@@ -53,6 +75,8 @@ defmodule Ankole.SignalsGateway.BindingFilters do
     match?(%{}, fact)
   end
 
+  # All listed equalities must hold (AND). Short-circuit on the first miss or
+  # error so a bad field name fails fast rather than evaluating the rest.
   defp match_eq(filters, fact) when is_map(filters) do
     filters
     |> Enum.map(fn {field, expected} -> match_field(field, expected, fact) end)
@@ -65,6 +89,10 @@ defmodule Ankole.SignalsGateway.BindingFilters do
 
   defp match_eq(_filters, _fact), do: {:error, :invalid_binding_filter}
 
+  # Both sides must be scalars: the operator-provided `expected` and the value
+  # pulled off the fact. Anything non-scalar (a nested map/list) is rejected as
+  # an invalid filter rather than compared structurally — v1 only does scalar
+  # equality.
   defp match_field(field, expected, fact) do
     with {:ok, field} <- normalize_field(field),
          :ok <- allowed_field?(field),
@@ -91,6 +119,10 @@ defmodule Ankole.SignalsGateway.BindingFilters do
   defp fetch_field(fact, "channel_metadata." <> key),
     do: fetch_nested(Map.get(fact, :channel_metadata), key)
 
+  # `to_existing_atom` (not `to_atom`) is the safety valve: filter field names
+  # are operator strings, and only IngressFact struct keys exist as atoms by the
+  # time this runs. An unknown name raises ArgumentError, which we convert into
+  # an unsupported-field error instead of minting a new atom from input.
   defp fetch_field(fact, field) do
     fact
     |> Map.get(String.to_existing_atom(field))
@@ -99,9 +131,14 @@ defmodule Ankole.SignalsGateway.BindingFilters do
     ArgumentError -> {:error, {:unsupported_binding_filter_field, field}}
   end
 
+  # Metadata maps are JSON-normalized to string keys, so the nested lookup uses
+  # the raw key string directly. A missing parent map yields nil (no match)
+  # rather than an error: the filter simply does not apply to this fact.
   defp fetch_nested(%{} = map, key), do: map |> Map.get(key) |> normalize_actual()
   defp fetch_nested(_map, _key), do: {:ok, nil}
 
+  # Fact enum fields (channel_kind, reply_mode) are atoms; compare them as
+  # strings so a filter written as `"channel_kind" => "im_group"` matches.
   defp normalize_actual(value) when is_atom(value), do: {:ok, Atom.to_string(value)}
   defp normalize_actual(value), do: {:ok, value}
 

--- a/app/control_plane/lib/ankole/signals_gateway/commands.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/commands.ex
@@ -1,8 +1,18 @@
 defmodule Ankole.SignalsGateway.Commands do
   @moduledoc """
   Visible text command parser for signal entries.
+
+  Recognizes the small set of `/slash` commands a human can type into a chat to
+  control the agent. Parsing runs on the *visible* message text (after any
+  structured @-mention is stripped) so that "@agent /stop" works the same as
+  "/stop". The classifier is deliberately strict: unknown leading slashes are
+  `:not_command`, so an unrelated message starting with "/" is treated as plain
+  text.
   """
 
+  # The only recognized commands. `steer` and `stop` reach a running actor;
+  # `new`/`compress`/`retry` manage the session. Output is currently a "stub" —
+  # the parser identifies intent; execution is wired up elsewhere.
   @commands MapSet.new(["new", "compress", "retry", "steer", "stop"])
 
   @doc """
@@ -37,6 +47,11 @@ defmodule Ankole.SignalsGateway.Commands do
     end)
   end
 
+  # CJK keyboards commonly emit full-width punctuation: a full-width space
+  # (U+3000) and full-width digits. Normalizing them to ASCII lets a command
+  # typed on an IME ("\uff0fstop" spacing, "retry \uff11") parse the same as one typed on
+  # a Latin keyboard. Only the leading whitespace is trimmed; argsText keeps its
+  # original spacing.
   defp normalize_command_text(text) do
     text
     |> String.trim_leading()
@@ -63,6 +78,10 @@ defmodule Ankole.SignalsGateway.Commands do
   defp normalize_full_width_digit("９"), do: "9"
   defp normalize_full_width_digit(grapheme), do: grapheme
 
+  # `raw` (the original, un-normalized text) is preserved in the result so a
+  # command handler can recover exactly what the human typed; `name`/`argsText`
+  # are the parsed form. Split on the first whitespace run: head is the command,
+  # tail is the free-form argument string.
   defp parse_normalized("/" <> rest, raw) do
     {name, args_text} =
       rest

--- a/app/control_plane/lib/ankole/signals_gateway/ingress_fact.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/ingress_fact.ex
@@ -9,6 +9,10 @@ defmodule Ankole.SignalsGateway.IngressFact do
 
   alias Ankole.SignalsGateway.JsonPayload
 
+  # Every accepted signal shape (entry / lifecycle / reaction / action /
+  # internal) is represented by this one struct. Only the routing identity that
+  # all shapes share is enforced; the rest of the fields are populated per-kind
+  # by the constructors below, so most are nil for any given fact.
   @enforce_keys [:kind, :agent_uid, :binding_name, :adapter, :ingress_event_id]
   defstruct [
     :kind,
@@ -86,6 +90,10 @@ defmodule Ankole.SignalsGateway.IngressFact do
   @spec internal(map()) :: {:ok, t()} | {:error, term()}
   def internal(attrs), do: new(:internal, attrs)
 
+  # Durability check runs before struct construction: if any map/list field
+  # can't be made JSON-safe, the fact never forms and the signal is rejected
+  # before any mirror or actor input is written (see JsonPayload's "fail before
+  # provider ack" rule).
   defp new(kind, attrs) when is_map(attrs) do
     with {:ok, normalized_attrs} <- normalize_durable_fields(kind, attrs),
          {:ok, fact} <- build(kind, normalized_attrs) do
@@ -95,6 +103,9 @@ defmodule Ankole.SignalsGateway.IngressFact do
 
   defp new(_kind, _attrs), do: {:error, :invalid_ingress_fact_attrs}
 
+  # `struct!` raises on unknown keys; a KeyError here means the constructor
+  # supplied a field this struct doesn't declare (a gateway bug), so it surfaces
+  # as an invalid-attrs error rather than crashing the ingress request.
   defp build(kind, attrs) do
     attrs =
       attrs
@@ -106,6 +117,9 @@ defmodule Ankole.SignalsGateway.IngressFact do
     KeyError -> {:error, :invalid_ingress_fact_attrs}
   end
 
+  # Normalize only the free-form JSON-bearing fields (the structured scalars are
+  # already safe). `:action` is special-cased so it is only normalized for action
+  # facts, where it actually carries a payload.
   defp normalize_durable_fields(kind, attrs) do
     attrs
     |> normalize_map_field(:channel_metadata)

--- a/app/control_plane/lib/ankole/signals_gateway/ingress_pipeline.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/ingress_pipeline.ex
@@ -5,6 +5,18 @@ defmodule Ankole.SignalsGateway.IngressPipeline do
   This module keeps the high-level flow explicit without creating a stored plan
   or a second queue: construct fact, evaluate binding filters, then let the
   caller execute the existing transactional mirror / actor input work.
+
+  Why construct-then-filter, and why inline rather than a stored plan or a
+  second queue: ingress is supposed to be a thin admission boundary. A signal
+  must be turned into a normalized fact *first* (so filters compare against
+  durable, atom-free fields, not raw provider maps), and admission must be
+  decided *before* any DB write so a rejected signal leaves no trace. The
+  remaining accept work (channel/entry mirror + actor input) already runs in one
+  Repo transaction in `SignalsGateway`; routing it through a persisted "plan" or
+  a separate job queue would buy nothing but add a second source of truth and a
+  recovery path nobody asked for. The whole ingress effect stays in the request
+  that received it, succeeds or rolls back atomically, and is easy to reason
+  about.
   """
 
   alias Ankole.SignalsGateway.BindingFilters
@@ -33,6 +45,9 @@ defmodule Ankole.SignalsGateway.IngressPipeline do
     BindingFilters.match?(filters, fact)
   end
 
+  # `kind` selects which IngressFact constructor enforces the required keys for
+  # that signal shape; an unrecognized kind is a programmer error in the gateway,
+  # not provider input, so it surfaces as a plain error tuple.
   defp construct_fact(:entry, attrs), do: IngressFact.entry(attrs)
   defp construct_fact(:lifecycle, attrs), do: IngressFact.lifecycle(attrs)
   defp construct_fact(:reaction, attrs), do: IngressFact.reaction(attrs)

--- a/app/control_plane/lib/ankole/signals_gateway/input_tombstone.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/input_tombstone.ex
@@ -1,6 +1,20 @@
 defmodule Ankole.SignalsGateway.InputTombstone do
   @moduledoc """
   Short-lived guard that prevents late receive redelivery after delete or recall.
+
+  Problem it solves: providers do not order delete/recall against the original
+  receive. A "message deleted" event can race ahead of (or arrive interleaved
+  with) a retried "message received" for the same entry, which would otherwise
+  resurrect a message the human already retracted. When the gateway processes a
+  delete/recall it drops a tombstone keyed by
+  `{agent_uid, binding_name, signal_channel_id, provider_entry_id}`; a later
+  receive for that key is dropped while the tombstone is live (see
+  `SignalsGateway.active_tombstone?/3`).
+
+  Why a TTL and not forever: this only needs to outlive provider redelivery
+  windows, not be a permanent denylist. The TTL (24h, set by the gateway) is
+  swept by the cleanup job so the table self-empties. A tombstone is a transient
+  ordering guard, not a record of the deletion.
   """
 
   use Ecto.Schema
@@ -30,6 +44,9 @@ defmodule Ankole.SignalsGateway.InputTombstone do
       primary_key: true
 
     field :provider_entry_id, :string, primary_key: true
+    # Wall-clock expiry of the guard. A receive arriving at-or-before this
+    # instant is dropped; after it, the cleanup job deletes the row and normal
+    # ingress resumes for that entry.
     field :tombstoned_until, :utc_datetime_usec
 
     timestamps()

--- a/app/control_plane/lib/ankole/signals_gateway/jobs/cleanup_expired_state.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/jobs/cleanup_expired_state.ex
@@ -1,8 +1,17 @@
 defmodule Ankole.SignalsGateway.Jobs.CleanupExpiredState do
   @moduledoc """
   Bounded recurring cleanup for SignalsGateway TTL state.
+
+  The gateway writes tombstones with a 24h expiry but never deletes them inline
+  (ingress should stay a thin write path). This Oban worker is the sweeper that
+  reclaims expired rows so the tombstone table self-empties. It is purely
+  housekeeping: dropping an already-expired tombstone changes no behavior, which
+  is why a missed or retried run is harmless.
   """
 
+  # max_attempts: 3 because the body is idempotent and best-effort — if a sweep
+  # fails it will simply run again on the next schedule; there is nothing to
+  # carefully preserve across retries.
   use Oban.Worker, queue: :default, max_attempts: 3
 
   alias Ankole.SignalsGateway
@@ -10,6 +19,8 @@ defmodule Ankole.SignalsGateway.Jobs.CleanupExpiredState do
   @doc false
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
+    # Counts are intentionally discarded; the job is for the side effect, and
+    # always reports :ok so Oban does not retry successful housekeeping.
     _counts = SignalsGateway.cleanup_expired_state()
     :ok
   end

--- a/app/control_plane/lib/ankole/signals_gateway/json_payload.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/json_payload.ex
@@ -39,6 +39,10 @@ defmodule Ankole.SignalsGateway.JsonPayload do
       when is_binary(value) or is_number(value) or is_boolean(value) or is_nil(value),
       do: {:ok, value}
 
+  # Reject non-nil/boolean atoms instead of stringifying them: an atom round-trips
+  # out of JSONB as a string, so silently accepting one would let durable state
+  # disagree with what was written. Callers must convert atoms to strings before
+  # they reach durable payloads. (true/false/nil matched above are valid JSON.)
   def normalize(value, _opts) when is_atom(value), do: {:error, :unsupported_atom}
 
   def normalize(value, opts) when is_list(value) do
@@ -118,6 +122,10 @@ defmodule Ankole.SignalsGateway.JsonPayload do
     end)
   end
 
+  # In a changeset, normalization is best-effort: rewrite the value when it can
+  # be made JSON-safe, but on failure leave the original in place so the paired
+  # `validate_change` produces a real validation error (rather than this step
+  # swallowing the bad value).
   defp normalize_change(value, opts) do
     case normalize(value, opts) do
       {:ok, normalized} -> normalized

--- a/app/control_plane/lib/ankole/signals_gateway/outbox_adapter.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/outbox_adapter.ex
@@ -12,6 +12,10 @@ defmodule Ankole.SignalsGateway.OutboxAdapter do
 
   alias Ankole.SignalsGateway.Sanitizer
 
+  # The closed universe of capabilities an adapter may advertise. The gateway
+  # checks an operation against these before dispatching (e.g. `:reply` needs
+  # `:reply_entry`). `:outbound_reconciliation` is the one that decides whether a
+  # send interrupted mid-flight can be recovered vs. marked unknown.
   @capabilities MapSet.new([
                   :post_entry,
                   :reply_entry,
@@ -24,6 +28,9 @@ defmodule Ankole.SignalsGateway.OutboxAdapter do
                   :outbound_reconciliation
                 ])
 
+  # Precomputed string→atom lookup so capabilities declared as strings (from
+  # plugin manifests / JSON) resolve to the known atoms without ever calling
+  # `String.to_atom` on external input.
   @capability_names Map.new(@capabilities, fn capability ->
                       {Atom.to_string(capability), capability}
                     end)
@@ -99,6 +106,12 @@ defmodule Ankole.SignalsGateway.OutboxAdapter do
 
   def reconcile(%__MODULE__{}, _outbox), do: {:error, :adapter_reconcile_missing}
 
+  # Coerce whatever the adapter returned into the three outcomes dispatch
+  # understands. `:unknown` is a first-class result, not an error: it means the
+  # adapter sent something but cannot confirm it landed, which the gateway turns
+  # into `unknown_after_send` rather than retrying (a retry could double-post).
+  # Any other shape is an adapter contract violation, sanitized before it is
+  # stored in the error column.
   defp normalize_adapter_result({:ok, %{} = result}), do: {:ok, result}
   defp normalize_adapter_result({:error, reason}), do: {:error, reason}
   defp normalize_adapter_result(:unknown), do: :unknown

--- a/app/control_plane/lib/ankole/signals_gateway/outbox_entry.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/outbox_entry.ex
@@ -1,6 +1,21 @@
 defmodule Ankole.SignalsGateway.OutboxEntry do
   @moduledoc """
   Durable provider-visible side-effect intent committed by an actor.
+
+  The README's split is "streaming is progress; committed work is truth" — this
+  row is the truth side for anything the agent does to the outside world (post a
+  reply, edit, delete, react, render a card). The actor runtime commits the
+  *intent* here transactionally; a separate dispatch pass actually calls the
+  provider and drives the row through its status machine:
+
+      created → sending → succeeded
+                       ↘ failed (retried with backoff until max_attempts)
+                       ↘ unknown_after_send (sent flag set but no confirmation)
+      created → unsupported (channel/adapter can't perform this operation)
+
+  Keyed by `{agent_uid, binding_name, outbound_key}`; `commit_outbox` upserts
+  `on_conflict: :nothing`, so the same `outbound_key` committed twice produces
+  exactly one provider side effect (the idempotency contract).
   """
 
   use Ecto.Schema
@@ -24,6 +39,10 @@ defmodule Ankole.SignalsGateway.OutboxEntry do
     field :binding_name, :string, primary_key: true
     field :outbound_key, :string, primary_key: true
 
+    # The provider-visible action this row represents. `source_provider_entry_id`
+    # is the entry being replied to; `target_provider_entry_id` is the entry an
+    # edit/delete/reaction acts on; `provider_entry_id` is filled in after a
+    # successful post with the id the provider assigned to the new entry.
     field :operation, Ecto.Enum,
       values: [:post, :reply, :edit, :delete, :reaction_add, :reaction_remove, :divider, :card]
 
@@ -36,18 +55,32 @@ defmodule Ankole.SignalsGateway.OutboxEntry do
     field :source_provider_entry_id, :string
     field :target_provider_entry_id, :string
     field :provider_entry_id, :string
+    # Back-references to where this side effect originated, for audit/recovery.
     field :source_actor_input_id, Ecto.UUID
     field :llm_turn_id, Ecto.UUID
     field :assistant_message_id, Ecto.UUID
     field :payload, :map, default: %{}
+    # Plain-text rendering used both as the search/mirror text and as the
+    # fallback when a rich operation (card/divider) needs a text representation.
     field :fallback_visible_text, :string
     field :idempotency_key, :string
     field :attempt_count, :integer, default: 0
+    # Retry ceiling for the backoff loop. Default 10 attempts, paired with the
+    # gateway's 5s-base / 5m-cap exponential schedule, bounds a stuck send to
+    # roughly the cap times a handful of attempts before it stops retrying.
     field :max_attempts, :integer, default: 10
     field :last_attempted_at, :utc_datetime_usec
     field :last_error, :map, default: %{}
+    # Set the moment dispatch tells the adapter to send. If the node restarts
+    # while still in `:sending`, this timestamp is the signal that a provider
+    # call may already be in flight, triggering reconcile-or-mark-unknown
+    # recovery instead of a blind resend (see in_flight_recovery_action/2).
     field :platform_send_started_at, :utc_datetime_usec
+    # When a `:failed` row becomes eligible for its next attempt; nil once
+    # attempts are exhausted.
     field :next_attempt_at, :utc_datetime_usec
+    # Adapter-supplied breadcrumb carried across a reconcile (e.g. a provider
+    # idempotency token) so recovery can confirm a prior send.
     field :recovery_state, :map, default: %{}
 
     timestamps()

--- a/app/control_plane/lib/ankole/signals_gateway/sanitizer.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/sanitizer.ex
@@ -7,6 +7,11 @@ defmodule Ankole.SignalsGateway.Sanitizer do
   repaired here.
   """
 
+  # Bounds so a hostile or pathological provider payload can't blow up an error
+  # log or the `last_error` JSON column: stop recursing past 6 levels, keep at
+  # most 50 entries of any map/list, and clip any string to 1000 chars. These
+  # are previews for humans, not lossless captures — truncation is expected and
+  # marked with `__truncated__`.
   @default_max_depth 6
   @default_max_items 50
   @default_max_string 1_000
@@ -135,6 +140,10 @@ defmodule Ankole.SignalsGateway.Sanitizer do
 
   defp key_to_string(key, limits), do: bounded_inspect(key, limits.max_string)
 
+  # Redaction is by key name, not value content. Normalize separators so
+  # "Set-Cookie", "set.cookie", and "set_cookie" all match, and use suffix rules
+  # (`*_token`, `*_secret`, …) to catch provider-prefixed variants like
+  # "lark_app_secret" without enumerating every provider.
   defp sensitive_key?(key) do
     normalized =
       key

--- a/app/control_plane/lib/ankole/signals_gateway/signal_binding.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/signal_binding.ex
@@ -1,6 +1,14 @@
 defmodule Ankole.SignalsGateway.SignalBinding do
   @moduledoc """
   Per-agent signal ingress route configured by an operator.
+
+  A binding is the unit of "this agent listens to this provider source": it ties
+  an `{agent_uid, name}` to an `adapter` plus a `config_ref` (the provider
+  credential/config the adapter resolves separately). It also carries the
+  admission `filters` (see `BindingFilters`) and the policy for unaddressed group
+  messages. Every `emit_*` call in `SignalsGateway` is routed by looking up the
+  binding for an `{agent_uid, binding_name}` pair, so the binding is effectively
+  the gateway's routing key.
   """
 
   use Ecto.Schema
@@ -24,13 +32,23 @@ defmodule Ankole.SignalsGateway.SignalBinding do
     field :name, :string, primary_key: true
     field :adapter, :string
     field :config_ref, :string
+    # v1 admission filter, stored as the `{"eq" => ...}` JSON object that
+    # BindingFilters understands; empty object means accept everything.
     field :filters, :map, default: %{}
 
+    # What the agent does with a group message that does NOT explicitly address
+    # it: stay out (:ignore), just mirror it for context (:record_only), or be
+    # allowed to jump in (:may_intervene → ambient "may_intervene" actor input).
+    # Default :ignore so a freshly bound agent is silent in shared rooms until an
+    # operator opts into more.
     field :unaddressed_group_message_policy, Ecto.Enum,
       values: [:ignore, :record_only, :may_intervene],
       default: :ignore
 
     field :enabled, :boolean, default: true
+    # When set on an enabled binding, ingress is refused with this reason instead
+    # of accepted — lets an operator soft-disable a route (e.g. revoked provider
+    # creds) without deleting it. See SignalsGateway.get_binding/2.
     field :unavailable_reason, :string
 
     timestamps()

--- a/app/control_plane/lib/ankole/signals_gateway/signal_channel.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/signal_channel.ex
@@ -1,6 +1,14 @@
 defmodule Ankole.SignalsGateway.SignalChannel do
   @moduledoc """
   Latest observed provider channel mirror.
+
+  A "channel" is the provider-side container an entry lives in (an IM DM/group, a
+  webhook endpoint, an issue, an alert stream). This row is a pure external-fact
+  mirror: it records what the provider currently looks like, separate from any
+  agent execution. `reply_mode` (how the agent is allowed to respond — channel
+  post vs. threaded entry reply) is read by the outbox to choose a send
+  operation. Keyed by the provider-native channel id, so writes upsert rather
+  than insert per event.
   """
 
   use Ecto.Schema

--- a/app/control_plane/lib/ankole/signals_gateway/signal_entry.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/signal_entry.ex
@@ -1,6 +1,18 @@
 defmodule Ankole.SignalsGateway.SignalEntry do
   @moduledoc """
   Latest observed provider entry mirror keyed by channel and provider entry id.
+
+  An "entry" is a single provider message/post. This row mirrors the latest
+  observed state of that external fact (text, attachments, reactions, author) so
+  Ankole can render context and reconcile edits/deletes — it is NOT the agent's
+  actor input or conversation turn, which live elsewhere. The gateway also writes
+  this mirror for its own outbound posts after a successful send, so an entry the
+  agent produced and an entry a human produced share one shape.
+
+  `search_text` / `metadata_text` / `content_hash` are denormalized for search
+  and change detection; `document_id` is a stable per-entry digest. The
+  composite `{signal_channel_id, provider_entry_id}` primary key is what makes
+  re-delivery idempotent (upsert the same entry instead of duplicating it).
   """
 
   use Ecto.Schema


### PR DESCRIPTION
Add WHY-focused comments across the SignalsGateway ingress/outbox subsystem for a first-time reader: the construct-then-filter inline pipeline (no stored plan / second queue), the outbox status machine with exponential backoff (5s base / 5m cap, 10 attempts) and in-flight restart recovery, tombstone TTL (24h) and its interaction with delete/recall, the ambient batch sliding window and 60s hard cap, the ambient recall row cap (80), and the v1 exact-match binding filters.

Comment-only: no code, logic, control flow, names, or ordering changed.