### PR TITLE
fix(ai-gateway): handle ChatGPT Subscription response streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 0.53.1 (2026-08-01)
+
+- Keep complete-response callers on the ChatGPT Subscription protocol that the Codex endpoint accepts. AIGateway now opens the required upstream SSE stream and collects its terminal Response, removes the unsupported `truncation` field with the existing ChatGPT-only request cleanup, and leaves OpenAI, OpenRouter, and other providers on their current request path.
+
+- Fix local Tool Search and program continuations when a provider sends complete output-item events but omits the terminal `output` array. The response loop now uses the raw items from that provider round only when terminal output is empty, clears them before the next round, and keeps a nonempty terminal output authoritative. This prevents a public search call from being stored without its matching output.
+
 ## Version 0.53.0 (2026-08-01)
 
 - Rebuild AIGateway Tool Search and programmatic tool calling around one public Response lifecycle. `ResponseStream` now owns streaming and collected execution, absolute open deadlines, retry boundaries, task monitors, sequence numbers, stateful commits, and cancellation. A bounded program task supervisor keeps dirty native work outside the stream owner. Client and server Tool Search, deferred loading, top-level programs, nested program calls, repeated pauses, and pre-provider program resumes now use one multi-round loop with frozen tool bindings, stable item and pair identities, and one global output index across provider rounds. A pre-provider resume emits the sole public admission lifecycle before its local items, preserves that buffered lifecycle through admission and continuation-open failures, and suppresses all later provider admission frames. If another process commits a stateful terminal first, the live stream projects that durable winner instead of publishing the conflicting provider terminal.

--- a/app/control_plane/lib/ankole/ai_gateway/chatgpt_protocol.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/chatgpt_protocol.ex
@@ -2,7 +2,15 @@ defmodule Ankole.AIGateway.ChatGPTProtocol do
   @moduledoc false
 
   @lite_metadata_key "ws_request_header_x_openai_internal_codex_responses_lite"
-  @forbidden_fields ~w(generate max_output_tokens metadata prompt_cache_retention safety_identifier stream_options)
+  @forbidden_fields ~w(
+    generate
+    max_output_tokens
+    metadata
+    prompt_cache_retention
+    safety_identifier
+    stream_options
+    truncation
+  )
   @max_input_id_bytes 64
 
   @spec prepare(map(), map()) ::

--- a/app/control_plane/lib/ankole/ai_gateway/responses_preparation.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/responses_preparation.ex
@@ -87,7 +87,7 @@ defmodule Ankole.AIGateway.ResponsesPreparation do
     with {:ok, provider_request} <- provider_request(runtime, request),
          {:ok, provider_request, tool_plan} <- plan_tools(runtime, provider_request),
          :ok <- validate_tool_budget_owners(request, provider_request, tool_plan),
-         response_stream_driver? = response_stream_driver?(tool_plan),
+         response_stream_driver? = response_stream_driver?(runtime, tool_plan),
          provider_request =
            StreamLoop.apply_tool_budget(
              tool_plan,
@@ -128,7 +128,8 @@ defmodule Ankole.AIGateway.ResponsesPreparation do
     )
   end
 
-  defp response_stream_driver?(plan), do: ToolSearch.response_stream_required?(plan)
+  defp response_stream_driver?(%{"provider_kind" => "chatgpt_subscription"}, _plan), do: true
+  defp response_stream_driver?(_runtime, plan), do: ToolSearch.response_stream_required?(plan)
 
   defp validate_tool_budget_owners(
          %{"max_tool_calls" => limit, "tool_choice" => "none"},

--- a/app/control_plane/lib/ankole/ai_gateway/tool_search/stream_loop.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/tool_search/stream_loop.ex
@@ -30,6 +30,7 @@ defmodule Ankole.AIGateway.ToolSearch.StreamLoop do
   defstruct plan: nil,
             provider_request: nil,
             provider_items_rev: [],
+            current_round_items_rev: [],
             provider_history_count: 0,
             provider_history_item_bytes: 0,
             provider_history_error: nil,
@@ -253,7 +254,7 @@ defmodule Ankole.AIGateway.ToolSearch.StreamLoop do
           | {:local, [map()], map(), t()}
   def intercept_terminal(%__MODULE__{} = loop, event_type, %{} = response) do
     loop = accumulate_usage(loop, response)
-    output = response |> Map.get("output") |> list_of_maps()
+    output = terminal_output(loop, response)
 
     case remember_provider_items(loop, output) do
       {:ok, loop} ->
@@ -433,6 +434,8 @@ defmodule Ankole.AIGateway.ToolSearch.StreamLoop do
     do: {:emit, renumber(event, loop), bump_sequence(loop, event)}
 
   defp observe_item_done(loop, %{"item" => %{} = item} = event) do
+    loop = %{loop | current_round_items_rev: [item | loop.current_round_items_rev]}
+
     if rewritable_call_item?(loop, item) do
       event = event |> Map.put("item", rewrite_call_item(loop, item)) |> renumber(loop)
       {:emit, event, bump_sequence(loop, event)}
@@ -513,7 +516,12 @@ defmodule Ankole.AIGateway.ToolSearch.StreamLoop do
   end
 
   defp begin_next_round(loop) do
-    %{loop | rounds: loop.rounds + 1, suppressed_item_ids: MapSet.new()}
+    %{
+      loop
+      | rounds: loop.rounds + 1,
+        suppressed_item_ids: MapSet.new(),
+        current_round_items_rev: []
+    }
   end
 
   defp search_output_items(loop, executed) do
@@ -682,6 +690,13 @@ defmodule Ankole.AIGateway.ToolSearch.StreamLoop do
   # ─────────────────────────────────────────────────────────────────
   # Terminal helpers
   # ─────────────────────────────────────────────────────────────────
+
+  defp terminal_output(loop, response) do
+    case response |> Map.get("output") |> list_of_maps() do
+      [] -> Enum.reverse(loop.current_round_items_rev)
+      output -> output
+    end
+  end
 
   defp rewrite_items(loop, items) do
     Enum.map(items, &rewrite_call_item(loop, &1))

--- a/app/control_plane/test/ankole/ai_gateway/chatgpt_protocol_test.exs
+++ b/app/control_plane/test/ankole/ai_gateway/chatgpt_protocol_test.exs
@@ -14,6 +14,7 @@ defmodule Ankole.AIGateway.ChatGPTProtocolTest do
       "prompt_cache_retention" => "24h",
       "safety_identifier" => "unsafe-upstream-field",
       "stream_options" => %{"include_usage" => true},
+      "truncation" => "auto",
       "instructions" => nil,
       "parallel_tool_calls" => true,
       "tools" => [],
@@ -45,6 +46,7 @@ defmodule Ankole.AIGateway.ChatGPTProtocolTest do
     refute Map.has_key?(prepared, "prompt_cache_retention")
     refute Map.has_key?(prepared, "safety_identifier")
     refute Map.has_key?(prepared, "stream_options")
+    refute Map.has_key?(prepared, "truncation")
     refute Map.has_key?(prepared, "parallel_tool_calls")
     assert prepared["instructions"] == ""
     assert prepared["store"] == false
@@ -131,7 +133,9 @@ defmodule Ankole.AIGateway.ChatGPTProtocolTest do
   test "restores a codex responses-lite request for a standard provider" do
     request = %{
       "model" => "gpt-5.6",
+      "max_output_tokens" => 512,
       "instructions" => "",
+      "truncation" => "auto",
       "tools" => nil,
       "parallel_tool_calls" => false,
       "client_metadata" => %{@lite_marker => "true", "trace_id" => "trace-1"},
@@ -159,6 +163,8 @@ defmodule Ankole.AIGateway.ChatGPTProtocolTest do
     assert [%{"name" => "weather"}] = restored["tools"]
     assert [%{"role" => "user"}] = restored["input"]
     assert restored["client_metadata"] == %{"trace_id" => "trace-1"}
+    assert restored["max_output_tokens"] == 512
+    assert restored["truncation"] == "auto"
   end
 
   test "preserves a responses-lite request for the subscription protocol" do

--- a/app/control_plane/test/ankole/ai_gateway/responses_dispatch_test.exs
+++ b/app/control_plane/test/ankole/ai_gateway/responses_dispatch_test.exs
@@ -262,6 +262,63 @@ defmodule Ankole.AIGateway.ResponsesDispatchTest do
     assert codex_request.body["tools"] == codex_tools
   end
 
+  test "ChatGPT complete responses collect SSE and strip unsupported request fields" do
+    %{principal: agent} = agent_fixture()
+
+    base_url =
+      start_recording_upstream(self(), fn _request ->
+        {:sse, 200,
+         openai_response_stream_events(
+           "resp_chatgpt_complete",
+           "gpt-5.6-sol",
+           "stream collected"
+         )}
+      end)
+
+    assert {:ok, _provider} =
+             ProviderConfigs.create_provider(%{
+               provider_id: "chatgpt-complete-response",
+               provider_kind: "chatgpt_subscription",
+               base_url: base_url,
+               credential_pool: %{
+                 "entries" => [
+                   %{
+                     "id" => "enterprise",
+                     "label" => "Enterprise",
+                     "access_token" => "access-token",
+                     "account_id" => "account-id",
+                     "auth_type" => "enterprise_access_token"
+                   }
+                 ]
+               },
+               connection_options: %{"transport" => %{"http_versions" => ["h1"]}}
+             })
+
+    assert {:ok, _profile} =
+             ModelProfiles.put_model_profile(agent.uid, "primary", %{
+               provider_id: "chatgpt-complete-response",
+               model: "gpt-5.6-sol"
+             })
+
+    assert {:ok, %{body: body}} =
+             AIGateway.create_response(agent.uid, %{
+               "model" => "primary",
+               "input" => "hello",
+               "max_output_tokens" => 1_024,
+               "truncation" => "auto"
+             })
+
+    assert_receive {:gateway_request, request}
+    assert request.path == "responses"
+    assert request.headers["accept"] == "text/event-stream"
+    assert request.body["stream"] == true
+    refute Map.has_key?(request.body, "max_output_tokens")
+    refute Map.has_key?(request.body, "truncation")
+
+    assert get_in(body, ["output", Access.at(0), "content", Access.at(0), "text"]) ==
+             "stream collected"
+  end
+
   test "first-party OpenAI keeps function and custom PTC native" do
     %{principal: agent} = agent_fixture()
 

--- a/app/control_plane/test/ankole/ai_gateway/tool_search_stream_test.exs
+++ b/app/control_plane/test/ankole/ai_gateway/tool_search_stream_test.exs
@@ -399,6 +399,63 @@ defmodule Ankole.AIGateway.ToolSearchStreamTest do
       assert sequences == [Enum.at(sequences, 0), Enum.at(sequences, 0) + 1]
     end
 
+    test "uses streamed round items when a terminal omits output", %{
+      state: state,
+      provider_request: provider_request
+    } do
+      arguments = ~s({"paths":["bx_market_data"]})
+
+      {state, _events, _statuses} =
+        Enum.reduce(search_call_events("call_sparse", arguments), {state, [], []}, fn event,
+                                                                                      {state, all,
+                                                                                       statuses} ->
+          {state, events, status} = observe!(state, event)
+          {state, all ++ events, statuses ++ [status]}
+        end)
+
+      {state, [search_output_event], {:round, continuation_request}} =
+        observe!(state, completed_event([], 4))
+
+      assert search_output_event["item"]["type"] == "tool_search_output"
+
+      original_input_length = length(provider_request["input"])
+      [call, output] = Enum.drop(continuation_request["input"], original_input_length)
+      assert call["type"] == "function_call"
+      assert call["call_id"] == "call_sparse"
+      assert output["type"] == "function_call_output"
+      assert output["call_id"] == "call_sparse"
+
+      message = %{
+        "id" => "msg_sparse",
+        "type" => "message",
+        "role" => "assistant",
+        "content" => [%{"type" => "output_text", "text" => "行情如下"}]
+      }
+
+      {state, [_message_event], :continue} =
+        observe!(state, %{
+          "type" => "response.output_item.done",
+          "sequence_number" => 1,
+          "output_index" => 0,
+          "item" => message
+        })
+
+      {_state, [terminal], {:terminal, outcome, :keep_upstream}} =
+        observe!(state, completed_event([], 2))
+
+      assert Enum.map(terminal["response"]["output"], & &1["type"]) == [
+               "tool_search_call",
+               "tool_search_output",
+               "message"
+             ]
+
+      assert Enum.map(outcome.public_items, & &1["type"]) == [
+               "tool_search_call",
+               "tool_search_output",
+               "message"
+             ]
+    end
+
     test "admits a terminal-only search call before its output and the next round", %{
       state: state
     } do

--- a/docs/design-docs/AIGateway.md
+++ b/docs/design-docs/AIGateway.md
@@ -220,8 +220,8 @@ the upstream compact endpoint.
 The provider prepares the Codex protocol as follows:
 
 - It removes downstream-only and unsupported request fields, including caller
-  `metadata` and `max_output_tokens`, before dispatch. AIGateway still stores
-  metadata locally.
+  `metadata`, `max_output_tokens`, and `truncation`, before dispatch. AIGateway
+  still stores metadata locally and applies its own history limits.
 - It converts standard string input to one user message because the Codex
   endpoint accepts only an input-item list.
 - It supplies an empty `instructions` value when the client omits it.
@@ -235,8 +235,9 @@ The provider prepares the Codex protocol as follows:
 - It sends the required content, accept, beta, connection, originator, and user
   agent headers.
 - It uses the account ID stored in the selected credential.
-- It supports both POST SSE and upstream WebSocket `response.create`. An
-  oversized WebSocket message maps to HTTP 413.
+- It always streams upstream. A complete-response caller collects the terminal
+  Response from POST SSE. A streaming WebSocket caller uses upstream WebSocket
+  `response.create`. An oversized WebSocket message maps to HTTP 413.
 
 The kernel returns only safe provider response headers to the control plane.
 It keeps the `x-codex-*` rate-limit family and `cf-mitigated`, which lets the
@@ -443,6 +444,11 @@ Tool Search uses one synthesized provider function and exposes
 executes the search in AIGateway. Client mode returns the search call to the
 caller. Both modes preserve one public response lifecycle across later provider
 rounds.
+
+A nonempty provider terminal output remains authoritative. If the terminal
+omits output after complete output-item events, the loop uses the raw items from
+that provider round to decide local execution. It clears these temporary items
+before the next provider round.
 
 Programmatic tool calls run in a fresh bare V8 isolate. The program has no Node,
 filesystem, or network API. It runs until it finishes or reaches its first


### PR DESCRIPTION
## Summary

- Route complete-response calls for ChatGPT Subscription through the required upstream SSE stream and collect one terminal Response. This covers no-tool callers such as Brain while leaving OpenAI, OpenRouter, and other providers on their existing request path.
- Remove the unsupported truncation field at the ChatGPT protocol boundary. The upstream 0.53.0 branch already removes max_output_tokens.
- When a provider sends complete output-item events and then an empty terminal output array, use the raw items from that provider round for the Tool Search or program decision. Clear those temporary items before the next round and keep every nonempty terminal output authoritative.

## Root cause

Two protocol gaps remained after 0.53.0. A ChatGPT complete-response call without a local tool plan still used the non-streaming driver, which the Codex endpoint rejects. Separately, StreamLoop inspected terminal output before ResponseStream applied its accumulated-item fallback. A sparse ChatGPT terminal could therefore hide the raw server search call from the loop, while the public rewritten tool_search_call was still persisted without its matching tool_search_output. The next continuation was invalid and surfaced as AI 服务返回了错误，请重试。

## Verification

- mix format --check-formatted
- MIX_ENV=test mix compile --warnings-as-errors
- Three focused regression files: 96 passed
- Full AIGateway suite: 480 passed, 9 real-LLM tests excluded by tag
- Full control-plane suite: 1833/1834 passed, 9 excluded. The only failure is the unrelated existing BackgroundAgentJobV2MigrationTest assertion against the local test schema; it reproduces alone as 4/5 passed.

Live ChatGPT Subscription acceptance was not run because the active local provider is OpenRouter.