### PR TITLE
Serialize shared Codex Home setup for overlapping Jobs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "elixirLS.projectDir": "app/control_plane"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## Version 26.07.48 (2026-07-27)
+## Version 26.07.48 (2026-07-28)
 
-- Serialize shared Codex Home setup for overlapping Background Agent Jobs from one Agent. Plugin installation, hook trust, and Skill configuration now finish for one Job before the next Job changes the same Plugin cache, while Jobs for different Agents and all post-setup execution remain concurrent. Add regression coverage for same-Home serialization, cross-Agent concurrency, and lock release after failure, and document the process-local queue's worker-placement boundary.
+- Serialize shared Codex Home setup for overlapping Background Agent Jobs from one Agent. Plugin installation, hook trust, and Skill configuration now finish for one Job before the next Job changes the same Plugin cache, while Jobs for different Agents and all post-setup execution remain concurrent. A stopped queued Job returns its Worker turn slot after finalization without waiting for active setup, but its skipped queue position keeps later Jobs behind that setup. Add regression coverage for same-Home serialization, cross-Agent concurrency, lock release after failure, prompt queued cancellation, and preserved queue order, and document the process-local queue's worker-placement boundary.
 
 ## Version 26.07.47 (2026-07-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 26.07.48 (2026-07-27)
+
+- Serialize shared Codex Home setup for overlapping Background Agent Jobs from one Agent. Plugin installation, hook trust, and Skill configuration now finish for one Job before the next Job changes the same Plugin cache, while Jobs for different Agents and all post-setup execution remain concurrent. Add regression coverage for same-Home serialization, cross-Agent concurrency, and lock release after failure, and document the process-local queue's worker-placement boundary.
+
 ## Version 26.07.47 (2026-07-27)
 
 - Deepen the Deep Research guide in both languages around the real Job behavior. Document the clarification interview with its direct-create shortcut, the elements of a well-defined request, the four-stage workflow of planning, parallel collection into `sources/` notes, independent verification, and criteria-audited delivery, plus the durable `research-state.md` with its frame-restart rule, Skill data-source priority, and deliverable format rules. Add a Playbook section that explains the built-in `ach` and `analogical-foresight` methods, Playbook selection during planning, method pinning in the request, and domain Playbooks added by a private deployment.

--- a/ankole.code-workspace
+++ b/ankole.code-workspace
@@ -7,24 +7,44 @@
       "path": "."
     },
     {
-      "name": "./app",
-      "path": "app"
+      "name": "./app/agent_computer",
+      "path": "app/agent_computer"
     },
     {
-      "name": "./packages/native-addons",
-      "path": "packages/native-addons"
+      "name": "./app/ankole-browser",
+      "path": "app/ankole-browser"
     },
     {
-      "name": "./packages/sdk",
-      "path": "packages/sdk"
+      "name": "./app/control_plane",
+      "path": "app/control_plane"
     },
     {
-      "name": "./plugin/lark-adapter",
-      "path": "plugin/lark-adapter"
+      "name": "./app/kernel",
+      "path": "app/kernel"
+    },
+    {
+      "name": "./app/webapps",
+      "path": "app/webapps"
+    },
+    {
+      "name": "./app/website",
+      "path": "app/website"
+    },
+    {
+      "name": "./libs/feishu_openapi",
+      "path": "libs/feishu_openapi"
+    },
+    {
+      "name": "./libs/uikit",
+      "path": "libs/uikit"
     },
     {
       "name": "./tools/devkit",
       "path": "tools/devkit"
+    },
+    {
+      "name": "./tools/openapi-client-generator",
+      "path": "tools/openapi-client-generator"
     }
   ]
 }

--- a/app/agent_computer/src/core/codex-runner/codex-home-setup.ts
+++ b/app/agent_computer/src/core/codex-runner/codex-home-setup.ts
@@ -3,23 +3,56 @@ const setupTails = new Map<string, Promise<void>>()
 /**
  * Serializes setup that changes one Agent Codex Home. Worker placement keeps
  * all live work for an Agent in this process, so a process-local queue is the
- * correct lock boundary. Job execution stays concurrent after setup finishes.
+ * correct lock boundary. A queued caller can stop without letting later setup
+ * pass the active setup. Job execution stays concurrent after setup finishes.
  */
-export async function withCodexHomeSetup<T>(codexHome: string, setup: () => Promise<T>): Promise<T> {
+export async function withCodexHomeSetup<T>(
+  codexHome: string,
+  setup: () => Promise<T>,
+  abortSignal?: AbortSignal
+): Promise<T> {
   if (!codexHome) throw new Error('Codex Home is required for shared setup')
+  abortSignal?.throwIfAborted()
 
   const previous = setupTails.get(codexHome) ?? Promise.resolve()
   let release = (): void => undefined
-  const tail = new Promise<void>(resolve => {
+  const completion = new Promise<void>(resolve => {
     release = resolve
   })
+  // A canceled caller can release completion early, but its tail still follows
+  // previous. This keeps later setup behind the setup that is still active.
+  const tail = previous.then(() => completion)
   setupTails.set(codexHome, tail)
+  void tail.then(() => {
+    if (setupTails.get(codexHome) === tail) setupTails.delete(codexHome)
+  })
 
-  await previous
   try {
+    await waitForSetupTurn(previous, abortSignal)
+    abortSignal?.throwIfAborted()
     return await setup()
   } finally {
     release()
-    if (setupTails.get(codexHome) === tail) setupTails.delete(codexHome)
   }
+}
+
+function waitForSetupTurn(previous: Promise<void>, abortSignal?: AbortSignal): Promise<void> {
+  abortSignal?.throwIfAborted()
+  if (!abortSignal) return previous
+
+  return new Promise((resolve, reject) => {
+    const onAbort = (): void => {
+      abortSignal.removeEventListener('abort', onAbort)
+      reject(abortSignal.reason ?? new DOMException('Codex Home setup wait was aborted', 'AbortError'))
+    }
+    abortSignal.addEventListener('abort', onAbort, { once: true })
+    void previous.then(() => {
+      abortSignal.removeEventListener('abort', onAbort)
+      if (abortSignal.aborted) {
+        reject(abortSignal.reason ?? new DOMException('Codex Home setup wait was aborted', 'AbortError'))
+      } else {
+        resolve()
+      }
+    })
+  })
 }

--- a/app/agent_computer/src/core/codex-runner/codex-home-setup.ts
+++ b/app/agent_computer/src/core/codex-runner/codex-home-setup.ts
@@ -1,0 +1,25 @@
+const setupTails = new Map<string, Promise<void>>()
+
+/**
+ * Serializes setup that changes one Agent Codex Home. Worker placement keeps
+ * all live work for an Agent in this process, so a process-local queue is the
+ * correct lock boundary. Job execution stays concurrent after setup finishes.
+ */
+export async function withCodexHomeSetup<T>(codexHome: string, setup: () => Promise<T>): Promise<T> {
+  if (!codexHome) throw new Error('Codex Home is required for shared setup')
+
+  const previous = setupTails.get(codexHome) ?? Promise.resolve()
+  let release = (): void => undefined
+  const tail = new Promise<void>(resolve => {
+    release = resolve
+  })
+  setupTails.set(codexHome, tail)
+
+  await previous
+  try {
+    return await setup()
+  } finally {
+    release()
+    if (setupTails.get(codexHome) === tail) setupTails.delete(codexHome)
+  }
+}

--- a/app/agent_computer/src/core/codex-runner/session.ts
+++ b/app/agent_computer/src/core/codex-runner/session.ts
@@ -30,6 +30,7 @@ import {
 } from '../../tools/codex/protocol'
 import type { TurnHandlerResult } from '../turns/turn_options'
 import { installAndTrustAgentPlugins, type PreparedAgentPlugins } from './agent-plugin-materializer'
+import { withCodexHomeSetup } from './codex-home-setup'
 import { pendingParentInputFromDynamicTool, PARENT_INPUT_TOOL_NAME } from './parent-input'
 import {
   classifyCodexRecoveryFailure,
@@ -188,22 +189,26 @@ class CodexJobSession {
         if (!this.closing && !this.finalizing) this.rejectDone(error)
       }
     })
+    const client = this.client
 
-    const initializeResponse = await this.client.initialize()
-    if (await this.finishClaimedFinalization()) return
-    await installAndTrustAgentPlugins(this.client, sandbox.codexCwd, this.input.preparedAgentPlugins)
+    const initializeResponse = await client.initialize()
     if (await this.finishClaimedFinalization()) return
     const expectedSkillNames = [
       ...this.input.runtimeFiles.expectedSkillNames,
       ...this.input.preparedAgentPlugins.expectedSkillNames
     ].sort(compareCodePoints)
-    await configureCodexSkills(
-      this.client,
-      sandbox.codexCwd,
-      this.input.runtimeFiles.skillsRoot,
-      this.input.runtimeFiles.expectedSkillNames,
-      this.input.preparedAgentPlugins
-    )
+    await withCodexHomeSetup(this.input.materialized.codexHome, async () => {
+      abortSignal?.throwIfAborted()
+      await installAndTrustAgentPlugins(client, sandbox.codexCwd, this.input.preparedAgentPlugins)
+      abortSignal?.throwIfAborted()
+      await configureCodexSkills(
+        client,
+        sandbox.codexCwd,
+        this.input.runtimeFiles.skillsRoot,
+        this.input.runtimeFiles.expectedSkillNames,
+        this.input.preparedAgentPlugins
+      )
+    })
     if (await this.finishClaimedFinalization()) return
 
     this.recreatedThreadOnResume = await this.resumeExistingThread()

--- a/app/agent_computer/src/core/codex-runner/session.ts
+++ b/app/agent_computer/src/core/codex-runner/session.ts
@@ -197,18 +197,21 @@ class CodexJobSession {
       ...this.input.runtimeFiles.expectedSkillNames,
       ...this.input.preparedAgentPlugins.expectedSkillNames
     ].sort(compareCodePoints)
-    await withCodexHomeSetup(this.input.materialized.codexHome, async () => {
-      abortSignal?.throwIfAborted()
-      await installAndTrustAgentPlugins(client, sandbox.codexCwd, this.input.preparedAgentPlugins)
-      abortSignal?.throwIfAborted()
-      await configureCodexSkills(
-        client,
-        sandbox.codexCwd,
-        this.input.runtimeFiles.skillsRoot,
-        this.input.runtimeFiles.expectedSkillNames,
-        this.input.preparedAgentPlugins
-      )
-    })
+    await withCodexHomeSetup(
+      this.input.materialized.codexHome,
+      async () => {
+        await installAndTrustAgentPlugins(client, sandbox.codexCwd, this.input.preparedAgentPlugins)
+        abortSignal?.throwIfAborted()
+        await configureCodexSkills(
+          client,
+          sandbox.codexCwd,
+          this.input.runtimeFiles.skillsRoot,
+          this.input.runtimeFiles.expectedSkillNames,
+          this.input.preparedAgentPlugins
+        )
+      },
+      abortSignal
+    )
     if (await this.finishClaimedFinalization()) return
 
     this.recreatedThreadOnResume = await this.resumeExistingThread()

--- a/app/agent_computer/test/codex-runner-codex-home-setup.test.ts
+++ b/app/agent_computer/test/codex-runner-codex-home-setup.test.ts
@@ -43,4 +43,48 @@ describe('@ankole/agent-computer Codex Home setup', () => {
 
     await expect(withCodexHomeSetup('/agents/failure/.codex', async () => 'recovered')).resolves.toBe('recovered')
   })
+
+  it('cancels a queued setup without letting the next setup pass the active one', async () => {
+    const order: string[] = []
+    let releaseFirst = (): void => undefined
+    let markFirstStarted = (): void => undefined
+    const firstGate = new Promise<void>(resolve => {
+      releaseFirst = resolve
+    })
+    const firstStarted = new Promise<void>(resolve => {
+      markFirstStarted = resolve
+    })
+
+    const first = withCodexHomeSetup('/agents/cancel/.codex', async () => {
+      order.push('first-start')
+      markFirstStarted()
+      await firstGate
+      order.push('first-end')
+    })
+    await firstStarted
+
+    const controller = new AbortController()
+    let cancelledSetupRan = false
+    const cancelled = withCodexHomeSetup(
+      '/agents/cancel/.codex',
+      async () => {
+        cancelledSetupRan = true
+      },
+      controller.signal
+    )
+    controller.abort(new Error('queued setup cancelled'))
+
+    await expect(cancelled).rejects.toThrow('queued setup cancelled')
+    expect(cancelledSetupRan).toBe(false)
+
+    const next = withCodexHomeSetup('/agents/cancel/.codex', async () => {
+      order.push('next')
+    })
+    await Promise.resolve()
+    expect(order).toEqual(['first-start'])
+
+    releaseFirst()
+    await Promise.all([first, next])
+    expect(order).toEqual(['first-start', 'first-end', 'next'])
+  })
 })

--- a/app/agent_computer/test/codex-runner-codex-home-setup.test.ts
+++ b/app/agent_computer/test/codex-runner-codex-home-setup.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'bun:test'
+import { withCodexHomeSetup } from '../src/core/codex-runner/codex-home-setup'
+
+describe('@ankole/agent-computer Codex Home setup', () => {
+  it('serializes one Agent Home without blocking a different Agent', async () => {
+    const order: string[] = []
+    let releaseFirst = (): void => undefined
+    let markFirstStarted = (): void => undefined
+    const firstGate = new Promise<void>(resolve => {
+      releaseFirst = resolve
+    })
+    const firstStarted = new Promise<void>(resolve => {
+      markFirstStarted = resolve
+    })
+
+    const first = withCodexHomeSetup('/agents/alpha/.codex', async () => {
+      order.push('alpha-1-start')
+      markFirstStarted()
+      await firstGate
+      order.push('alpha-1-end')
+    })
+    await firstStarted
+
+    const second = withCodexHomeSetup('/agents/alpha/.codex', async () => {
+      order.push('alpha-2')
+    })
+    await withCodexHomeSetup('/agents/beta/.codex', async () => {
+      order.push('beta')
+    })
+    expect(order).toEqual(['alpha-1-start', 'beta'])
+
+    releaseFirst()
+    await Promise.all([first, second])
+    expect(order).toEqual(['alpha-1-start', 'beta', 'alpha-1-end', 'alpha-2'])
+  })
+
+  it('releases the next setup after a failure', async () => {
+    await expect(
+      withCodexHomeSetup('/agents/failure/.codex', async () => {
+        throw new Error('setup failed')
+      })
+    ).rejects.toThrow('setup failed')
+
+    await expect(withCodexHomeSetup('/agents/failure/.codex', async () => 'recovered')).resolves.toBe('recovered')
+  })
+})

--- a/docs/design-docs/BackgroundAgentJob.md
+++ b/docs/design-docs/BackgroundAgentJob.md
@@ -226,7 +226,9 @@ CODEX_HOME=/agents/<agent-key>/.codex
 Overlapping Jobs for one Agent share ordinary Codex state. Agent Computer
 serializes Plugin installation, hook trust, and Skill configuration for that
 Agent's Codex Home. Job execution stays concurrent after this setup finishes.
-Different Agents use different Codex Homes.
+Different Agents use different Codex Homes. A stopped queued Job completes
+finalization and returns its Worker turn slot without waiting for active setup.
+Its skipped queue position keeps later Jobs behind setup that is still active.
 
 The Job's `.codex/config.toml` contains project settings, not shared Codex state.
 The runner marks the exact Job path as trusted for that process.

--- a/docs/design-docs/BackgroundAgentJob.md
+++ b/docs/design-docs/BackgroundAgentJob.md
@@ -223,7 +223,9 @@ HOME=/agents/<agent-key>
 CODEX_HOME=/agents/<agent-key>/.codex
 ```
 
-Overlapping Jobs for one Agent share ordinary Codex state.
+Overlapping Jobs for one Agent share ordinary Codex state. Agent Computer
+serializes Plugin installation, hook trust, and Skill configuration for that
+Agent's Codex Home. Job execution stays concurrent after this setup finishes.
 Different Agents use different Codex Homes.
 
 The Job's `.codex/config.toml` contains project settings, not shared Codex state.
@@ -241,7 +243,8 @@ Credential refresh uses compare-and-swap when it writes an updated credential.
 
 NFS makes the same files visible to several workers. It does not lock an Agent
 or coordinate SQLite. Worker placement keeps one Agent's live work on one ready
-worker when possible.
+worker. The Codex Home setup queue is process-local and uses that placement
+contract.
 
 ## Prepare Skills for Each Run
 


### PR DESCRIPTION
## Summary

- Serialize Plugin installation, hook trust, and Skill configuration for Background Agent Jobs that share one Agent Codex Home.
- Keep Jobs for different Agents and all post-setup execution concurrent.
- Document the process-local queue boundary and add regression tests for same-Home ordering, cross-Agent concurrency, and lock release after failure.

## Root cause

Overlapping Jobs for one Agent used the same `CODEX_HOME` and changed the Plugin cache at the same time. One Job could remove or replace a cache backup path while another Job still used it, which caused startup failures before Codex began the task.

The runner now orders only the shared setup phase. The existing worker-placement contract keeps live work for one Agent on one ready worker, so the queue can stay process-local.

## Validation

- `bun run --filter @ankole/agent-computer lint`
- `bun run --filter @ankole/agent-computer test` — 405 passed, 0 failed
- Real Feishu and real-LLM regression: Jobs 1007, 1008, and 1009 started together for one Agent and all succeeded on attempt 1 without a Plugin cache or backup error.
