### PR TITLE
Keep AIGateway Codex tools portable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 26.07.50 (2026-07-29)
+
+- Keep AIGateway Background Agent Jobs on a portable Codex tool protocol. The Agent Codex Home now derives a model catalog from the installed Codex binary and keeps its model instructions and other metadata, but disables Responses Lite, client tool search, code-only tool mode, and native multi-Agent selection. Those Codex-backend features hid configured MCP tools from an OpenRouter Chat Completions provider and let financial-data Jobs finish without a data call. A Job project can no longer replace the runtime-owned catalog, and setup fails with a clear error when Codex returns an unreadable, empty, or invalid catalog. Cover preserved instructions, the portable overrides, official-subscription mode, invalid catalogs, and project override removal, and record the provider boundary in the AIGateway and Background Agent Job design documents.
+
 ## Version 26.07.49 (2026-07-28)
 
 - Wait out an upstream outage instead of failing a Background Agent Job inside it. A retryable worker Turn failure on a Job session now waits on a fixed ladder from one minute to two hours between execution attempts, so the five-attempt budget spans roughly 3.7 hours; the previous 5–120-second exponential backoff let a production Job burn all attempts inside one 47-minute provider outage and fail. Ordinary actor events keep the short backoff because a user waits on them. Cover the ladder in the Job dispatch exhaustion test and record the wait contract in the Background Agent Job design document.

--- a/app/agent_computer/src/core/codex-runner/project-config.ts
+++ b/app/agent_computer/src/core/codex-runner/project-config.ts
@@ -35,6 +35,7 @@ function applyRuntimeConfig(config: TomlTable, runtime: CodexRuntimeConfig): voi
   const profile = runtime.modelProfile
 
   config.model = profile.model
+  delete config.model_catalog_json
   if (profile.modelReasoningEffort) config.model_reasoning_effort = profile.modelReasoningEffort
   else delete config.model_reasoning_effort
 

--- a/app/agent_computer/src/tools/codex/config.ts
+++ b/app/agent_computer/src/tools/codex/config.ts
@@ -13,20 +13,32 @@ export type MaterializedCodexConfig = {
 }
 
 const AIGATEWAY_MODEL_BINDING_ENV = 'ANKOLE_AIGATEWAY_MODEL_BINDING'
+const AIGATEWAY_MODEL_CATALOG_FILE = 'aigateway-model-catalog.json'
+const bundledModelCatalogCache = new Map<string, string>()
 
-export function materializeCodexConfig(input: {
-  agentsRoot: string
-  agentUID: string
-  runtime: CodexRuntimeConfig
-}): MaterializedCodexConfig {
+type MaterializeCodexConfigDependencies = {
+  readBundledModelCatalog?: () => string
+}
+
+export function materializeCodexConfig(
+  input: {
+    agentsRoot: string
+    agentUID: string
+    runtime: CodexRuntimeConfig
+  },
+  dependencies: MaterializeCodexConfigDependencies = {}
+): MaterializedCodexConfig {
   const paths = agentHomePaths(input.agentsRoot, input.agentUID)
   mkdirSync(paths.codexHome, { recursive: true, mode: 0o700 })
   chmodSync(paths.codexHome, 0o700)
 
   const configPath = join(paths.codexHome, 'config.toml')
-  const common = codexConfigToml(undefined)
+  const common = codexConfigToml(undefined, undefined)
   if (input.runtime.mode === 'aigateway') {
-    atomicWriteIfChanged(configPath, codexConfigToml(input.runtime.aiGatewayKey.baseUrl))
+    const modelCatalogPath = join(paths.codexHome, AIGATEWAY_MODEL_CATALOG_FILE)
+    const bundledCatalog = (dependencies.readBundledModelCatalog ?? readBundledModelCatalog)()
+    atomicWriteIfChanged(modelCatalogPath, aigatewayModelCatalogJSON(bundledCatalog))
+    atomicWriteIfChanged(configPath, codexConfigToml(input.runtime.aiGatewayKey.baseUrl, modelCatalogPath))
   } else {
     atomicWriteIfChanged(configPath, common)
   }
@@ -69,7 +81,7 @@ export function codexConfigCLIOverrides(projectRoot: string): string[] {
   ]
 }
 
-function codexConfigToml(baseURL: string | undefined): string {
+function codexConfigToml(baseURL: string | undefined, modelCatalogPath: string | undefined): string {
   const common = `approval_policy = "never"
 sandbox_mode = "danger-full-access"
 cli_auth_credentials_store = "file"
@@ -91,9 +103,11 @@ enabled = true
 hide_spawn_agent_metadata = true
 `
   if (!baseURL) return common
+  if (!modelCatalogPath) throw new Error('AIGateway Codex configuration requires a model catalog path')
 
   const normalizedBaseURL = baseURL.replace(/\/+$/, '')
   return `model_provider = "ankole_aigateway"
+model_catalog_json = ${JSON.stringify(modelCatalogPath)}
 model_auto_compact_token_limit = 100000
 ${common}
 
@@ -105,6 +119,59 @@ env_http_headers = { "x-ankole-aigateway-model-binding" = "${AIGATEWAY_MODEL_BIN
 wire_api = "responses"
 supports_websockets = true
 `
+}
+
+function readBundledModelCatalog(): string {
+  const binary = process.env.ANKOLE_CODEX_BINARY || 'codex'
+  const cached = bundledModelCatalogCache.get(binary)
+  if (cached) return cached
+
+  const result = Bun.spawnSync([binary, 'debug', 'models', '--bundled'], {
+    stdout: 'pipe',
+    stderr: 'pipe'
+  })
+  if (result.exitCode !== 0) {
+    const detail = result.stderr.toString().trim().replace(/\s+/g, ' ').slice(0, 512)
+    throw new Error(`Codex could not read its bundled model catalog${detail ? `: ${detail}` : ''}`)
+  }
+
+  const catalog = result.stdout.toString()
+  if (!catalog.trim()) throw new Error('Codex returned an empty bundled model catalog')
+  bundledModelCatalogCache.set(binary, catalog)
+  return catalog
+}
+
+function aigatewayModelCatalogJSON(source: string): string {
+  let catalog: unknown
+  try {
+    catalog = JSON.parse(source)
+  } catch (error) {
+    throw new Error(
+      `Codex returned an invalid bundled model catalog: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+  if (!isJSONObject(catalog) || !Array.isArray(catalog.models) || catalog.models.length === 0) {
+    throw new Error('Codex bundled model catalog must contain at least one model')
+  }
+
+  const models = catalog.models.map((model, index) => {
+    if (!isJSONObject(model) || typeof model.slug !== 'string' || !model.slug) {
+      throw new Error(`Codex bundled model catalog contains an invalid model at index ${index}`)
+    }
+    return {
+      ...model,
+      use_responses_lite: false,
+      supports_search_tool: false,
+      tool_mode: 'direct',
+      multi_agent_version: null
+    }
+  })
+
+  return `${JSON.stringify({ ...catalog, models }, null, 2)}\n`
+}
+
+function isJSONObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
 }
 
 function encodeAIGatewayModelBinding(runtime: Extract<CodexRuntimeConfig, { mode: 'aigateway' }>): string {

--- a/app/agent_computer/test/codex-config.test.ts
+++ b/app/agent_computer/test/codex-config.test.ts
@@ -39,6 +39,23 @@ function aigatewayRuntime(): CodexRuntimeConfig {
   }
 }
 
+function bundledModelCatalog(): string {
+  return JSON.stringify({
+    models: [
+      {
+        slug: 'gpt-5.6-sol',
+        display_name: 'GPT-5.6 Sol',
+        base_instructions: 'PRESERVED_BASE_INSTRUCTIONS',
+        model_messages: { instructions_template: 'PRESERVED_MODEL_INSTRUCTIONS' },
+        use_responses_lite: true,
+        supports_search_tool: true,
+        tool_mode: 'code_mode_only',
+        multi_agent_version: 'v2'
+      }
+    ]
+  })
+}
+
 describe('@ankole/agent-computer Codex config', () => {
   it('shares the official Codex Home at Agent scope without CODEX_SQLITE_HOME', () => {
     const agentsRoot = mkdtempSync(join(tmpdir(), 'ankole-codex-config-'))
@@ -86,12 +103,16 @@ describe('@ankole/agent-computer Codex config', () => {
   it('keeps the shared AIGateway provider model-free and sends the frozen binding through one process header', () => {
     const agentsRoot = mkdtempSync(join(tmpdir(), 'ankole-codex-config-aigateway-'))
     try {
-      const materialized = materializeCodexConfig({
-        agentsRoot,
-        agentUID: 'agent-1',
-        runtime: aigatewayRuntime()
-      })
+      const materialized = materializeCodexConfig(
+        {
+          agentsRoot,
+          agentUID: 'agent-1',
+          runtime: aigatewayRuntime()
+        },
+        { readBundledModelCatalog: bundledModelCatalog }
+      )
       const config = parse(readFileSync(join(materialized.codexHome, 'config.toml'), 'utf8')) as Record<string, any>
+      const modelCatalog = JSON.parse(readFileSync(config.model_catalog_json, 'utf8')) as Record<string, any>
       const binding = JSON.parse(
         Buffer.from(materialized.env.ANKOLE_AIGATEWAY_MODEL_BINDING!, 'base64url').toString('utf8')
       )
@@ -100,6 +121,18 @@ describe('@ankole/agent-computer Codex config', () => {
       expect(config.model_provider).toBe('ankole_aigateway')
       expect(config.model_reasoning_effort).toBeUndefined()
       expect(config.model_auto_compact_token_limit).toBe(100000)
+      expect(config.model_catalog_json).toBe(join(materialized.codexHome, 'aigateway-model-catalog.json'))
+      expect(modelCatalog.models).toEqual([
+        expect.objectContaining({
+          slug: 'gpt-5.6-sol',
+          base_instructions: 'PRESERVED_BASE_INSTRUCTIONS',
+          model_messages: { instructions_template: 'PRESERVED_MODEL_INSTRUCTIONS' },
+          use_responses_lite: false,
+          supports_search_tool: false,
+          tool_mode: 'direct',
+          multi_agent_version: null
+        })
+      ])
       expect(config.model_providers.ankole_aigateway.env_http_headers).toEqual({
         'x-ankole-aigateway-model-binding': 'ANKOLE_AIGATEWAY_MODEL_BINDING'
       })
@@ -121,8 +154,23 @@ describe('@ankole/agent-computer Codex config', () => {
       expect(officialConfig.model).toBeUndefined()
       expect(officialConfig.model_provider).toBeUndefined()
       expect(officialConfig.model_providers).toBeUndefined()
+      expect(officialConfig.model_catalog_json).toBeUndefined()
       expect(officialConfig.model_auto_compact_token_limit).toBeUndefined()
       expect(official.env.ANKOLE_AIGATEWAY_MODEL_BINDING).toBeUndefined()
+    } finally {
+      rmSync(agentsRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects an invalid bundled model catalog for AIGateway', () => {
+    const agentsRoot = mkdtempSync(join(tmpdir(), 'ankole-codex-config-invalid-catalog-'))
+    try {
+      expect(() =>
+        materializeCodexConfig(
+          { agentsRoot, agentUID: 'agent-1', runtime: aigatewayRuntime() },
+          { readBundledModelCatalog: () => '{"models":[]}' }
+        )
+      ).toThrow('must contain at least one model')
     } finally {
       rmSync(agentsRoot, { recursive: true, force: true })
     }

--- a/app/agent_computer/test/codex-runner-project-config.test.ts
+++ b/app/agent_computer/test/codex-runner-project-config.test.ts
@@ -46,6 +46,7 @@ describe('@ankole/agent-computer Codex job project config', () => {
       configPath,
       [
         'model = "plugin-model"',
+        'model_catalog_json = "/plugin/models.json"',
         'model_reasoning_effort = "medium"',
         'web_search = "live"',
         '',
@@ -84,6 +85,7 @@ describe('@ankole/agent-computer Codex job project config', () => {
 
       expect(materialized).toEqual({ path: configPath })
       expect(config.model).toBe('gpt-5.6-sol')
+      expect(config.model_catalog_json).toBeUndefined()
       expect(config.model_provider).toBeUndefined()
       expect(config.model_reasoning_effort).toBe('xhigh')
       expect(config.web_search).toBe('disabled')

--- a/app/agent_computer/test/codex-runner.test.ts
+++ b/app/agent_computer/test/codex-runner.test.ts
@@ -866,6 +866,18 @@ if (process.argv.includes('--version')) {
   console.log('codex-cli 0.145.0')
   process.exit(0)
 }
+if (process.argv[2] === 'debug' && process.argv[3] === 'models' && process.argv.includes('--bundled')) {
+  console.log(JSON.stringify({
+    models: [{
+      slug: 'gpt-5.6-sol',
+      use_responses_lite: true,
+      supports_search_tool: true,
+      tool_mode: 'code_mode_only',
+      multi_agent_version: 'v2'
+    }]
+  }))
+  process.exit(0)
+}
 writeFileSync('browser-env.json', JSON.stringify({
   ANKOLE_BROWSER_SOCKET: process.env.ANKOLE_BROWSER_SOCKET,
   ANKOLE_BROWSER_ROUTE: process.env.ANKOLE_BROWSER_ROUTE,

--- a/docs/design-docs/AIGateway.md
+++ b/docs/design-docs/AIGateway.md
@@ -78,9 +78,13 @@ selector, provider options, and parallel-tool-call capability in the
 `x-ankole-aigateway-model-binding` provider header. AIGateway replaces the
 Codex-facing model name with the selector before provider resolution and uses
 the stored provider options as request defaults. It sets `parallel_tool_calls`
-from the stored provider capability. An explicit Codex Responses Lite marker in
-the HTTP header or WebSocket client metadata keeps this value false. The
-`coding` profile name never enters Codex as a model name.
+from the stored provider capability. The Agent Codex Home derives an AIGateway
+model catalog from the catalog in the installed Codex binary. It keeps the
+model instructions and other model metadata, but disables Responses Lite,
+client tool search, code-only tool mode, and native multi-Agent selection.
+These features require the ChatGPT Codex backend and do not form a portable
+provider contract. The `coding` profile name never enters Codex as a model
+name.
 
 An official-subscription Job does not use this binding. Agent Computer loads its
 stored model settings and native `auth.json` credentials instead.

--- a/docs/design-docs/BackgroundAgentJob.md
+++ b/docs/design-docs/BackgroundAgentJob.md
@@ -249,8 +249,12 @@ reasoning effort. The runner never sends `coding` to Codex. It attaches the
 Job's exact provider and model selector, all stored provider options, and the
 stored parallel-tool-call capability to each AIGateway request. AIGateway
 applies that binding before it resolves the provider. It sets
-`parallel_tool_calls` from the provider capability unless Codex marks the
-request as Responses Lite.
+`parallel_tool_calls` from the provider capability. The Agent Codex Home also
+derives an AIGateway model catalog from the installed Codex binary. It keeps
+the model instructions and other metadata, but selects direct tools and
+disables Responses Lite, client tool search, and native multi-Agent metadata.
+This keeps Codex backend-only request forms out of portable AIGateway provider
+requests.
 
 For an official subscription, the runner writes `model` and
 `model_reasoning_effort` from the Job snapshot. It writes


### PR DESCRIPTION
## Problem

Background Agent Jobs run Codex through either an official ChatGPT subscription or Ankole AIGateway. The AIGateway path can resolve to OpenRouter or another OpenAI-compatible provider, but Agent Computer previously kept backend-specific capabilities from the bundled Codex model catalog:

- Responses Lite
- client `tool_search`
- code-only tool mode
- native multi-Agent selection

With an OpenRouter Chat Completions provider, Codex could discover configured MCP servers but leave their tools deferred and unreachable. A financial-data Job could then finish without making its required MCP call. BullX exposed the failure, but any AIGateway-backed Codex Job that depends on configured MCP tools can hit it.

This behavior matches upstream Codex reports:

- [openai/codex#32086](https://github.com/openai/codex/issues/32086): Responses Lite hides the client `tool_search` entrypoint in `AdditionalTools`. The issue discussion confirms the same failure for deferred MCP namespaces.
- [openai/codex#31894](https://github.com/openai/codex/issues/31894): Responses Lite turns do not expose exec and code-mode tools.
- [openai/codex#19425](https://github.com/openai/codex/issues/19425): an MCP server can be discovered while its tools remain unavailable to a Codex thread.

This PR does not patch Codex. It keeps Ankole's provider boundary portable.

## Solution

- Read the installed Codex binary's bundled model catalog during AIGateway Codex Home setup.
- Preserve model instructions and other model metadata.
- For AIGateway mode only, force a direct portable tool profile:
  - `use_responses_lite = false`
  - `supports_search_tool = false`
  - `tool_mode = "direct"`
  - `multi_agent_version = null`
- Keep official ChatGPT subscription mode unchanged.
- Store the derived catalog in Agent Codex Home and reject unreadable, empty, or invalid catalogs.
- Remove project-level `model_catalog_json` so a Job template cannot replace the runtime-owned catalog.
- Record the provider boundary in the AIGateway and Background Agent Job design documents.

## Verification

- `bun run agent-computer:test`: 412 tests passed and 0 failed.
- `bun run --filter @ankole/agent-computer lint`: formatting and TypeScript checks passed.
- A real Feishu IM request ran through a real LLM and Background Agent Job. After the portable catalog was applied, Job 1021 completed the bounded `110022.OF` financial-data task through the configured BullX MCP tools.

The live test used the local development environment. This PR does not include a deployment.
