### PR TITLE
fix: flatten namespaced tool-call history for OpenAI compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.62.2 (2026-08-09)
+
+- Project namespaced `function_call` and `custom_tool_call` history even when a Responses request has no current tool declaration. Codex automatic compaction sends this shape after its Responses Lite carrier becomes empty, so strict OpenAI-compatible providers now receive the existing flat provider alias instead of rejecting the replayed `namespace` field. Cover ordinary function replay, the exact empty-carrier custom-tool shape, and the OpenAI-compatible dispatch boundary.
+
 ## Version 0.62.1 (2026-08-09)
 
 - Flatten namespaced `custom_tool_call` history at the generic Responses provider boundary with the same provider alias used by its tool declaration. Strict OpenAI-compatible providers now receive `functions__exec` without the Ankole `namespace` field when Codex replays an `exec` result, instead of rejecting the next request with `unknown_parameter`. Keep the public Codex call as `functions.exec`, preserve the existing type-independent output restoration, and cover declaration, replay, output pairing, and public restoration in one focused regression test.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.62.1 (2026-08-09)
+
+- Flatten namespaced `custom_tool_call` history at the generic Responses provider boundary with the same provider alias used by its tool declaration. Strict OpenAI-compatible providers now receive `functions__exec` without the Ankole `namespace` field when Codex replays an `exec` result, instead of rejecting the next request with `unknown_parameter`. Keep the public Codex call as `functions.exec`, preserve the existing type-independent output restoration, and cover declaration, replay, output pairing, and public restoration in one focused regression test.
+
 ## Version 0.62.0 (2026-08-09)
 
 - Align `/steer` with Codex pending-input behavior. A steer no longer aborts the active AIGateway WebSocket model call; the Worker keeps the completed model result and any tool result, then adds the queued steer to the next model request at the existing tool-result boundary. Explicit Turn cancellation still aborts the WebSocket through the turn-scoped signal, and wait-like Background Agent Job tools can still use steering as an explicit wake-up signal. Move the visible reply handoff from steer admission to the exact `turn_accepted` revision, so the old card continues to receive progress until the Worker has put the steer into model input. If the current Turn finishes at an older revision, the stale delivery is superseded and the open steer starts the next Turn. This removes the v0.61.5 generic provider-call preemption without restoring the frozen `continued` card that it was added to prevent.

--- a/app/control_plane/lib/ankole/ai_gateway/tool_search.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/tool_search.ex
@@ -65,9 +65,9 @@ defmodule Ankole.AIGateway.ToolSearch do
   Rewrites one Responses request into a provider-safe request plus a plan.
 
   Requests without a `tool_search` declaration, without `defer_loading` tools,
-  and without PTC surface pass through unchanged with a `nil` plan. Invalid
-  declarations fail loudly instead of reaching a provider that cannot serve
-  them.
+  without PTC surface, and without history that needs provider projection pass
+  through unchanged with a `nil` plan. Invalid declarations fail loudly instead
+  of reaching a provider that cannot serve them.
   """
   @spec plan(map()) :: {:ok, map(), Plan.t() | nil} | {:error, term()}
   def plan(%{} = request) do
@@ -90,7 +90,7 @@ defmodule Ankole.AIGateway.ToolSearch do
         declared_search? or settled_search_history?(history) or client_search_history?(history)
 
       projection_required? =
-        settled_program_history?(history) or
+        namespaced_call_history?(history) or settled_program_history?(history) or
           Enum.any?(contracts, fn contract ->
             contract.deferred? or
               not is_nil(contract.namespace) or
@@ -541,6 +541,20 @@ defmodule Ankole.AIGateway.ToolSearch do
   end
 
   defp settled_program_history?(_history), do: false
+
+  defp namespaced_call_history?(%ResponseItems.History{entries: entries}) do
+    Enum.any?(entries, fn
+      %{
+        item: %{"type" => type, "namespace" => namespace, "name" => name}
+      }
+      when type in ["function_call", "custom_tool_call"] and is_binary(namespace) and
+             is_binary(name) ->
+        true
+
+      _entry ->
+        false
+    end)
+  end
 
   defp settled_search_history?(%ResponseItems.History{error: nil, ledger: ledger}) do
     pairs = ResponseItems.search_pairs(ledger)

--- a/app/control_plane/lib/ankole/ai_gateway/tool_search.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/tool_search.ex
@@ -846,9 +846,10 @@ defmodule Ankole.AIGateway.ToolSearch do
   end
 
   defp rewrite_ordinary_input_item(
-         %{"type" => "function_call", "namespace" => namespace, "name" => name} = item
+         %{"type" => type, "namespace" => namespace, "name" => name} = item
        )
-       when is_binary(namespace) and is_binary(name) do
+       when type in ["function_call", "custom_tool_call"] and is_binary(namespace) and
+              is_binary(name) do
     item
     |> Map.put("name", ToolContract.provider_alias(namespace, name))
     |> Map.delete("namespace")

--- a/app/control_plane/test/ankole/ai_gateway/responses_dispatch_test.exs
+++ b/app/control_plane/test/ankole/ai_gateway/responses_dispatch_test.exs
@@ -198,6 +198,61 @@ defmodule Ankole.AIGateway.ResponsesDispatchTest do
            ]
   end
 
+  test "openai-compatible Responses flattens namespaced replay without current tools" do
+    %{principal: agent} = agent_fixture()
+
+    base_url =
+      start_recording_upstream(self(), fn _request ->
+        {:json, 200,
+         %{
+           "id" => "resp_compaction_replay",
+           "object" => "response",
+           "status" => "completed",
+           "output" => [],
+           "usage" => %{}
+         }}
+      end)
+
+    configure_openai_compatible_responses_provider!(
+      agent.uid,
+      base_url,
+      "compatible-compaction-replay"
+    )
+
+    assert {:ok, %{body: %{"id" => "resp_compaction_replay"}}} =
+             AIGateway.create_response(agent.uid, %{
+               "model" => "primary",
+               "tools" => nil,
+               "client_metadata" => %{
+                 "ws_request_header_x_openai_internal_codex_responses_lite" => "true"
+               },
+               "input" => [
+                 %{"type" => "additional_tools", "role" => "developer", "tools" => []},
+                 %{
+                   "type" => "custom_tool_call",
+                   "call_id" => "call_apply_patch",
+                   "namespace" => "functions",
+                   "name" => "apply_patch",
+                   "input" => "*** Begin Patch"
+                 },
+                 %{
+                   "type" => "custom_tool_call_output",
+                   "call_id" => "call_apply_patch",
+                   "output" => "Done!"
+                 }
+               ]
+             })
+
+    assert_receive {:gateway_request, request}
+    assert request.body["tools"] == []
+
+    [provider_call, provider_output] = request.body["input"]
+    assert provider_call["type"] == "custom_tool_call"
+    assert provider_call["name"] == "functions__apply_patch"
+    refute Map.has_key?(provider_call, "namespace")
+    assert provider_output["call_id"] == provider_call["call_id"]
+  end
+
   test "first-party OpenAI preserves PTC tools whose execution owner is native" do
     %{principal: agent} = agent_fixture()
 

--- a/app/control_plane/test/ankole/ai_gateway/tool_search_test.exs
+++ b/app/control_plane/test/ankole/ai_gateway/tool_search_test.exs
@@ -250,6 +250,54 @@ defmodule Ankole.AIGateway.ToolSearchTest do
       assert public_call["name"] == "stock_price"
     end
 
+    test "flattens namespaced custom tool history for provider replay" do
+      namespace = %{
+        "type" => "namespace",
+        "name" => "functions",
+        "description" => "Functions.",
+        "tools" => [
+          %{
+            "type" => "custom",
+            "name" => "exec",
+            "description" => "Run one tool program.",
+            "format" => %{"type" => "text"}
+          }
+        ]
+      }
+
+      request =
+        base_request([namespace], [
+          %{
+            "type" => "custom_tool_call",
+            "call_id" => "call_exec",
+            "namespace" => "functions",
+            "name" => "exec",
+            "input" => "return await tools.shell()"
+          },
+          %{
+            "type" => "custom_tool_call_output",
+            "call_id" => "call_exec",
+            "output" => "ok"
+          }
+        ])
+
+      assert {:ok, provider_request, plan} = ToolSearch.plan(request)
+
+      assert [%{"type" => "custom", "name" => "functions__exec"}] =
+               provider_request["tools"]
+
+      [provider_call, provider_output] = provider_request["input"]
+      assert provider_call["type"] == "custom_tool_call"
+      assert provider_call["name"] == "functions__exec"
+      refute Map.has_key?(provider_call, "namespace")
+      assert provider_output["type"] == "custom_tool_call_output"
+      assert provider_output["call_id"] == provider_call["call_id"]
+
+      public_call = ToolSearch.public_function_call(plan, provider_call)
+      assert public_call["namespace"] == "functions"
+      assert public_call["name"] == "exec"
+    end
+
     test "rejects a base tool colliding with the search tool name" do
       request =
         base_request([

--- a/app/control_plane/test/ankole/ai_gateway/tool_search_test.exs
+++ b/app/control_plane/test/ankole/ai_gateway/tool_search_test.exs
@@ -298,6 +298,67 @@ defmodule Ankole.AIGateway.ToolSearchTest do
       assert public_call["name"] == "exec"
     end
 
+    test "flattens namespaced custom tool history with an empty Responses Lite carrier" do
+      request = %{
+        "model" => "gpt-5.6",
+        "tools" => nil,
+        "input" => [
+          %{"type" => "additional_tools", "role" => "developer", "tools" => []},
+          %{
+            "type" => "custom_tool_call",
+            "call_id" => "call_apply_patch",
+            "namespace" => "functions",
+            "name" => "apply_patch",
+            "input" => "*** Begin Patch"
+          },
+          %{
+            "type" => "custom_tool_call_output",
+            "call_id" => "call_apply_patch",
+            "output" => "Done!"
+          }
+        ]
+      }
+
+      assert {:ok, provider_request, %ToolSearch.Plan{}} = ToolSearch.plan(request)
+
+      [carrier, provider_call, provider_output] = provider_request["input"]
+      assert carrier["tools"] == []
+      assert provider_request["tools"] == nil
+      assert provider_call["type"] == "custom_tool_call"
+      assert provider_call["name"] == "functions__apply_patch"
+      refute Map.has_key?(provider_call, "namespace")
+      assert provider_output["call_id"] == provider_call["call_id"]
+    end
+
+    test "flattens namespaced function history without current tools" do
+      request = %{
+        "model" => "gpt-5.6",
+        "input" => [
+          %{
+            "type" => "function_call",
+            "call_id" => "call_shell",
+            "namespace" => "functions",
+            "name" => "shell",
+            "arguments" => "{}"
+          },
+          %{
+            "type" => "function_call_output",
+            "call_id" => "call_shell",
+            "output" => "ok"
+          }
+        ]
+      }
+
+      assert {:ok, provider_request, %ToolSearch.Plan{}} = ToolSearch.plan(request)
+
+      [provider_call, provider_output] = provider_request["input"]
+      assert provider_request["tools"] == []
+      assert provider_call["type"] == "function_call"
+      assert provider_call["name"] == "functions__shell"
+      refute Map.has_key?(provider_call, "namespace")
+      assert provider_output["call_id"] == provider_call["call_id"]
+    end
+
     test "rejects a base tool colliding with the search tool name" do
       request =
         base_request([


### PR DESCRIPTION
## Problem

Ankole exposes namespaced tools to Codex but must flatten them for strict OpenAI-compatible Responses providers. The declaration path already used the provider alias (`namespace__name`), while replayed history could still reach the provider with Ankole's public `namespace` field.

The first failure appeared after an `exec` result as HTTP 400 `unknown_parameter` for `input[n].namespace`. A second path remained after the initial custom-tool fix: Codex automatic compaction can send a Responses Lite carrier with no current tool declaration. `ToolSearch.plan/1` then returned no projection plan, so namespaced `function_call` or `custom_tool_call` history bypassed provider projection entirely.

## Solution

- Treat namespaced `function_call` and `custom_tool_call` history as requiring provider projection, even when the current request has no tool declaration.
- Rewrite both history item types with the existing `ToolContract.provider_alias/2` and remove the provider-unsupported `namespace` field.
- Preserve each call/output pair through its existing `call_id`.
- Cover the exact empty Responses Lite carrier produced after compaction at the OpenAI-compatible dispatch boundary.

This keeps the public Codex tool identity namespaced while sending strict providers the flat alias they already receive in tool declarations.

## Commit breakdown

1. `3969056c` flattens namespaced `custom_tool_call` replay when the request already creates a tool projection plan and records version 0.62.1.
2. `46e30091` makes namespaced history itself create the plan, covers both ordinary function and custom calls without current declarations, adds the dispatch regression, and records version 0.62.2.

## Validation

- `MIX_ENV=test mix test test/ankole/ai_gateway/tool_search_test.exs test/ankole/ai_gateway/responses_dispatch_test.exs` — 133 passed.
- `bun run --filter @ankole/control-plane type-check` — passed.
- `bun run fmt:check` — 9 tasks passed.
- A real local BackgroundAgentJob through `coding -> gflux` completed successfully after namespaced tool replay and delivered its final response.

A broader Control Plane suite run completed 2,012 tests with two unrelated local-state failures: `BackgroundAgentJobV2MigrationTest` found an already-present `agent_plugin_ids` column, and `ChatGPTAuthTest` reused an existing refresh credential instead of entering the expected device authorization flow.
