### PR TITLE
Fix Bearer authentication for Skill-backed MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.57.1 (2026-08-04)
+
+- Fix Skill-backed HTTP MCP authentication after the mcporter migration. Keep each raw bearer token in WorkerEnv, write only its `${VARIABLE}` placeholder into the invocation config, and let mcporter add the required `Bearer` authorization scheme. Add Worker-image integration coverage for the real mcporter HTTP request, keep secrets out of generated files, and correct the MCP-backed Skill contract and proposal.
+
 ## Version 0.57.0 (2026-08-03)
 
 - Declare the Automation Job SDK preload as a Worker entry point for unused-file analysis. The Worker loads this file through `bun --preload`, so it has no static TypeScript import and Knip cannot infer the runtime edge.

--- a/app/agent_computer/src/tools/mcp/mcporter-config.ts
+++ b/app/agent_computer/src/tools/mcp/mcporter-config.ts
@@ -16,7 +16,7 @@ export type MaterializedMCPorterConfig = {
 type MCPorterServer = {
   description?: string
   baseUrl?: string
-  bearerTokenEnv?: string
+  bearerToken?: string
   command?: string
   args?: string[]
   cwd?: string
@@ -41,7 +41,7 @@ export function renderMCPorterConfig(servers: readonly MCPorterConfiguredServer[
         ? {
             ...(server.description ? { description: server.description } : {}),
             baseUrl: server.url,
-            ...(server.bearerTokenEnvVar ? { bearerTokenEnv: server.bearerTokenEnvVar } : {}),
+            ...(server.bearerTokenEnvVar ? { bearerToken: `\${${server.bearerTokenEnvVar}}` } : {}),
             ...filters
           }
         : {

--- a/app/agent_computer/test/integration/mcporter-http-auth.integration.test.ts
+++ b/app/agent_computer/test/integration/mcporter-http-auth.integration.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { materializeMCPorterConfig, type MaterializedMCPorterConfig, type MCPServerConfig } from '../../src/tools/mcp'
+
+describe('mcporter HTTP authentication through the Worker image', () => {
+  let config: MaterializedMCPorterConfig | undefined
+  let root: string | undefined
+  let server: ReturnType<typeof Bun.serve> | undefined
+
+  afterEach(() => {
+    config?.cleanup()
+    config = undefined
+    server?.stop(true)
+    server = undefined
+    if (root) rmSync(root, { recursive: true, force: true })
+    root = undefined
+  })
+
+  it('adds the Bearer scheme to a token resolved from WorkerEnv', async () => {
+    const requests: Array<{ rpcMethod: string | undefined; authorization: string | null }> = []
+    server = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      async fetch(request) {
+        if (request.method !== 'POST') {
+          requests.push({
+            rpcMethod: undefined,
+            authorization: request.headers.get('authorization')
+          })
+          return new Response('SSE stream is not supported', { status: 405, headers: { Allow: 'POST' } })
+        }
+
+        const message = (await request.json()) as { id?: string | number; method?: string }
+        requests.push({
+          rpcMethod: message.method,
+          authorization: request.headers.get('authorization')
+        })
+        if (request.headers.get('authorization') !== 'Bearer integration-token') {
+          return jsonRPCResponse(
+            message.id,
+            undefined,
+            {
+              code: -32001,
+              message: 'unauthorized'
+            },
+            401
+          )
+        }
+
+        if (message.method === 'initialize') {
+          return jsonRPCResponse(message.id, {
+            protocolVersion: '2025-06-18',
+            capabilities: { tools: {} },
+            serverInfo: { name: 'authenticated-fixture', version: '1.0.0' }
+          })
+        }
+        if (message.method === 'notifications/initialized') return new Response(null, { status: 202 })
+        if (message.method === 'tools/list') {
+          return jsonRPCResponse(message.id, {
+            tools: [
+              {
+                name: 'echo',
+                description: 'Echo one value.',
+                inputSchema: { type: 'object', properties: { value: { type: 'string' } } }
+              }
+            ]
+          })
+        }
+        return jsonRPCResponse(message.id, undefined, { code: -32601, message: 'not found' }, 404)
+      }
+    })
+
+    root = mkdtempSync(join(tmpdir(), 'ankole-mcporter-http-auth-'))
+    const servers: MCPServerConfig[] = [
+      {
+        name: 'authenticated-fixture',
+        sourceSkills: ['authenticated-fixture'],
+        transport: 'streamable_http',
+        url: `http://127.0.0.1:${server.port}/mcp`,
+        bearerTokenEnvVar: 'MCP_AUTH_TOKEN'
+      }
+    ]
+    config = materializeMCPorterConfig(servers, { directory: root })
+    const configSource = readFileSync(config.path, 'utf8')
+    expect(configSource).toContain('"bearerToken": "${MCP_AUTH_TOKEN}"')
+    expect(configSource).not.toContain('integration-token')
+
+    const child = Bun.spawn(
+      ['mcporter', 'list', 'authenticated-fixture.echo', '--schema', '--json', '--timeout', '10000'],
+      {
+        env: { ...process.env, ...config.env, MCP_AUTH_TOKEN: 'integration-token' },
+        stdout: 'pipe',
+        stderr: 'pipe'
+      }
+    )
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text()
+    ])
+
+    expect(exitCode, stderr).toBe(0)
+    expect(stdout).toContain('echo')
+    expect(requests.map(request => request.rpcMethod)).toContain('initialize')
+    expect(requests.map(request => request.rpcMethod)).toContain('tools/list')
+    expect(requests.every(request => request.authorization === 'Bearer integration-token')).toBe(true)
+  })
+})
+
+function jsonRPCResponse(
+  id: string | number | undefined,
+  result: unknown,
+  error?: { code: number; message: string },
+  status = 200
+): Response {
+  return Response.json(
+    {
+      jsonrpc: '2.0',
+      ...(id === undefined ? {} : { id }),
+      ...(error ? { error } : { result })
+    },
+    { status }
+  )
+}

--- a/app/agent_computer/test/mcporter-config.test.ts
+++ b/app/agent_computer/test/mcporter-config.test.ts
@@ -53,7 +53,7 @@ describe('@ankole/agent-computer Skill MCPorter config', () => {
           'a-remote': {
             description: 'Remote data',
             baseUrl: 'https://mcp.example.test/rpc',
-            bearerTokenEnv: 'REMOTE_MCP_TOKEN',
+            bearerToken: '${REMOTE_MCP_TOKEN}',
             allowedTools: ['quote']
           },
           'z-local': {

--- a/docs/design-docs/BullXSkillMcporterProposal.zh-Hans.md
+++ b/docs/design-docs/BullXSkillMcporterProposal.zh-Hans.md
@@ -128,8 +128,8 @@ Skill 路由优于 Tool Search。因此，本提案把路由中心合一视为�
   上游明确推荐“一台 MCP server 或一个 workflow 对应一个小 Skill”，由 Skill 调用相关工具，反对
   一个通用 mcporter Skill 重新制造大目录问题。
 - [mcporter 0.13.0 配置规则](https://github.com/openclaw/mcporter/blob/v0.13.0/docs/config.md)：
-  `MCPORTER_CONFIG` 选择唯一配置文件，`imports: []` 关闭宿主配置导入，`bearerTokenEnv` 只保存环境
-  变量名，`allowedTools` 和 `blockedTools` 可以限制发现和调用。
+  `MCPORTER_CONFIG` 选择唯一配置文件，`imports: []` 关闭宿主配置导入，`bearerToken` 接受环境变量
+  placeholder，`allowedTools` 和 `blockedTools` 可以限制发现和调用。
 - mcporter 0.13.0 源码和 `docs/call-syntax.md`：`mcporter call` 支持 `--json -` 从 stdin 读取 JSON
   object，`--output json` 把成功和失败结果写成机器可读 JSON。
 
@@ -234,7 +234,7 @@ BullX 的生成结果等价于：
     "bullx-financial-data": {
       "description": "BullX Financial Data MCP server",
       "baseUrl": "https://ai-terminal.yuma.host/api/v1/financial-data/mcp",
-      "bearerTokenEnv": "BULLX_FINANCIAL_DATA_MCP_API_KEY"
+      "bearerToken": "${BULLX_FINANCIAL_DATA_MCP_API_KEY}"
     }
   }
 }
@@ -245,8 +245,9 @@ BullX 的生成结果等价于：
 - 必须设置 `imports: []`，避免 mcporter 自动导入 Agent Home、Codex、Claude、Cursor 或 VS Code 的
   配置。
 - 必须设置 `MCPORTER_CONFIG`，禁止依赖 cwd 或 `~/.mcporter/mcporter.json` 的偶然内容。
-- 文件只保存 WorkerEnv 变量名，不保存解析后的 secret。
-- `streamable_http` 映射为 `baseUrl` 和 `bearerTokenEnv`。
+- 文件只保存 WorkerEnv 变量 placeholder，不保存解析后的 secret。
+- `streamable_http` 映射为 `baseUrl` 和 `bearerToken` placeholder。mcporter 在执行时解析变量并添加
+  `Bearer` authorization scheme。
 - `stdio` 如仍保留支持，使用 `command: "/bin/sh"` 和 `args: ["-lc", <声明命令>]` 保持当前语义。
 - 只有 `enabled_tools` 时生成 `allowedTools`；只有 `disabled_tools` 时生成 `blockedTools`；两者同时存在
   时生成 `enabled_tools - disabled_tools` 的最终 `allowedTools`，因为 mcporter 不允许两种字段同时存在。
@@ -491,6 +492,7 @@ compatibility branch。
 - 同一 Skill 声明生成 byte-stable mcporter JSON。
 - 配置总是包含 `imports: []`。
 - bearer token value 从不进入配置、错误或日志。
+- 镜像固定的 mcporter 从 placeholder 读取 token，并发送 `Authorization: Bearer <token>`。
 - allowlist、denylist 和两者同时存在时的最终过滤结果正确。
 - 重名相同声明合并，不同声明大声失败。
 - 临时配置使用 `0600`、唯一文件名并在 success、failure、timeout 和 cancellation 后删除。

--- a/docs/design-docs/MCPBackedSkills.md
+++ b/docs/design-docs/MCPBackedSkills.md
@@ -115,9 +115,11 @@ The generated file always contains `imports: []`. The explicit
 `MCPORTER_CONFIG` path and this empty import list prevent mcporter from reading
 an Agent Home, project, Codex, editor, or host MCP config.
 
-An HTTP entry becomes `baseUrl` plus `bearerTokenEnv`. A stdio entry becomes
-`command: /bin/sh` plus `args: [-lc, <declared command>]`. Credential values are
-not read while the file is generated and cannot enter the file.
+An HTTP entry becomes `baseUrl` plus a `bearerToken` `${VARIABLE}` placeholder.
+A stdio entry becomes `command: /bin/sh` plus
+`args: [-lc, <declared command>]`. Credential values are not read while the
+file is generated and cannot enter the file. mcporter resolves the placeholder
+at execution time and adds the standard `Bearer` authorization scheme.
 
 Each execution receives a fresh view:
 
@@ -198,8 +200,8 @@ only while a mcporter list or call process uses it.
 
 WorkerEnv provides credentials to the same trusted sandbox that runs the model
 command or Automation script. The generated file stores only environment
-variable names. A missing variable diagnostic must name the variable and must
-not print a credential value.
+variable placeholders. A missing variable diagnostic must name the variable
+and must not print a credential value.
 
 The server output is untrusted input. Removing the native MCP client also
 removes these client-side guarantees:


### PR DESCRIPTION
## Summary

- Render Skill-backed HTTP MCP credentials as a deferred bearerToken placeholder so the pinned mcporter client adds the standard Bearer authorization scheme.
- Keep WorkerEnv secret values out of invocation-scoped configuration files.
- Add a Worker-image integration test that runs the real mcporter HTTP transport and verifies the received Authorization header.
- Update the normative MCP-backed Skill contract, the BullX migration proposal, and CHANGELOG version 0.56.4.

## Root cause

Commit 88dc2db1 migrated Skill-backed MCP from the native client to mcporter. The old client generated Authorization: Bearer <token>, but the new adapter mapped the token environment variable to bearerTokenEnv. mcporter 0.12.3 treats that field as a complete Authorization value and does not add the Bearer scheme, so BullX rejected initialize with HTTP 401. mcporter then surfaced its SSE fallback 405 instead of the first failure.

## Verification

- bun run lint: 8 packages passed.
- Agent Computer unit suite: 446 passed, 0 failed.
- Agent Computer integration suite: 19 passed, 5 unrelated Browser tests skipped, 0 failed.
- Agent Computer build: 490 modules bundled successfully.
- Real BullX acceptance: bullx_market_data_get_realtime_quote schema loaded successfully and the read-only 001208.SZ call succeeded with request ID 019fc6b5-812c-7da2-b839-e9af63514984.
- The invocation-scoped config cleanup was read back after the live call.