### PR TITLE
Fix PTC compaction boundaries and oversized checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.50.2 (2026-07-31)
+
+- Fix repeated AIGateway context overflow and provider errors after a large Programmatic Tool Calling run. Compaction now treats `program` and `program_output` as one client tool pair, renders their code and result through the existing bounded summarizer format, moves the preferred boundary forward across a completed pair or an over-budget tail, and refuses to store a checkpoint whose replay input is still over budget. Automatic truncation checks the calls it drops against the outputs it keeps, so it cannot lower an orphaned `program_output` into a provider `function_call_output`. Cover large cross-row program compaction, checkpoint size, and provider-facing truncation order.
+
 ## Version 0.50.1 (2026-07-31)
 
 - Prevent Programmatic Tool Calling from aborting the control plane under V8 heap pressure. ProgramRunner created a Tokio runtime but built `JsRuntime` before it entered that runtime. As a result, `deno_core` registered the isolate without a runtime handle and aborted the process when V8 posted a delayed GC task. Enter the runtime before `JsRuntime` creation, keep the guard alive until the isolate is dropped, and add a small-heap regression test that forces the delayed-task path.

--- a/app/control_plane/lib/ankole/ai_gateway/compaction.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/compaction.ex
@@ -32,13 +32,18 @@ defmodule Ankole.AIGateway.Compaction do
   @default_tail_rows 2
   @summarizer_max_output_tokens 8_192
   @summarizer_retry_max_output_tokens 16_384
+  @checkpoint_overhead_tokens 1_000
   @brain_pre_compaction_nudge_marker "ankole.brain.pre_compaction_nudge.v1"
   @opaque_ref_keys ~w(agent_computer_path blob_ref content_type file_id file_url filename id image_url media_type mime_type name path provider_file_id provider_ref provider_uri storage_ref uri url)
   @max_ref_chars 512
   @tool_call_output_types %{
     "function_call" => "function_call_output",
-    "custom_tool_call" => "custom_tool_call_output"
+    "custom_tool_call" => "custom_tool_call_output",
+    "program" => "program_output"
   }
+  @tool_call_types Map.keys(@tool_call_output_types)
+  @tool_output_types Map.values(@tool_call_output_types)
+  @text_compactable_tool_types @tool_call_types ++ @tool_output_types
 
   @type result :: %{
           history: [Message.t()],
@@ -305,8 +310,15 @@ defmodule Ankole.AIGateway.Compaction do
          total_tokens,
          threshold
        ) do
-    with {:ok, candidate} <- compaction_candidate(subject_uid, history, current_input),
-         {:ok, summary} <- summarize_candidate(subject_uid, candidate, request) do
+    with {:ok, candidate} <-
+           compaction_candidate(
+             subject_uid,
+             history,
+             current_input,
+             retained_tail_budget_tokens(threshold)
+           ),
+         {:ok, summary} <- summarize_candidate(subject_uid, candidate, request),
+         :ok <- checkpoint_within_budget(candidate, summary, current_input, threshold) do
       previous_response_id = "resp_#{candidate.anchor.id}"
 
       {:ok,
@@ -795,10 +807,11 @@ defmodule Ankole.AIGateway.Compaction do
     minimum_count = min(tail_rows(), length(tail))
 
     case Enum.find_value(Range.new(minimum_count, length(tail)), fn count ->
-           candidate = checkpoint ++ Enum.take(tail, -count)
-           items = messages_to_items(candidate) ++ input_items(current_input)
+           {dropped_prefix, retained_tail} = Enum.split(tail, length(tail) - count)
+           candidate = checkpoint ++ retained_tail
 
-           if tool_call_prefix_valid?(items), do: candidate
+           if stable_tool_boundary?(dropped_prefix, retained_tail, current_input),
+             do: candidate
          end) do
       nil -> {:error, :no_safe_truncation_boundary}
       candidate -> {:ok, candidate}
@@ -837,14 +850,29 @@ defmodule Ankole.AIGateway.Compaction do
   defp overflow_reason(reason) when is_atom(reason), do: Atom.to_string(reason)
   defp overflow_reason(reason), do: inspect(reason)
 
-  defp compaction_candidate(subject_uid, history, current_input) do
+  defp compaction_candidate(
+         subject_uid,
+         history,
+         current_input,
+         retained_tail_budget_tokens \\ nil
+       ) do
     with %Message{} = anchor <- List.last(history),
          rows_after_compaction = rows_after_last_compaction(history),
-         compressible_limit when compressible_limit > 0 <-
+         preferred_prefix_count when preferred_prefix_count > 0 <-
            length(rows_after_compaction) - tail_rows(),
-         candidate_region = Enum.take(rows_after_compaction, compressible_limit),
-         prefix = Enum.take_while(candidate_region, &text_compactable_message?/1),
-         prefix <- snap_prefix_to_tool_boundary(prefix, rows_after_compaction, current_input),
+         compactable_count =
+           rows_after_compaction
+           |> Enum.take_while(&text_compactable_message?/1)
+           |> length(),
+         prefix_count when is_integer(prefix_count) and prefix_count > 0 <-
+           compaction_prefix_count(
+             rows_after_compaction,
+             current_input,
+             preferred_prefix_count,
+             compactable_count,
+             retained_tail_budget_tokens
+           ),
+         prefix = Enum.take(rows_after_compaction, prefix_count),
          %Message{} = _covers_until <- List.last(prefix) do
       retained_tail = Enum.drop(rows_after_compaction, length(prefix))
 
@@ -869,19 +897,42 @@ defmodule Ankole.AIGateway.Compaction do
     end
   end
 
-  defp snap_prefix_to_tool_boundary([], _rows_after_compaction, _current_input), do: []
+  defp compaction_prefix_count(
+         _rows_after_compaction,
+         _current_input,
+         _preferred_prefix_count,
+         0,
+         _retained_tail_budget_tokens
+       ),
+       do: nil
 
-  defp snap_prefix_to_tool_boundary(prefix, rows_after_compaction, current_input) do
-    tail_messages = Enum.drop(rows_after_compaction, length(prefix))
-    split_call_ids = split_tool_call_ids(prefix, tail_messages, current_input)
+  defp compaction_prefix_count(
+         rows_after_compaction,
+         current_input,
+         preferred_prefix_count,
+         compactable_count,
+         retained_tail_budget_tokens
+       ) do
+    start_count = min(preferred_prefix_count, compactable_count)
 
-    if MapSet.size(split_call_ids) == 0 do
-      prefix
-    else
-      prefix
-      |> remove_suffix_through_tool_calls(split_call_ids)
-      |> snap_prefix_to_tool_boundary(rows_after_compaction, current_input)
-    end
+    forward_counts = Enum.to_list(start_count..compactable_count)
+
+    backward_counts =
+      if start_count > 1,
+        do: 1..(start_count - 1) |> Enum.to_list() |> Enum.reverse(),
+        else: []
+
+    Enum.find(forward_counts ++ backward_counts, fn count ->
+      prefix = Enum.take(rows_after_compaction, count)
+      retained_tail = Enum.drop(rows_after_compaction, count)
+
+      stable_tool_boundary?(prefix, retained_tail, current_input) and
+        retained_tail_within_budget?(
+          retained_tail,
+          current_input,
+          retained_tail_budget_tokens
+        )
+    end)
   end
 
   defp split_tool_call_ids(prefix, tail_messages, current_input) do
@@ -897,26 +948,19 @@ defmodule Ankole.AIGateway.Compaction do
     MapSet.intersection(prefix_call_ids, tail_output_call_ids)
   end
 
-  defp remove_suffix_through_tool_calls(prefix, split_call_ids) do
-    prefix
-    |> Enum.reverse()
-    |> drop_until_split_tool_call(split_call_ids)
-    |> Enum.reverse()
+  defp stable_tool_boundary?(prefix, tail_messages, current_input) do
+    MapSet.size(split_tool_call_ids(prefix, tail_messages, current_input)) == 0
   end
 
-  defp drop_until_split_tool_call([], _split_call_ids), do: []
+  defp retained_tail_within_budget?(_retained_tail, _current_input, nil), do: true
 
-  defp drop_until_split_tool_call([message | rest], split_call_ids) do
-    call_ids =
-      message
-      |> message_items()
-      |> tool_call_ids()
-
-    if MapSet.disjoint?(call_ids, split_call_ids) do
-      drop_until_split_tool_call(rest, split_call_ids)
-    else
-      rest
-    end
+  defp retained_tail_within_budget?(
+         retained_tail,
+         current_input,
+         retained_tail_budget_tokens
+       ) do
+    items = messages_to_items(retained_tail) ++ input_items(current_input)
+    items_token_estimate(items) <= retained_tail_budget_tokens
   end
 
   defp rows_after_last_compaction(history) do
@@ -1422,6 +1466,44 @@ defmodule Ankole.AIGateway.Compaction do
     Map.put(internal_metadata, "request_metadata", request_metadata(request))
   end
 
+  defp checkpoint_within_budget(candidate, summary, current_input, threshold) do
+    checkpoint_items =
+      candidate.retained_user_originals ++
+        [
+          %{
+            "type" => "compaction",
+            "encrypted_content" => summary.text,
+            "created_by" => "ankole-aigateway"
+          }
+        ] ++ messages_to_items(candidate.retained_tail) ++ input_items(current_input)
+
+    if items_token_estimate(checkpoint_items) <= checkpoint_budget_tokens(threshold) do
+      :ok
+    else
+      {:error, :compaction_output_over_budget}
+    end
+  end
+
+  defp checkpoint_budget_tokens(threshold) do
+    max(threshold.tokens, CompactionRender.min_render_budget_tokens())
+  end
+
+  defp retained_tail_budget_tokens(threshold) do
+    max(
+      checkpoint_budget_tokens(threshold) -
+        user_message_budget_tokens() -
+        @summarizer_retry_max_output_tokens -
+        @checkpoint_overhead_tokens,
+      CompactionRender.min_render_budget_tokens()
+    )
+  end
+
+  defp items_token_estimate(items) do
+    items
+    |> Ankole.JSON.encode!()
+    |> CompactionRender.approx_tokens()
+  end
+
   defp message_content_text(%Message{content: content}) when is_list(content) do
     content
     |> Enum.map(&CompactionRender.item_text/1)
@@ -1446,13 +1528,7 @@ defmodule Ankole.AIGateway.Compaction do
        do: true
 
   defp text_compactable_item?(%{"type" => type})
-       when type in [
-              "function_call",
-              "function_call_output",
-              "custom_tool_call",
-              "custom_tool_call_output",
-              "reasoning"
-            ],
+       when type in @text_compactable_tool_types or type == "reasoning",
        do: true
 
   defp text_compactable_item?(_item), do: false
@@ -1476,17 +1552,14 @@ defmodule Ankole.AIGateway.Compaction do
     end)
   end
 
-  defp message_items(%Message{content: content}) when is_list(content), do: content
-  defp message_items(_message), do: []
-
   defp input_items(items) when is_list(items), do: Enum.filter(items, &is_map/1)
   defp input_items(_items), do: []
 
-  defp item_call_ids(items, item_type) do
+  defp item_call_ids(items, item_types) do
     items
     |> Enum.reduce(MapSet.new(), fn
-      %{"type" => ^item_type, "call_id" => call_id}, acc when is_binary(call_id) ->
-        MapSet.put(acc, call_id)
+      %{"type" => type, "call_id" => call_id}, acc when is_binary(call_id) ->
+        if type in item_types, do: MapSet.put(acc, call_id), else: acc
 
       _item, acc ->
         acc
@@ -1494,39 +1567,11 @@ defmodule Ankole.AIGateway.Compaction do
   end
 
   defp tool_call_ids(items) do
-    MapSet.union(
-      item_call_ids(items, "function_call"),
-      item_call_ids(items, "custom_tool_call")
-    )
+    item_call_ids(items, @tool_call_types)
   end
 
   defp tool_call_output_ids(items) do
-    MapSet.union(
-      item_call_ids(items, "function_call_output"),
-      item_call_ids(items, "custom_tool_call_output")
-    )
-  end
-
-  defp tool_call_prefix_valid?(items) when is_list(items) do
-    items
-    |> Enum.reduce_while(%{}, fn
-      %{"type" => type, "call_id" => call_id}, seen
-      when type in ["function_call", "custom_tool_call"] and is_binary(call_id) ->
-        {:cont, Map.put(seen, call_id, Map.fetch!(@tool_call_output_types, type))}
-
-      %{"type" => type, "call_id" => call_id}, seen
-      when type in ["function_call_output", "custom_tool_call_output"] and is_binary(call_id) ->
-        if Map.get(seen, call_id) == type,
-          do: {:cont, seen},
-          else: {:halt, :orphaned_tool_output}
-
-      _item, seen ->
-        {:cont, seen}
-    end)
-    |> case do
-      :orphaned_tool_output -> false
-      _seen -> true
-    end
+    item_call_ids(items, @tool_output_types)
   end
 
   defp tail_rows do

--- a/app/control_plane/lib/ankole/ai_gateway/compaction_render.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/compaction_render.ex
@@ -109,6 +109,27 @@ defmodule Ankole.AIGateway.CompactionRender do
     "custom_tool_call_output call_ref=#{call_ref} output=#{output}"
   end
 
+  def item_text(%{"type" => "program"} = item, opts) do
+    caps = Keyword.get(opts, :caps, @item_caps_tokens)
+    call_ref = Keyword.get(opts, :call_ref) || "(none)"
+
+    code =
+      Map.get(item, "code") |> stringify() |> truncate_text(cap(caps, :function_call_arguments))
+
+    "program call_ref=#{call_ref} code=#{code}"
+  end
+
+  def item_text(%{"type" => "program_output"} = item, opts) do
+    caps = Keyword.get(opts, :caps, @item_caps_tokens)
+    call_ref = Keyword.get(opts, :call_ref) || "(none)"
+    status = Map.get(item, "status") || "unknown"
+
+    result =
+      Map.get(item, "result") |> stringify() |> truncate_text(cap(caps, :function_call_output))
+
+    "program_output call_ref=#{call_ref} status=#{status} result=#{result}"
+  end
+
   def item_text(%{"type" => "reasoning"} = item, opts) do
     caps = Keyword.get(opts, :caps, @item_caps_tokens)
 

--- a/app/control_plane/test/ankole/ai_gateway/compaction_render_test.exs
+++ b/app/control_plane/test/ankole/ai_gateway/compaction_render_test.exs
@@ -63,6 +63,31 @@ defmodule Ankole.AIGateway.CompactionRenderTest do
     refute rendered =~ call_id
   end
 
+  test "caps program code and output with one local alias" do
+    call_id = "019f0000-0000-7000-8000-000000000003"
+
+    rendered =
+      CompactionRender.render_items([
+        %{
+          "type" => "program",
+          "call_id" => call_id,
+          "code" => String.duplicate("const result = await tools.market({});\n", 1_000)
+        },
+        %{
+          "type" => "program_output",
+          "call_id" => call_id,
+          "status" => "completed",
+          "result" => String.duplicate("x", 300_000)
+        }
+      ])
+
+    assert rendered =~ "program call_ref=call_1"
+    assert rendered =~ "program_output call_ref=call_1 status=completed"
+    assert rendered =~ "tokens elided"
+    refute rendered =~ call_id
+    assert CompactionRender.approx_tokens(rendered) <= 2_700
+  end
+
   test "global budget elides oldest eligible items while preserving users and latest items" do
     items =
       for index <- 1..20 do

--- a/app/control_plane/test/ankole/ai_gateway/responses_dispatch_test.exs
+++ b/app/control_plane/test/ankole/ai_gateway/responses_dispatch_test.exs
@@ -2158,7 +2158,7 @@ defmodule Ankole.AIGateway.ResponsesDispatchTest do
     assert Enum.drop(artifact.content["output"], 3) == m3.content
   end
 
-  test "websocket stateful auto-compaction keeps client tool calls with protected results" do
+  test "websocket stateful auto-compaction closes a complete client tool batch" do
     %{principal: agent} = agent_fixture()
 
     with_compaction_config(threshold: 0.50, max_threshold_tokens: 10, tail_rows: 2)
@@ -2172,7 +2172,7 @@ defmodule Ankole.AIGateway.ResponsesDispatchTest do
          openai_response_stream_events(
            "resp_summary_tool_tail",
            "gpt-compact-light",
-           "## Active Task\nOnly the first row was compressed.",
+           "## Active Task\nThe complete tool batch was compressed.",
            %{"input_tokens" => 7, "output_tokens" => 5, "total_tokens" => 12}
          )}
       end)
@@ -2273,10 +2273,12 @@ defmodule Ankole.AIGateway.ResponsesDispatchTest do
     [_, conversation_section] =
       Regex.run(~r/<conversation>\n(.*?)\n<\/conversation>/s, summarizer_input)
 
+    assert conversation_section =~ "function_call web_search call_ref=call_1"
+    assert conversation_section =~ "custom_tool_call apply_patch call_ref=call_2"
+    assert conversation_section =~ "function_call_output call_ref=call_1 output=search result"
+    assert conversation_section =~ "custom_tool_call_output call_ref=call_2 output=Done!"
     refute conversation_section =~ "call_keep_with_tail"
     refute conversation_section =~ "call_custom_keep_with_tail"
-    refute conversation_section =~ "search result"
-    refute conversation_section =~ "Done!"
 
     provider_request = request.response_context.request
     [user_orig_1, compaction_item | rest] = provider_request["input"]
@@ -2285,9 +2287,9 @@ defmodule Ankole.AIGateway.ResponsesDispatchTest do
     assert compaction_item["type"] == "compaction"
 
     assert compaction_item["encrypted_content"] ==
-             "## Active Task\nOnly the first row was compressed."
+             "## Active Task\nThe complete tool batch was compressed."
 
-    assert rest == tool_calls ++ tool_results ++ m4.content ++ current_input
+    assert rest == m4.content ++ current_input
 
     [compaction] =
       Repo.all(Message)
@@ -2295,13 +2297,141 @@ defmodule Ankole.AIGateway.ResponsesDispatchTest do
 
     assert compaction.previous_message_id == m4.id
     assert compaction.metadata["auto"] == true
+    assert compaction.metadata["covered_message_count"] == 3
 
     assert %CompactionArtifact{} = artifact = Repo.get!(CompactionArtifact, compaction.id)
 
     assert get_in(artifact.content, ["summary", "text"]) ==
-             "## Active Task\nOnly the first row was compressed."
+             "## Active Task\nThe complete tool batch was compressed."
 
-    assert Enum.drop(artifact.content["output"], 2) == tool_calls ++ tool_results ++ m4.content
+    assert Enum.drop(artifact.content["output"], 2) == m4.content
+  end
+
+  test "websocket stateful auto-compaction closes and compresses one large program batch" do
+    %{principal: agent} = agent_fixture()
+
+    with_compaction_config(threshold: 0.50, max_threshold_tokens: 160, tail_rows: 2)
+
+    base_url =
+      start_recording_upstream(self(), fn request ->
+        assert request.path == "v1/responses"
+        assert request.body["model"] == "gpt-compact-light"
+
+        {:sse, 200,
+         openai_response_stream_events(
+           "resp_summary_program_batch",
+           "gpt-compact-light",
+           "## Active Task\nThe completed program batch was compressed.",
+           %{"input_tokens" => 15, "output_tokens" => 9, "total_tokens" => 24}
+         )}
+      end)
+
+    create_openai_compaction_provider!(
+      agent,
+      "openai-auto-compaction-program-batch",
+      base_url
+    )
+
+    {:ok, conversation} =
+      StatefulResponses.ensure_conversation(agent.uid, "dispatch-program-batch-compaction")
+
+    program_call_id = "call_program_batch"
+    nested_call_id = "call_program_batch_market"
+
+    {:ok, m1} =
+      start_stateful_message(agent.uid, conversation, "program-batch-call", [
+        %{
+          "type" => "program",
+          "call_id" => program_call_id,
+          "code" => "const quote = await tools.market({ symbol: \"AAPL\" }); text(quote);",
+          "fingerprint" => "program-batch-fingerprint"
+        },
+        %{
+          "type" => "function_call",
+          "call_id" => nested_call_id,
+          "name" => "market",
+          "arguments" => ~s({"symbol":"AAPL"}),
+          "caller" => %{"type" => "program", "caller_id" => program_call_id}
+        }
+      ])
+
+    {:ok, m1} = StatefulResponses.commit_complete(m1, [], usage(170))
+
+    {:ok, m2} =
+      start_linked_stateful_message(agent.uid, conversation, m1, "program-batch-tool-output", [
+        %{
+          "type" => "function_call_output",
+          "call_id" => nested_call_id,
+          "output" => ~s({"price":212.5})
+        }
+      ])
+
+    {:ok, m2} = StatefulResponses.commit_complete(m2, [], usage(175))
+
+    large_result = "PROGRAM_RESULT_SENTINEL:" <> String.duplicate("x", 300_000)
+
+    {:ok, m3} =
+      start_linked_stateful_message(agent.uid, conversation, m2, "program-batch-output", [
+        %{
+          "type" => "program_output",
+          "call_id" => program_call_id,
+          "status" => "completed",
+          "result" => large_result
+        }
+      ])
+
+    {:ok, m3} = StatefulResponses.commit_complete(m3, [], usage(178))
+
+    {:ok, m4} =
+      start_linked_stateful_message(agent.uid, conversation, m3, "program-batch-final", [
+        text_message(
+          "assistant",
+          "FINAL_RESPONSE_SENTINEL #{brain_pre_compaction_nudge_marker()} " <>
+            String.duplicate("final ", 20_000)
+        )
+      ])
+
+    {:ok, _m4} = StatefulResponses.commit_complete(m4, [], usage(180))
+
+    current_input = [text_message("user", "continue with the result")]
+
+    assert {:ok, request} =
+             AIGateway.prepare_websocket_request(agent.uid, %{
+               "model" => "primary",
+               "input" => current_input,
+               "tools" => programmatic_tools(),
+               "store" => true,
+               "conversation" => "conv_#{conversation.id}",
+               "metadata" => %{"actor_event_id" => "program-batch-compaction-event"}
+             })
+
+    assert_receive {:gateway_request, summarizer_request}
+    summarizer_input = Ankole.JSON.encode!(summarizer_request.body["input"])
+
+    assert summarizer_input =~ "program call_ref=call_1"
+    assert summarizer_input =~ "program_output call_ref=call_1 status=completed"
+    assert summarizer_input =~ "tokens elided"
+    assert summarizer_input =~ "FINAL_RESPONSE_SENTINEL"
+    refute summarizer_input =~ program_call_id
+    assert byte_size(summarizer_input) < 50_000
+
+    provider_input = request.response_context.request["input"]
+
+    assert [%{"type" => "compaction"} = compaction_item | ^current_input] = provider_input
+
+    assert compaction_item["encrypted_content"] ==
+             "## Active Task\nThe completed program batch was compressed."
+
+    refute Ankole.JSON.encode!(provider_input) =~ "PROGRAM_RESULT_SENTINEL"
+    refute Ankole.JSON.encode!(provider_input) =~ "FINAL_RESPONSE_SENTINEL"
+
+    [checkpoint] = Repo.all(Message) |> Enum.filter(&(&1.type == "checkpoint"))
+    assert checkpoint.metadata["covered_message_count"] == 4
+
+    assert %CompactionArtifact{} = artifact = Repo.get!(CompactionArtifact, checkpoint.id)
+    assert get_in(artifact.content, ["retention", "actual"]) == 0
+    assert length(artifact.content["output"]) == 1
+    assert byte_size(Ankole.JSON.encode!(artifact.content["output"])) < 10_000
   end
 
   test "websocket stateful auto-compaction renders reasoning summaries without encrypted content" do
@@ -2712,6 +2842,149 @@ defmodule Ankole.AIGateway.ResponsesDispatchTest do
 
     provider_request = request.response_context.request
     assert provider_request["input"] == call.content ++ tail.content ++ current_input
+  end
+
+  test "websocket stateful truncation keeps a program call with its output" do
+    %{principal: agent} = agent_fixture()
+
+    with_compaction_config(threshold: 0.50, max_threshold_tokens: 160, tail_rows: 2)
+
+    assert {:ok, _provider} =
+             ProviderConfigs.create_provider(%{
+               provider_id: "openai-truncation-program-boundary",
+               provider_kind: "openai",
+               base_url: "http://127.0.0.1:1/v1",
+               credential_pool: %{
+                 "entries" => [%{"label" => "Default", "api_key" => "sk-openai"}]
+               },
+               connection_options: %{
+                 "upstream_transport" => "websocket"
+               }
+             })
+
+    assert {:ok, _profile} =
+             ModelProfiles.put_model_profile(agent.uid, "primary", %{
+               provider_id: "openai-truncation-program-boundary",
+               model: "gpt-main"
+             })
+
+    {:ok, conversation} =
+      StatefulResponses.ensure_conversation(agent.uid, "dispatch-truncation-program-boundary")
+
+    {:ok, opaque} =
+      start_stateful_message(agent.uid, conversation, "program-truncation-opaque", [
+        media_message_with_memory_nudge("https://files.example.test/program-boundary.png")
+      ])
+
+    {:ok, opaque} = StatefulResponses.commit_complete(opaque, [], usage(120))
+
+    program_call_id = "call_program_truncation"
+    nested_call_id = "call_program_truncation_market"
+
+    {:ok, program} =
+      start_linked_stateful_message(agent.uid, conversation, opaque, "program-truncation-call", [
+        %{
+          "type" => "program",
+          "call_id" => program_call_id,
+          "code" => "const quote = await tools.market({}); text(quote);",
+          "fingerprint" => "program-truncation-fingerprint"
+        },
+        %{
+          "type" => "function_call",
+          "call_id" => nested_call_id,
+          "name" => "market",
+          "arguments" => "{}",
+          "caller" => %{"type" => "program", "caller_id" => program_call_id}
+        }
+      ])
+
+    {:ok, program} = StatefulResponses.commit_complete(program, [], usage(130))
+
+    {:ok, nested_output} =
+      start_linked_stateful_message(
+        agent.uid,
+        conversation,
+        program,
+        "program-truncation-nested-output",
+        [
+          %{
+            "type" => "function_call_output",
+            "call_id" => nested_call_id,
+            "output" => ~s({"price":212.5})
+          }
+        ]
+      )
+
+    {:ok, nested_output} = StatefulResponses.commit_complete(nested_output, [], usage(140))
+
+    {:ok, program_output} =
+      start_linked_stateful_message(
+        agent.uid,
+        conversation,
+        nested_output,
+        "program-truncation-output",
+        [
+          %{
+            "type" => "program_output",
+            "call_id" => program_call_id,
+            "status" => "completed",
+            "result" => ~s({"price":212.5})
+          }
+        ]
+      )
+
+    {:ok, program_output} = StatefulResponses.commit_complete(program_output, [], usage(150))
+
+    {:ok, final} =
+      start_linked_stateful_message(
+        agent.uid,
+        conversation,
+        program_output,
+        "program-truncation-tail",
+        [
+          text_message("assistant", "program result ready #{brain_pre_compaction_nudge_marker()}")
+        ]
+      )
+
+    {:ok, _final} = StatefulResponses.commit_complete(final, [], usage(180))
+
+    current_input = [text_message("user", "use that result")]
+
+    assert {:ok, request} =
+             AIGateway.prepare_websocket_request(agent.uid, %{
+               "model" => "primary",
+               "input" => current_input,
+               "tools" => programmatic_tools(),
+               "store" => true,
+               "conversation" => "conv_#{conversation.id}",
+               "truncation" => "auto",
+               "metadata" => %{"actor_event_id" => "program-truncation-boundary-event"}
+             })
+
+    provider_input = request.response_context.request["input"]
+
+    program_call =
+      Enum.find(
+        provider_input,
+        &(&1["type"] == "function_call" and &1["call_id"] == program_call_id)
+      )
+
+    settled_output =
+      Enum.find(
+        provider_input,
+        &(&1["type"] == "function_call_output" and &1["call_id"] == program_call_id)
+      )
+
+    assert program_call["name"] == "program"
+    assert settled_output["output"] =~ "completed"
+
+    assert Enum.find_index(provider_input, &(&1 == program_call)) <
+             Enum.find_index(provider_input, &(&1 == settled_output))
+
+    refute Enum.any?(provider_input, &(&1["call_id"] == nested_call_id))
+    refute Ankole.JSON.encode!(provider_input) =~ "program-boundary.png"
+    assert Enum.take(provider_input, -2) == final.content ++ current_input
+    refute_receive {:gateway_request, _request}
   end
 
   test "websocket stateful truncation keeps the compaction checkpoint with the stable tail" do
@@ -4534,6 +4807,19 @@ defmodule Ankole.AIGateway.ResponsesDispatchTest do
         "total_tokens" => input_tokens + output_tokens
       }
     }
+  end
+
+  defp programmatic_tools do
+    [
+      %{
+        "type" => "function",
+        "name" => "market",
+        "description" => "Return market data.",
+        "allowed_callers" => ["programmatic"],
+        "parameters" => %{"type" => "object", "properties" => %{}}
+      },
+      %{"type" => "programmatic_tool_calling"}
+    ]
   end
 
   defp with_compaction_config(config) do

--- a/docs/design-docs/AIGateway.md
+++ b/docs/design-docs/AIGateway.md
@@ -460,8 +460,18 @@ The checkpoint and artifact use the same UUID.
 When AIGateway builds model history, it replaces the checkpoint with that
 output. It also keeps selected original user facts.
 
-The compaction summarizer keeps client tool call and output pairs with one-call
-`call_N` aliases. Persisted provider call IDs do not enter its prompt.
+The compaction summarizer treats `function_call`, `custom_tool_call`, and
+`program` as calls paired with their matching output items. It renders bounded
+arguments, code, and results with one-call `call_N` aliases. Persisted provider
+call IDs do not enter its prompt.
+
+The configured tail row count is a preference. AIGateway can move the
+compaction boundary forward to include a completed call batch or to keep the
+retained tail and current input within the history budget. It can move the
+boundary backward when the current input closes a call. Before AIGateway stores
+a checkpoint, it estimates the selected user originals, summary, retained tail,
+and current input together. An over-budget result cannot create an artifact and
+uses the normal overflow policy.
 
 The summarizer uses the standard streaming Responses preparation and stream
 owner. AIGateway creates its request context before model resolution and keeps
@@ -483,12 +493,13 @@ read the newest snapshot in the visible history.
 When the context exceeds its threshold and compaction has no candidate, a
 request with `truncation=auto` keeps the last compaction checkpoint and the
 configured stable tail, then expands the tail backward until the client tool
-calls and outputs in history and the current input form a valid boundary. The
-checkpoint stays because it is the only remaining record of the conversation
-before it. A suffix size cannot be derived from cumulative snapshots, so this
-path reports no post-truncation token estimate and leaves the measurement to
-the provider. When no valid boundary exists, the request returns
-`context_overflow`.
+calls and outputs in history and the current input form a valid boundary. This
+rule includes `program` and `program_output`; truncation cannot retain a program
+output after it drops the matching program. The checkpoint stays because it is
+the only remaining record of the conversation before it. A suffix size cannot
+be derived from cumulative snapshots, so this path reports no post-truncation
+token estimate and leaves the measurement to the provider. When no valid
+boundary exists, the request returns `context_overflow`.
 
 ## Store Vision Files and Generated Images
 


### PR DESCRIPTION
## Summary

- treat `program` and `program_output` as one AIGateway compaction pair
- move the preferred compaction boundary across completed tool batches and oversized retained tails
- reject checkpoint plans whose replay input remains over budget
- keep automatic truncation from lowering an orphaned program output to a provider function output
- render bounded PTC code and results with local call aliases

## Root cause

AIGateway understood function and custom-tool pairs but not the Programmatic Tool Calling pair. A large `program_output` could remain in a checkpoint after its `program` was dropped. Tool Search then lowered that orphan to `function_call_output`, which providers rejected, while the oversized checkpoint caused repeated context overflow and slow retries.

## Verification

- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- AIGateway compaction and dispatch tests: 70 passed
- Full control-plane suite: 1672/1674 passed, 5 excluded. The two failures are unchanged assertions outside this diff: the plugin registry test omits the compiled WeCom adapter, and the background-job migration test expects `agent_plugin_ids` to be absent although it exists in the current schema.

## Rollout note

This change prevents new poisoned checkpoints. Existing affected conversations need separate operator recovery or a new conversation; failed ActorEvents that already executed tools must not be replayed blindly.