### PR TITLE
fix(wecom): preserve WebSocket upgrade header casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.52.1 (2026-07-31)
+
+- Fix WeCom AI-bot WebSocket handshakes against the provider gateway by preserving the conventional RFC 6455 Header casing during the HTTP/1.1 upgrade. Add strict regression coverage for the connection path.
+
 ## Version 0.52.0 (2026-07-31)
 
 - Reintroduce `mcporter` 0.12.3 into the Agent Computer base image with the pinned global install, the Bun shim, and the version assertion, so scripts and Agents can call MCP servers from the shell. State the path in the automation job help: the mcporter CLI reads `~/.mcporter/mcporter.json` from the Agent Home, and a script reaches MCP data through Bun Shell.

--- a/libs/wecom_openapi/lib/wecom_openapi/bot/client.ex
+++ b/libs/wecom_openapi/lib/wecom_openapi/bot/client.ex
@@ -279,9 +279,12 @@ defmodule WeComOpenAPI.Bot.Client do
 
   defp connect(state) do
     with {:ok, scheme, host, port, path} <- parse_url(state.ws_url),
-         {:ok, conn} <- Mint.HTTP.connect(http_scheme(scheme), host, port, protocols: [:http1]),
-         {:ok, conn, ref} <-
-           Mint.WebSocket.upgrade(scheme, conn, path, [{"user-agent", @user_agent}]) do
+         {:ok, conn} <-
+           Mint.HTTP.connect(http_scheme(scheme), host, port,
+             protocols: [:http1],
+             case_sensitive_headers: true
+           ),
+         {:ok, conn, ref} <- wecom_websocket_upgrade(scheme, conn, path) do
       emit([:connect], %{duration_ms: 0}, %{host: host})
 
       {:ok,
@@ -296,6 +299,30 @@ defmodule WeComOpenAPI.Bot.Client do
       {:error, reason} -> {:error, reason}
       {:error, _conn, reason} -> {:error, reason}
     end
+  end
+
+  # WeCom's long-connection gateway currently treats the RFC 6455 upgrade
+  # header names as case-sensitive and returns 404 for Mint.WebSocket's
+  # lowercase defaults. Preserve the conventional HTTP/1 spelling used by the
+  # official SDK while retaining Mint.WebSocket for framing after the upgrade.
+  defp wecom_websocket_upgrade(scheme, conn, path) do
+    nonce = :crypto.strong_rand_bytes(16) |> Base.encode64()
+
+    conn =
+      conn
+      |> Mint.HTTP.put_private(:scheme, scheme)
+      |> Mint.HTTP.put_private(:sec_websocket_key, nonce)
+      |> Mint.HTTP.put_private(:extensions, [])
+
+    headers = [
+      {"Upgrade", "websocket"},
+      {"Connection", "Upgrade"},
+      {"Sec-WebSocket-Version", "13"},
+      {"Sec-WebSocket-Key", nonce},
+      {"User-Agent", @user_agent}
+    ]
+
+    Mint.HTTP.request(conn, "GET", path, headers, nil)
   end
 
   defp parse_url(url) do

--- a/libs/wecom_openapi/test/support/fake_ws_server.ex
+++ b/libs/wecom_openapi/test/support/fake_ws_server.ex
@@ -14,22 +14,30 @@ defmodule WeComOpenAPI.FakeWsServer do
   import Bitwise
 
   @doc "Start the server; returns `{pid, port}`. Frames go to `parent`."
-  def start(parent) do
+  def start(parent, opts \\ []) do
     {:ok, listener} = :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
     {:ok, {_address, port}} = :inet.sockname(listener)
-    pid = spawn_link(fn -> accept(listener, parent) end)
+    pid = spawn_link(fn -> accept(listener, parent, opts) end)
     {pid, port}
   end
 
-  defp accept(listener, parent) do
+  defp accept(listener, parent, opts) do
     {:ok, socket} = :gen_tcp.accept(listener, 5_000)
     :ok = :gen_tcp.close(listener)
     {:ok, request} = recv_until_headers(socket)
-    {:ok, key} = websocket_key(request)
-    :ok = :gen_tcp.send(socket, upgrade_response(key))
-    send(parent, {:ws_upgraded, self()})
-    :ok = :inet.setopts(socket, active: true)
-    loop(socket, parent, <<>>)
+
+    with :ok <- validate_header_case(request, opts),
+         {:ok, key} <- websocket_key(request) do
+      :ok = :gen_tcp.send(socket, upgrade_response(key))
+      send(parent, {:ws_upgraded, self()})
+      :ok = :inet.setopts(socket, active: true)
+      loop(socket, parent, <<>>)
+    else
+      {:error, reason} ->
+        :ok = :gen_tcp.send(socket, "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
+        :ok = :gen_tcp.close(socket)
+        send(parent, {:ws_rejected, self(), reason})
+    end
   end
 
   defp loop(socket, parent, buffer) do
@@ -60,6 +68,27 @@ defmodule WeComOpenAPI.FakeWsServer do
   end
 
   # --- handshake -----------------------------------------------------------
+
+  defp validate_header_case(request, opts) do
+    if Keyword.get(opts, :require_wecom_header_case, false) do
+      required_names = ["Upgrade", "Connection", "Sec-WebSocket-Version", "Sec-WebSocket-Key"]
+      present_names = request |> String.split("\r\n") |> Enum.map(&header_name/1)
+
+      case Enum.find(required_names, &(&1 not in present_names)) do
+        nil -> :ok
+        missing -> {:error, {:incorrect_header_case, missing}}
+      end
+    else
+      :ok
+    end
+  end
+
+  defp header_name(line) do
+    case String.split(line, ":", parts: 2) do
+      [name, _value] -> name
+      _parts -> nil
+    end
+  end
 
   defp recv_until_headers(socket, buffer \\ <<>>) do
     case :binary.match(buffer, "\r\n\r\n") do

--- a/libs/wecom_openapi/test/wecom_openapi/bot/client_test.exs
+++ b/libs/wecom_openapi/test/wecom_openapi/bot/client_test.exs
@@ -12,6 +12,42 @@ defmodule WeComOpenAPI.Bot.ClientTest do
     end
   end
 
+  test "connects to the WeCom gateway when its HTTP/1 upgrade headers are case-sensitive" do
+    parent = self()
+    {server, port} = FakeWsServer.start(parent, require_wecom_header_case: true)
+
+    {:ok, pid} =
+      Client.start_link(
+        bot_id: "bot-1",
+        secret: "secret-1",
+        dispatcher: Dispatcher.new(),
+        ws_url: "ws://127.0.0.1:#{port}/",
+        auto_reconnect: false
+      )
+
+    Process.unlink(pid)
+
+    on_exit(fn ->
+      Process.exit(pid, :shutdown)
+      if Process.alive?(server), do: send(server, :close)
+    end)
+
+    assert_receive {:ws_upgraded, ^server}, 2_000
+    assert_receive {:client_frame, %{"cmd" => "aibot_subscribe"} = auth}, 2_000
+
+    send(
+      server,
+      {:push,
+       %{
+         "headers" => %{"req_id" => auth["headers"]["req_id"]},
+         "errcode" => 0,
+         "errmsg" => "ok"
+       }}
+    )
+
+    wait_until(fn -> Client.status(pid) == :connected end)
+  end
+
   defp start_connected(dispatcher) do
     parent = self()
     {server, port} = FakeWsServer.start(parent)


### PR DESCRIPTION
## Problem

The WeCom AI-bot long-connection gateway rejects the HTTP/1.1 WebSocket upgrade when Mint emits the RFC 6455 header names in lowercase. The gateway returns `404` instead of switching protocols, so the adapter remains disconnected and inbound messages receive no response.

## Solution

- preserve the supplied HTTP/1.1 header casing with Mint's `case_sensitive_headers: true` option;
- send the WeCom upgrade headers with conventional casing while keeping Mint.WebSocket for handshake validation and frame processing;
- add strict fake-gateway coverage that requires the WeCom header casing and verifies the client reaches `:connected`.

## Validation

- `mix format --check-formatted`
- `mix test` in `libs/wecom_openapi` — 30 tests passed
- `git diff --check`

The change is limited to the WeCom transport client, its fake gateway/client test, and the required `CHANGELOG.md` bug-fix entry. No credentials or deployment configuration are included.

## Unverified

A live upstream CI run and maintainer review remain pending.
