### PR TITLE
feat: project provider-hosted web_search from Responses connections end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 0.66.0 (2026-08-12)
+
+- Let an OpenAI-compatible Responses connection declare provider-hosted `web_search`, and project that capability end to end: Main Turns declare the hosted tool to the provider, and Background Agent Jobs enable Codex live web search from the same frozen declaration.
+- Reject `hosted_web_search` on a connection whose `endpoint_kind` is not `responses`.
+
 ## Version 0.65.0 (2026-08-12)
 
 - Run each recurring Agent or BackgroundAgentJob task once and deliver the same final reply and attachments through one independently retryable outbox row for each configured Signal target.

--- a/app/agent_computer/src/core/codex-runner/project-config.ts
+++ b/app/agent_computer/src/core/codex-runner/project-config.ts
@@ -15,14 +15,21 @@ export function readCodexJobProjectConfig(projectRoot: string): Record<string, u
 /**
  * Applies Job execution settings and runner safety invariants over the
  * project initialized from selected Agent Plugin workspace templates.
+ *
+ * `hostedWebSearch` mirrors the Job's frozen hosted-tool projection: the
+ * provider connection decides Codex `web_search`, never the workspace
+ * template.
  */
-export function materializeCodexJobProjectConfig(input: { projectRoot: string }): MaterializedCodexJobProjectConfig {
+export function materializeCodexJobProjectConfig(input: {
+  projectRoot: string
+  hostedWebSearch: boolean
+}): MaterializedCodexJobProjectConfig {
   const path = join(input.projectRoot, '.codex', 'config.toml')
   const config = readToml(path)
 
   removeThreadRuntimeConfig(config)
   delete config.mcp_servers
-  applyRunnerSafety(config)
+  applyRunnerSafety(config, input.hostedWebSearch)
   // The published Bun types lag the canary runtime's documented stringify API.
   atomicWrite(path, (TOML as typeof TOML & { stringify(value: object): string }).stringify(config))
 
@@ -37,11 +44,11 @@ function removeThreadRuntimeConfig(config: TomlTable): void {
   delete config.service_tier
 }
 
-function applyRunnerSafety(config: TomlTable): void {
+function applyRunnerSafety(config: TomlTable, hostedWebSearch: boolean): void {
   config.approval_policy = 'never'
   config.sandbox_mode = 'danger-full-access'
   config.cli_auth_credentials_store = 'file'
-  config.web_search = 'disabled'
+  config.web_search = hostedWebSearch ? 'live' : 'disabled'
   config.project_doc_max_bytes = 131_072
 
   const features = tableAt(config, 'features')

--- a/app/agent_computer/src/core/codex-runner/setup.ts
+++ b/app/agent_computer/src/core/codex-runner/setup.ts
@@ -123,7 +123,8 @@ export async function prepareCodexJobExecution(input: CodexJobSetupInput) {
     agentUID: job.agentUid
   })
   materializeCodexJobProjectConfig({
-    projectRoot: jobProject.root
+    projectRoot: jobProject.root,
+    hostedWebSearch: (turnStart.hosted_tools ?? []).some(tool => tool.type === 'web_search')
   })
   const projectionAPIKey = runtimeConfig.aiGatewayKey
   opts.abortSignal?.throwIfAborted()

--- a/app/agent_computer/src/core/llm/types.ts
+++ b/app/agent_computer/src/core/llm/types.ts
@@ -123,7 +123,7 @@ export interface ToolDefinition<TSchema extends z.ZodType = z.ZodType> {
 
 export type ToolSet = Record<string, ToolDefinition>
 
-export type HostedTool = { type: 'image_generation' }
+export type HostedTool = { type: 'image_generation' } | { type: 'web_search' }
 
 export interface CallModelOptions {
   instructions?: string

--- a/app/agent_computer/src/core/llm/wire.ts
+++ b/app/agent_computer/src/core/llm/wire.ts
@@ -26,9 +26,7 @@ export function buildResponseCreateParams(model: ModelConfig, options: CallModel
     ...localTools,
     ...(hasDeferredTools ? [{ type: 'tool_search' as const, execution: 'server' as const }] : []),
     ...(options.programmaticToolCalling ? [{ type: 'programmatic_tool_calling' as const }] : []),
-    ...(options.hostedTools ?? []).map(() => ({
-      type: 'image_generation' as const
-    }))
+    ...(options.hostedTools ?? []).map(tool => ({ type: tool.type }))
   ]
   const promptCacheKey = reusablePromptCacheKey(options.instructions, tools)
 

--- a/app/agent_computer/src/lanes/actor_lane.ts
+++ b/app/agent_computer/src/lanes/actor_lane.ts
@@ -59,7 +59,9 @@ export type TurnStart = {
   runtime_env?: Record<string, string>
 }
 
-export type TurnHostedTool = { type: 'image_generation' }
+export type TurnHostedTool = { type: 'image_generation' } | { type: 'web_search' }
+
+const TURN_HOSTED_TOOL_TYPES = new Set(['image_generation', 'web_search'])
 
 export type TurnSteerUpdate = {
   turn: ActorTurnRef
@@ -248,9 +250,14 @@ function turnHostedToolsFromBytes(bytes: Uint8Array): TurnHostedTool[] | undefin
   if (!Array.isArray(value)) throw new Error('turn_start.hosted_tools must be an array')
 
   return value.map((tool, index) => {
-    if (!isRecord(tool) || tool.type !== 'image_generation' || Object.keys(tool).length !== 1) {
-      throw new Error(`turn_start.hosted_tools[${index}] must declare only image_generation`)
+    if (
+      !isRecord(tool) ||
+      typeof tool.type !== 'string' ||
+      !TURN_HOSTED_TOOL_TYPES.has(tool.type) ||
+      Object.keys(tool).length !== 1
+    ) {
+      throw new Error(`turn_start.hosted_tools[${index}] must declare a supported hosted tool type`)
     }
-    return { type: 'image_generation' }
+    return { type: tool.type } as TurnHostedTool
   })
 }

--- a/app/agent_computer/test/codex-runner-project-config.test.ts
+++ b/app/agent_computer/test/codex-runner-project-config.test.ts
@@ -32,7 +32,8 @@ describe('@ankole/agent-computer Codex job project config', () => {
 
     try {
       const materialized = materializeCodexJobProjectConfig({
-        projectRoot: root
+        projectRoot: root,
+        hostedWebSearch: false
       })
       const config = TOML.parse(readFileSync(configPath, 'utf8')) as Record<string, any>
 
@@ -62,6 +63,20 @@ describe('@ankole/agent-computer Codex job project config', () => {
     }
   })
 
+  it('enables Codex web search only from the projected hosted-tool declaration', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ankole-codex-project-config-web-search-'))
+    try {
+      materializeCodexJobProjectConfig({
+        projectRoot: root,
+        hostedWebSearch: true
+      })
+      const config = TOML.parse(readFileSync(join(root, '.codex', 'config.toml'), 'utf8')) as Record<string, any>
+      expect(config.web_search).toBe('live')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('fails closed on invalid template config', () => {
     const root = mkdtempSync(join(tmpdir(), 'ankole-codex-project-config-invalid-'))
     mkdirSync(join(root, '.codex'), { recursive: true })
@@ -69,7 +84,8 @@ describe('@ankole/agent-computer Codex job project config', () => {
     try {
       expect(() =>
         materializeCodexJobProjectConfig({
-          projectRoot: root
+          projectRoot: root,
+          hostedWebSearch: false
         })
       ).toThrow('invalid Codex project config')
     } finally {
@@ -81,9 +97,11 @@ describe('@ankole/agent-computer Codex job project config', () => {
     const root = mkdtempSync(join(tmpdir(), 'ankole-codex-project-config-default-'))
     try {
       materializeCodexJobProjectConfig({
-        projectRoot: root
+        projectRoot: root,
+        hostedWebSearch: false
       })
       const config = TOML.parse(readFileSync(join(root, '.codex', 'config.toml'), 'utf8')) as Record<string, any>
+      expect(config.web_search).toBe('disabled')
       expect(config.features.plugins).toBe(false)
       expect(config.model).toBeUndefined()
       expect(config.model_provider).toBeUndefined()

--- a/app/agent_computer/test/integration/codex-app-server-contract.integration.test.ts
+++ b/app/agent_computer/test/integration/codex-app-server-contract.integration.test.ts
@@ -767,7 +767,8 @@ test ! -e ./AGENTS.override.md
     resetCodexAgentRuntimeConfig(materialized.codexHome, runtimeConfig.aiGatewayKey.baseUrl)
     refreshCodexAgentRuntimeCredential(materialized.codexHome, runtimeConfig.aiGatewayKey.apiKey)
     materializeCodexJobProjectConfig({
-      projectRoot: project.root
+      projectRoot: project.root,
+      hostedWebSearch: false
     })
     appendOptionalMCPFixtures(project.root)
     let realClient: CodexAppServerClient | undefined

--- a/app/agent_computer/test/llm/responses-wire.test.ts
+++ b/app/agent_computer/test/llm/responses-wire.test.ts
@@ -173,15 +173,15 @@ describe('@ankole/agent-computer llm helpers: Responses HTTP and WebSocket wire 
       hostedTools: [{ type: 'image_generation' }]
     })
     const hostedOnly = buildResponseCreateParams(model, {
-      messages: [{ role: 'user', content: 'draw' }],
-      hostedTools: [{ type: 'image_generation' }]
+      messages: [{ role: 'user', content: 'draw and research' }],
+      hostedTools: [{ type: 'image_generation' }, { type: 'web_search' }]
     })
 
     expect(withHosted.tools).toEqual([
       expect.objectContaining({ type: 'function', name: 'annotate' }),
       { type: 'image_generation' }
     ])
-    expect(hostedOnly.tools).toEqual([{ type: 'image_generation' }])
+    expect(hostedOnly.tools).toEqual([{ type: 'image_generation' }, { type: 'web_search' }])
     expect(withHosted.prompt_cache_key).not.toBe(withoutHosted.prompt_cache_key)
   })
 

--- a/app/agent_computer/test/runtime.test.ts
+++ b/app/agent_computer/test/runtime.test.ts
@@ -410,7 +410,7 @@ describe('@ankole/agent-computer runtime', () => {
     })
   })
 
-  it('accepts only the image generation hosted-tool declaration on turn_start', () => {
+  it('accepts only supported hosted-tool declarations on turn_start', () => {
     const hostedToolsEnvelope = (hostedTools: unknown): Envelope =>
       createEnvelope({
         ...envelopeHeader('turn-start-hosted-tools'),
@@ -430,11 +430,14 @@ describe('@ankole/agent-computer runtime', () => {
         }
       })
 
-    expect(turnStartFromEnvelope(hostedToolsEnvelope([{ type: 'image_generation' }])).hosted_tools).toEqual([
-      { type: 'image_generation' }
-    ])
+    expect(
+      turnStartFromEnvelope(hostedToolsEnvelope([{ type: 'image_generation' }, { type: 'web_search' }])).hosted_tools
+    ).toEqual([{ type: 'image_generation' }, { type: 'web_search' }])
+    expect(() => turnStartFromEnvelope(hostedToolsEnvelope([{ type: 'computer_use' }]))).toThrow(
+      /must declare a supported hosted tool type/
+    )
     expect(() => turnStartFromEnvelope(hostedToolsEnvelope([{ type: 'function', name: 'untrusted' }]))).toThrow(
-      /must declare only image_generation/
+      /must declare a supported hosted tool type/
     )
   })
 

--- a/app/control_plane/lib/ankole/ai_gateway/provider_configs.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/provider_configs.ex
@@ -81,6 +81,32 @@ defmodule Ankole.AIGateway.ProviderConfigs do
   end
 
   @doc """
+  Returns whether the model's active provider connection declares the
+  provider-hosted `web_search` tool.
+
+  The write path already enforces that `hosted_web_search` pairs with a
+  Responses endpoint, so this read checks only the stored declaration. A
+  missing, disabled, or re-kinded provider row declares nothing.
+  """
+  @spec supports_hosted_web_search?(map()) :: boolean()
+  def supports_hosted_web_search?(%{
+        "provider_id" => provider_id,
+        "provider_kind" => provider_kind
+      })
+      when is_binary(provider_id) and is_binary(provider_kind) do
+    case fetch_active_provider(provider_id) do
+      {:ok, %Provider{provider_kind: ^provider_kind, connection_options: options}}
+      when is_map(options) ->
+        Map.get(options, "hosted_web_search") == true
+
+      _unavailable_or_changed ->
+        false
+    end
+  end
+
+  def supports_hosted_web_search?(_model_ref), do: false
+
+  @doc """
   Returns a safe projection for one provider.
   """
   @spec get_provider(String.t()) :: {:ok, map()} | {:error, term()}

--- a/app/control_plane/lib/ankole/ai_gateway/providers.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/providers.ex
@@ -167,7 +167,8 @@ defmodule Ankole.AIGateway.Providers do
     with {:ok, provider} <- fetch(provider_kind),
          :ok <-
            reject_unknown_keys(options, connection_option_keys(provider), :connection_options),
-         :ok <- validate_setting_options(provider, :connection, options, :connection_options) do
+         :ok <- validate_setting_options(provider, :connection, options, :connection_options),
+         :ok <- validate_provider_connection_options(provider, options) do
       {:ok, options}
     end
   end
@@ -204,6 +205,14 @@ defmodule Ankole.AIGateway.Providers do
 
   def normalize_credential_options(_provider_kind, _options),
     do: {:error, :invalid_credential_options}
+
+  defp validate_provider_connection_options(provider, options) do
+    if function_exported?(provider.module, :validate_connection_options, 1) do
+      provider.module.validate_connection_options(options)
+    else
+      :ok
+    end
+  end
 
   defp validate_provider_credential_options(provider, options) do
     if function_exported?(provider.module, :validate_credential_options, 1) do

--- a/app/control_plane/lib/ankole/ai_gateway/providers/openai_compatible.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/providers/openai_compatible.ex
@@ -14,6 +14,7 @@ defmodule Ankole.AIGateway.Providers.OpenAICompatible do
 
     setting(:api_key, encrypted: true, scope: :credential)
     setting(:endpoint_kind, default: "chat_completions")
+    setting(:hosted_web_search, type: :boolean, default: false)
     setting(:headers, type: :map, advanced: true)
     setting(:query_params, type: :map, advanced: true)
 
@@ -58,6 +59,20 @@ defmodule Ankole.AIGateway.Providers.OpenAICompatible do
         |> UniversalAIRequest.new("chat/completions", :openai_chat_completions)
         |> UniversalAIRequest.bearer_auth()
         |> ReasoningEffort.put_provider_options(ctx, target: :reasoning_effort)
+    end
+  end
+
+  @doc """
+  Rejects hosted `web_search` on a connection that does not use the Responses
+  endpoint. Hosted tools ride the Responses wire, so a Chat Completions
+  connection cannot serve them.
+  """
+  def validate_connection_options(options) when is_map(options) do
+    if Map.get(options, "hosted_web_search") == true and
+         Map.get(options, "endpoint_kind") != "responses" do
+      {:error, {:connection_options, {:hosted_web_search_requires_endpoint_kind, "responses"}}}
+    else
+      :ok
     end
   end
 

--- a/app/control_plane/lib/ankole/background_agent_jobs/runtime_projection.ex
+++ b/app/control_plane/lib/ankole/background_agent_jobs/runtime_projection.ex
@@ -168,9 +168,18 @@ defmodule Ankole.BackgroundAgentJobs.RuntimeProjection do
 
   defp hosted_tool_overrides(projection) do
     case Map.fetch(projection, "hosted_tools") do
-      {:ok, [%{}] = hosted_tools} -> {:ok, %{hosted_tools: hosted_tools}}
-      :error -> {:ok, %{}}
-      _invalid -> {:error, :background_agent_job_runtime_projection_invalid}
+      {:ok, [_ | _] = hosted_tools} ->
+        if Enum.all?(hosted_tools, &is_map/1) do
+          {:ok, %{hosted_tools: hosted_tools}}
+        else
+          {:error, :background_agent_job_runtime_projection_invalid}
+        end
+
+      :error ->
+        {:ok, %{}}
+
+      _invalid ->
+        {:error, :background_agent_job_runtime_projection_invalid}
     end
   end
 

--- a/app/control_plane/lib/ankole/signals_gateway/actor_runtime/turn_envelope.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/actor_runtime/turn_envelope.ex
@@ -165,19 +165,36 @@ defmodule Ankole.SignalsGateway.ActorRuntime.TurnEnvelope do
     end
   end
 
+  @supported_hosted_tool_types ["image_generation", "web_search"]
+
   defp turn_hosted_tools(turn_start_spec) do
     case map_get(turn_start_spec, :hosted_tools) do
-      [%{} = tool] -> normalize_turn_hosted_tool(tool)
-      nil -> nil
-      tools -> raise ArgumentError, "invalid turn hosted tools: #{inspect(tools)}"
+      [_ | _] = tools ->
+        normalized = Enum.map(tools, &normalize_turn_hosted_tool/1)
+
+        if normalized != Enum.uniq(normalized) do
+          raise ArgumentError, "duplicate turn hosted tools: #{inspect(tools)}"
+        end
+
+        normalized
+
+      nil ->
+        nil
+
+      tools ->
+        raise ArgumentError, "invalid turn hosted tools: #{inspect(tools)}"
+    end
+  end
+
+  defp normalize_turn_hosted_tool(%{} = tool) do
+    case map_get(tool, :type) do
+      type when type in @supported_hosted_tool_types -> %{"type" => type}
+      type -> raise ArgumentError, "unsupported turn hosted tool: #{inspect(type)}"
     end
   end
 
   defp normalize_turn_hosted_tool(tool) do
-    case map_get(tool, :type) do
-      "image_generation" -> [%{"type" => "image_generation"}]
-      type -> raise ArgumentError, "unsupported turn hosted tool: #{inspect(type)}"
-    end
+    raise ArgumentError, "invalid turn hosted tool: #{inspect(tool)}"
   end
 
   defp map_get(map, key) when is_atom(key) and is_map(map) do

--- a/app/control_plane/lib/ankole/signals_gateway/actor_runtime/turn_policy.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/actor_runtime/turn_policy.ex
@@ -2,6 +2,7 @@ defmodule Ankole.SignalsGateway.ActorRuntime.TurnPolicy do
   @moduledoc false
 
   alias Ankole.AIAgent.ModelProfiles
+  alias Ankole.AIGateway.ProviderConfigs
   alias Ankole.AIGateway.Providers
   alias Ankole.SignalsGateway.ActorRuntime.AgentConfig
 
@@ -94,13 +95,28 @@ defmodule Ankole.SignalsGateway.ActorRuntime.TurnPolicy do
   end
 
   defp hosted_tools(agent_uid, model_ref) do
+    case image_generation_hosted_tools(agent_uid, model_ref) ++ web_search_hosted_tools(model_ref) do
+      [] -> nil
+      tools -> tools
+    end
+  end
+
+  defp image_generation_hosted_tools(agent_uid, model_ref) do
     if Providers.supports_native_image_generation?(model_ref) do
       [%{"type" => "image_generation"}]
     else
       case ModelProfiles.resolve_runtime_profile(agent_uid, "image_generate") do
         {:ok, _runtime_profile} -> [%{"type" => "image_generation"}]
-        {:error, _reason} -> nil
+        {:error, _reason} -> []
       end
+    end
+  end
+
+  defp web_search_hosted_tools(model_ref) do
+    if ProviderConfigs.supports_hosted_web_search?(model_ref) do
+      [%{"type" => "web_search"}]
+    else
+      []
     end
   end
 

--- a/app/control_plane/test/ankole/ai_gateway/provider_runtime_test.exs
+++ b/app/control_plane/test/ankole/ai_gateway/provider_runtime_test.exs
@@ -971,6 +971,50 @@ defmodule Ankole.AIGateway.ProviderRuntimeTest do
     assert turn_start_spec.hosted_tools == [%{"type" => "image_generation"}]
   end
 
+  test "turn start specs declare hosted web search from the provider connection" do
+    %{principal: agent} = agent_fixture()
+
+    assert {:ok, provider} =
+             ProviderConfigs.create_provider(%{
+               provider_id: "compat-hosted-search",
+               provider_kind: "openai_compatible",
+               base_url: "https://compat.example.test/v1",
+               connection_options: %{
+                 "endpoint_kind" => "responses",
+                 "hosted_web_search" => true
+               },
+               credential_pool: %{"entries" => [%{"label" => "Default", "api_key" => "sk-test"}]}
+             })
+
+    assert {:ok, _profile} =
+             ModelProfiles.put_model_profile(agent.uid, "primary", %{
+               provider_id: "compat-hosted-search",
+               model: "sonar-live"
+             })
+
+    actor_key = %{agent_uid: agent.uid, session_id: "session-hosted-web-search"}
+
+    assert {:ok, turn_start_spec} = TurnPolicy.build_turn_start_spec(actor_key)
+    assert turn_start_spec.hosted_tools == [%{"type" => "web_search"}]
+
+    assert {:ok, _provider} =
+             ProviderConfigs.update_provider(provider.provider_id, %{
+               "connection_options" => %{"endpoint_kind" => "responses"}
+             })
+
+    assert {:ok, turn_start_spec} = TurnPolicy.build_turn_start_spec(actor_key)
+    refute Map.has_key?(turn_start_spec, :hosted_tools)
+
+    assert {:error,
+            {:connection_options, {:hosted_web_search_requires_endpoint_kind, "responses"}}} =
+             ProviderConfigs.update_provider(provider.provider_id, %{
+               "connection_options" => %{
+                 "endpoint_kind" => "chat_completions",
+                 "hosted_web_search" => true
+               }
+             })
+  end
+
   test "turn start specs include scoped agent runtime policy without creating a default output cap" do
     %{principal: agent} = agent_fixture()
     assert :ok = AgentConfig.ensure_registered()

--- a/app/control_plane/test/ankole/ai_gateway/responses_dispatch_test.exs
+++ b/app/control_plane/test/ankole/ai_gateway/responses_dispatch_test.exs
@@ -253,6 +253,38 @@ defmodule Ankole.AIGateway.ResponsesDispatchTest do
     assert provider_output["call_id"] == provider_call["call_id"]
   end
 
+  test "openai-compatible Responses passes the hosted web_search declaration through" do
+    %{principal: agent} = agent_fixture()
+
+    base_url =
+      start_recording_upstream(self(), fn _request ->
+        {:json, 200,
+         %{
+           "id" => "resp_hosted_web_search",
+           "object" => "response",
+           "status" => "completed",
+           "output" => [],
+           "usage" => %{}
+         }}
+      end)
+
+    configure_openai_compatible_responses_provider!(
+      agent.uid,
+      base_url,
+      "compatible-hosted-search"
+    )
+
+    assert {:ok, %{body: %{"id" => "resp_hosted_web_search"}}} =
+             AIGateway.create_response(agent.uid, %{
+               "model" => "primary",
+               "input" => "current weather in Berlin",
+               "tools" => [%{"type" => "web_search"}]
+             })
+
+    assert_receive {:gateway_request, request}
+    assert request.body["tools"] == [%{"type" => "web_search"}]
+  end
+
   test "first-party OpenAI preserves PTC tools whose execution owner is native" do
     %{principal: agent} = agent_fixture()
 

--- a/app/control_plane/test/ankole/background_agent_jobs_test.exs
+++ b/app/control_plane/test/ankole/background_agent_jobs_test.exs
@@ -1294,6 +1294,39 @@ defmodule Ankole.BackgroundAgentJobsTest do
     assert second_attempt.runtime_projection["model_ref"]["model"] == "openai/gpt-5.6-sol"
   end
 
+  test "runtime projections carry the frozen hosted tool declarations" do
+    %{principal: agent} = background_agent_fixture()
+    job = create_job!(agent.uid, "hosted-tool-projection")
+
+    spec =
+      runtime_turn_start_spec()
+      |> Map.put(:hosted_tools, [%{"type" => "image_generation"}, %{"type" => "web_search"}])
+
+    assert {:ok, attempt} =
+             BackgroundAgentJobs.claim_attempt_in_tx(Repo, job.id, agent.uid, 1, spec)
+
+    assert attempt.runtime_projection["hosted_tools"] == [
+             %{"type" => "image_generation"},
+             %{"type" => "web_search"}
+           ]
+
+    assert {:ok, overrides} =
+             RuntimeProjection.turn_start_overrides(attempt.runtime_projection,
+               agent_uid: agent.uid
+             )
+
+    assert overrides.hosted_tools == [
+             %{"type" => "image_generation"},
+             %{"type" => "web_search"}
+           ]
+
+    assert {:error, :background_agent_job_runtime_projection_invalid} =
+             RuntimeProjection.turn_start_overrides(
+               Map.put(attempt.runtime_projection, "hosted_tools", ["web_search"]),
+               agent_uid: agent.uid
+             )
+  end
+
   test "a legacy projection freezes inferred modalities on its next claim" do
     %{principal: agent} = background_agent_fixture()
     job = create_job!(agent.uid, "legacy-runtime-modalities")

--- a/app/control_plane/test/ankole/signals_gateway/actor_runtime/turn_envelope_test.exs
+++ b/app/control_plane/test/ankole/signals_gateway/actor_runtime/turn_envelope_test.exs
@@ -6,20 +6,49 @@ defmodule Ankole.SignalsGateway.ActorRuntime.TurnEnvelopeTest do
   alias Ankole.SignalsGateway.ActorRuntime.TurnEnvelope
   alias Ankole.SignalsGateway.ActorRuntime.TurnRef
 
-  test "projects only the declared image generation hosted tool" do
+  test "projects the declared hosted tools in policy order" do
     envelope =
       TurnEnvelope.turn_start(turn_ref(), actor_event(), [], %{
         workspace_id: 10_000,
         model_ref: model_ref(),
         request_context: %{},
-        hosted_tools: [%{"type" => "image_generation"}]
+        hosted_tools: [%{"type" => "image_generation"}, %{"type" => "web_search"}]
       })
 
     assert %FabricProto.Envelope{body: {:turn_start, turn_start}} = envelope
 
     assert Torque.decode!(turn_start.hosted_tools_json) == [
-             %{"type" => "image_generation"}
+             %{"type" => "image_generation"},
+             %{"type" => "web_search"}
            ]
+  end
+
+  test "rejects unsupported and duplicate hosted tools" do
+    spec = fn hosted_tools ->
+      %{
+        workspace_id: 10_000,
+        model_ref: model_ref(),
+        request_context: %{},
+        hosted_tools: hosted_tools
+      }
+    end
+
+    assert_raise ArgumentError, ~r/unsupported turn hosted tool/, fn ->
+      TurnEnvelope.turn_start(turn_ref(), actor_event(), [], spec.([%{"type" => "computer_use"}]))
+    end
+
+    assert_raise ArgumentError, ~r/duplicate turn hosted tools/, fn ->
+      TurnEnvelope.turn_start(
+        turn_ref(),
+        actor_event(),
+        [],
+        spec.([%{"type" => "web_search"}, %{"type" => "web_search"}])
+      )
+    end
+
+    assert_raise ArgumentError, ~r/invalid turn hosted tools/, fn ->
+      TurnEnvelope.turn_start(turn_ref(), actor_event(), [], spec.([]))
+    end
   end
 
   test "omits hosted tools when the turn policy did not declare one" do

--- a/docs/design-docs/AIGateway.md
+++ b/docs/design-docs/AIGateway.md
@@ -146,6 +146,16 @@ A setting has one scope:
 A language-model capability can declare `supports_parallel_tool_calls` and
 `supports_native_image_generation`. Both declarations default to false.
 
+Hosted-tool support that changes per endpoint belongs to the provider row, not
+to the provider kind. The `openai_compatible` provider accepts a
+`hosted_web_search` connection setting. It declares that the connection's
+Responses endpoint executes the hosted `web_search` tool itself. Configuration
+writes reject the declaration unless `endpoint_kind` is `responses`.
+`TurnPolicy` reads the stored declaration and adds `web_search` to the turn's
+hosted tools, so Main Turns and Background Jobs project one consistent
+capability. The supported turn hosted-tool types are `image_generation` and
+`web_search`; every boundary rejects other types.
+
 Trusted Plugins can add providers through `ai_gateway.provider`. A Plugin
 cannot replace AIGateway storage, authorization, profiles, credential
 selection, or secret handling.

--- a/docs/design-docs/BackgroundAgentJob.md
+++ b/docs/design-docs/BackgroundAgentJob.md
@@ -418,6 +418,12 @@ consume.
 Projected `web_search` and `web_fetch` calls send their semantic selectors
 directly to AIGateway. A Job does not query or cache a separate web-tool catalog.
 
+Codex built-in `web_search` follows the Job's frozen hosted-tool projection.
+When the Job's provider connection declares hosted `web_search`, the project
+config sets `web_search = "live"` and the provider executes that search inside
+the model request. Every other Job keeps `web_search = "disabled"`. The
+workspace template never decides this value.
+
 For AIGateway, the Agent Codex Home selects the `ankole_aigateway` provider.
 The Job configuration contains the real Codex model name and its supported
 reasoning effort. The runner never sends a logical profile name to Codex. It


### PR DESCRIPTION
Closes #60

## What

- `openai_compatible` connections accept a `hosted_web_search` boolean connection setting; configuration writes reject it unless `endpoint_kind` is `responses`.
- `TurnPolicy` reads the stored declaration and adds `web_search` to the turn hosted tools next to the existing `image_generation` projection.
- The turn envelope, worker actor lane, `HostedTool` types, and the Responses serializer carry a closed `{image_generation, web_search}` set and serialize each tool by its declared type. Every boundary still rejects unknown types.
- Background Agent Jobs freeze the declaration in the runtime projection as before; the Codex job project config now sets `web_search = "live"` from that frozen projection instead of always `"disabled"`. The workspace template still cannot decide this value.
- Design docs (`AIGateway.md`, `BackgroundAgentJob.md`) and `CHANGELOG.md` (Version 0.66.0) updated.

## Why

`endpoint_kind=responses` only selects the wire protocol. A Responses connection that natively serves `{"type":"web_search"}` had no declaration path: TurnPolicy and TurnEnvelope only produced and accepted `image_generation`, the Agent Computer serializer hardcoded that type, and Codex jobs disabled web search unconditionally. The AIGateway data plane already passes the tool and its `web_search_call` output items through, so this change only adds the missing capability declaration and its end-to-end projection.

## Verification

- Control plane: turn envelope/policy, provider runtime, background jobs, and responses dispatch suites pass on the rebased branch (157 tests); a full forced recompile emits zero warnings. New regression coverage spans the enabled / not-enabled / unsupported connection states, envelope rejection of unknown and duplicate tools, projection round-trips with legacy single-tool compatibility, and gateway passthrough of the `web_search` declaration to the provider request.
- Agent Computer: unit suite passes in the Worker image (547 tests); integration suite passes with the pinned Codex image (23 pass, 0 fail, 5 environment-gated skips).
- Not covered by automated tests: the pinned Codex runtime emitting `{"type":"web_search"}` under `web_search = "live"` against a real provider. `"live"` comes from the generated `WebSearchMode` vocabulary; one live Job smoke test after merge would close that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)