### PR TITLE
docs: correct agent-scoped cron and checkback routes in guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.67.1 (2026-08-12)
+
+- Correct the Console API and Automation blueprints guides in all four locales: cron schedules and checkbacks are agent-scoped (`/agents/:agent_uid/...`), not session-nested, and the cron creation example now carries the required `owner_session_id`, `delivery`, and `idempotency_key` body fields.
+
 ## Version 0.67.0 (2026-08-12)
 
 - Make BackgroundAgentJob retries honest and bounded: a retryable attempt failure returns the Job to `queued` and frees its Agent slot and Worker assignment, the new `execution_failures` budget (5) counts only real execution failures while total claims cap at 25, and infrastructure interruptions retry within minutes while provider-class failures keep the hours-spanning ladder. Operators see `execution_failures` beside `attempts`, and the per-Agent running cap becomes the `agent_computer.background_agent_job.max_running_per_agent` setting (default 3; confirm provider quota before raising it).

--- a/app/website/src/content/docs/automation-blueprints/en-US.md
+++ b/app/website/src/content/docs/automation-blueprints/en-US.md
@@ -35,15 +35,18 @@ Start with a direct Agent wake while the handling is unclear. Move only the prov
 A schedule wakes the Agent once a day. The Agent collects and summarizes the requested information, then posts the result to the bound chat channel. Create and test it with [Schedules](../schedules/) before you set the daily cron expression.
 
 ```bash
-curl -X POST https://ankole.example.com/api/v1/agents/<agent_uid>/sessions/<session_id>/cron-schedules \
+curl -X POST https://ankole.example.com/api/v1/agents/<agent_uid>/cron-schedules \
   -H "Authorization: Bearer $CONSOLE_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
+    "owner_session_id": "<session_id>",
     "binding_name": "main",
     "name": "daily-digest",
     "schedule": { "cron": "0 9 * * *", "kind": "cron" },
     "timezone": "Asia/Shanghai",
-    "payload": { "task": "Produce today'\''s digest of the topics in your mission." }
+    "delivery": { "targets": [{ "binding_name": "main", "signal_channel_id": "<signal_channel_id>" }] },
+    "payload": { "task": "Produce today'\''s digest of the topics in your mission." },
+    "idempotency_key": "daily-digest-1"
   }'
 ```
 
@@ -65,7 +68,7 @@ Keep the direct Agent schedule when every run needs semantic judgment. Read [Wor
 
 The agent is asked something in a turn, and decides to come back to it later. Instead of a fixed cron, the agent itself sets a one-shot wakeup with `check_back_later`. The shape from the agent's side is "look again in an hour" — the agent calls the tool; the operator surface is read-only.
 
-This fits work that is not on a cadence: "check whether the deploy finished in an hour," "re-read this thread after the standup." The agent owns the timing; you see the pending checkback through `GET /agents/:agent_uid/sessions/:session_id/checkbacks` and can cancel one with `DELETE`.
+This fits work that is not on a cadence: "check whether the deploy finished in an hour," "re-read this thread after the standup." The agent owns the timing; you see the pending checkback through `GET /agents/:agent_uid/checkbacks` and can cancel one with `DELETE`.
 
 ## Blueprint: research-and-report (schedule + background job)
 

--- a/app/website/src/content/docs/automation-blueprints/ja-JP.md
+++ b/app/website/src/content/docs/automation-blueprints/ja-JP.md
@@ -35,15 +35,18 @@ Ankole はワークフロー言語やステップグラフを追加しません�
 schedule が 1 日に 1 回 Agent を起こします。Agent は依頼された情報を収集して要約し、結果をバインドされた chat channel に投稿します。[スケジュール](../schedules/) で作成してテストしてから、毎日の cron 式を設定してください。
 
 ```bash
-curl -X POST https://ankole.example.com/api/v1/agents/<agent_uid>/sessions/<session_id>/cron-schedules \
+curl -X POST https://ankole.example.com/api/v1/agents/<agent_uid>/cron-schedules \
   -H "Authorization: Bearer $CONSOLE_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
+    "owner_session_id": "<session_id>",
     "binding_name": "main",
     "name": "daily-digest",
     "schedule": { "cron": "0 9 * * *", "kind": "cron" },
     "timezone": "Asia/Shanghai",
-    "payload": { "task": "Produce today'\''s digest of the topics in your mission." }
+    "delivery": { "targets": [{ "binding_name": "main", "signal_channel_id": "<signal_channel_id>" }] },
+    "payload": { "task": "Produce today'\''s digest of the topics in your mission." },
+    "idempotency_key": "daily-digest-1"
   }'
 ```
 
@@ -65,7 +68,7 @@ schedule が頻繁に発火するものの、確認が機械的で通常は結�
 
 agent が turn の中で何かを尋ねられ、後でそれに戻ることにします。固定の cron ではなく、agent 自身が `check_back_later` で一度だけの wakeup を設定します。agent 側の形は「1 時間後にもう一度見る」です。agent がツールを呼び、運用者側のサーフェスは読み取り専用です。
 
-これは周期を持たない作業に合います。「デプロイが 1 時間後に完了したか確認する」「スタンドアップの後にこの thread を読み直す」などです。タイミングを所有するのは agent であり、保留中の checkback は `GET /agents/:agent_uid/sessions/:session_id/checkbacks` で確認でき、`DELETE` で 1 つキャンセルできます。
+これは周期を持たない作業に合います。「デプロイが 1 時間後に完了したか確認する」「スタンドアップの後にこの thread を読み直す」などです。タイミングを所有するのは agent であり、保留中の checkback は `GET /agents/:agent_uid/checkbacks` で確認でき、`DELETE` で 1 つキャンセルできます。
 
 ## ブループリント: 調査して報告（schedule + background job）
 

--- a/app/website/src/content/docs/automation-blueprints/ko-KR.md
+++ b/app/website/src/content/docs/automation-blueprints/ko-KR.md
@@ -35,15 +35,18 @@ Ankole은 워크플로 언어나 단계 그래프를 추가하지 않습니다. 
 스케줄이 하루에 한 번 Agent를 깨웁니다. Agent는 요청된 정보를 수집하고 요약한 다음 결과를 바인딩된 chat channel에 게시합니다. 일일 cron 표현식을 설정하기 전에 [스케줄](../schedules/) 문서로 만들고 테스트하세요.
 
 ```bash
-curl -X POST https://ankole.example.com/api/v1/agents/<agent_uid>/sessions/<session_id>/cron-schedules \
+curl -X POST https://ankole.example.com/api/v1/agents/<agent_uid>/cron-schedules \
   -H "Authorization: Bearer $CONSOLE_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
+    "owner_session_id": "<session_id>",
     "binding_name": "main",
     "name": "daily-digest",
     "schedule": { "cron": "0 9 * * *", "kind": "cron" },
     "timezone": "Asia/Shanghai",
-    "payload": { "task": "Produce today'\''s digest of the topics in your mission." }
+    "delivery": { "targets": [{ "binding_name": "main", "signal_channel_id": "<signal_channel_id>" }] },
+    "payload": { "task": "Produce today'\''s digest of the topics in your mission." },
+    "idempotency_key": "daily-digest-1"
   }'
 ```
 
@@ -65,7 +68,7 @@ curl -X POST https://ankole.example.com/api/v1/agents/<agent_uid>/sessions/<sess
 
 agent가 turn에서 어떤 것을 요청받고, 나중에 다시 다루기로 결정합니다. 고정 cron 대신 agent 자신이 `check_back_later`로 일회성 깨우기를 설정합니다. agent 쪽에서의 형태는 “한 시간 후에 다시 보라”입니다. agent가 도구를 호출하고, operator 표면은 읽기 전용입니다.
 
-이것은 주기가 없는 작업에 맞습니다. “배포가 한 시간 안에 끝났는지 확인하세요”, “스탠드업 후 이 스레드를 다시 읽으세요” 같은 경우입니다. agent가 타이밍을 소유합니다. 대기 중인 checkback은 `GET /agents/:agent_uid/sessions/:session_id/checkbacks`로 확인하고 `DELETE`로 취소할 수 있습니다.
+이것은 주기가 없는 작업에 맞습니다. “배포가 한 시간 안에 끝났는지 확인하세요”, “스탠드업 후 이 스레드를 다시 읽으세요” 같은 경우입니다. agent가 타이밍을 소유합니다. 대기 중인 checkback은 `GET /agents/:agent_uid/checkbacks`로 확인하고 `DELETE`로 취소할 수 있습니다.
 
 ## 블루프린트: 리서치 후 보고(스케줄 + background job)
 

--- a/app/website/src/content/docs/automation-blueprints/zh-Hans-CN.md
+++ b/app/website/src/content/docs/automation-blueprints/zh-Hans-CN.md
@@ -35,15 +35,18 @@ Ankole 不增加工作流语言或步骤图。Automation job 是 Agent Home 内�
 计划任务每天触发一次，Agent 根据任务说明收集和整理信息，再把结果发到绑定的聊天渠道。先按 [计划任务](../schedules/) 创建并手动验证，再设置每天运行的 Cron 表达式。
 
 ```bash
-curl -X POST https://ankole.example.com/api/v1/agents/<agent_uid>/sessions/<session_id>/cron-schedules \
+curl -X POST https://ankole.example.com/api/v1/agents/<agent_uid>/cron-schedules \
   -H "Authorization: Bearer $CONSOLE_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
+    "owner_session_id": "<session_id>",
     "binding_name": "main",
     "name": "daily-digest",
     "schedule": { "cron": "0 9 * * *", "kind": "cron" },
     "timezone": "Asia/Shanghai",
-    "payload": { "task": "产出今天 mission 里那些话题的摘要。" }
+    "delivery": { "targets": [{ "binding_name": "main", "signal_channel_id": "<signal_channel_id>" }] },
+    "payload": { "task": "产出今天 mission 里那些话题的摘要。" },
+    "idempotency_key": "daily-digest-1"
   }'
 ```
 
@@ -65,7 +68,7 @@ Schedule 频繁触发、检查过程机械且通常无结果时，使用 automat
 
 agent 在回合里被问某事，决定稍后再回来。不是固定 cron，agent 自己用 `check_back_later` 设一次性唤醒。agent 那一侧的形态是"一小时后再看"——agent 调工具；运维界面只读。
 
-适合没有固定节奏的工作：”一小时后看部署完成没”、”站会后再读这个 thread”。agent 掌握时机；你通过 `GET /agents/:agent_uid/sessions/:session_id/checkbacks` 查看待执行的 checkback，可用 `DELETE` 取消。
+适合没有固定节奏的工作：”一小时后看部署完成没”、”站会后再读这个 thread”。agent 掌握时机；你通过 `GET /agents/:agent_uid/checkbacks` 查看待执行的 checkback，可用 `DELETE` 取消。
 
 ## 蓝图：研究并报告（调度 + 后台任务）
 

--- a/app/website/src/content/docs/console-api/en-US.md
+++ b/app/website/src/content/docs/console-api/en-US.md
@@ -138,7 +138,7 @@ Control Plane Plugins are the first-party extensions that change what the contro
 
 Alongside configuration, the Console is the observability path for the rest of the system — each subsystem already documented has its read surface here:
 
-- **Agents in flight**: `/agents/:agent_uid/sessions`, per-session cron schedules and checkbacks.
+- **Agents in flight**: `/agents/:agent_uid/sessions`, per-Agent cron schedules and checkbacks.
 - **Workers**: `/agent-computer-workers`, with file upload, move, and listing per worker.
 - **Jobs**: `/background-agent-jobs` (list, read, cancel).
 - **AI activity**: `/ai-gateway/conversations`, with messages per conversation.

--- a/app/website/src/content/docs/console-api/ja-JP.md
+++ b/app/website/src/content/docs/console-api/ja-JP.md
@@ -138,7 +138,7 @@ Control Plane Plugin は、signals adapter や Brain の source connector のよ
 
 configuration に加えて、Console はシステムの残りの部分に対する observability の経路でもあります。既に解説した各 subsystem は、ここに読み取り用の surface を持ちます。
 
-- **処理中の Agent**: `/agents/:agent_uid/sessions`。session ごとの cron schedule と checkback。
+- **処理中の Agent**: `/agents/:agent_uid/sessions`。Agent ごとの cron schedule と checkback。
 - **Worker**: `/agent-computer-workers`。worker ごとの file のアップロード、移動、一覧表示。
 - **Job**: `/background-agent-jobs`（一覧表示、読み取り、cancel）。
 - **AI の活動**: `/ai-gateway/conversations`。conversation ごとの message。

--- a/app/website/src/content/docs/console-api/ko-KR.md
+++ b/app/website/src/content/docs/console-api/ko-KR.md
@@ -138,7 +138,7 @@ Control Plane Plugins는 컨트롤 플레인 자체가 하는 일을 바꾸는 �
 
 구성과 함께, Console은 나머지 시스템의 관찰 경로이기도 합니다. 이미 문서화된 각 하위 시스템은 여기에 읽기 표면을 가집니다.
 
-- **실행 중인 Agents**: `/agents/:agent_uid/sessions`, 세션별 cron 일정과 checkback.
+- **실행 중인 Agents**: `/agents/:agent_uid/sessions`, Agent별 cron 일정과 checkback.
 - **Workers**: `/agent-computer-workers`, Worker별 파일 업로드, 이동, 목록.
 - **Jobs**: `/background-agent-jobs`(목록, 읽기, 취소).
 - **AI 활동**: `/ai-gateway/conversations`, 대화별 메시지.

--- a/app/website/src/content/docs/console-api/zh-Hans-CN.md
+++ b/app/website/src/content/docs/console-api/zh-Hans-CN.md
@@ -140,7 +140,7 @@ Control Plane Plugin 是改变控制面自身行为的第一方扩展，例如 s
 
 除了配置，Console 也是系统其余部分的可观测路径——每一个已经实现的子系统，在这里都有它的读取界面：
 
-- **进行中的 agent**：`/agents/:agent_uid/sessions`，每个 session 的 cron schedule 和 checkback。
+- **进行中的 agent**：`/agents/:agent_uid/sessions`，每个 agent 的 cron schedule 和 checkback。
 - **worker**：`/agent-computer-workers`，按 worker 上传、移动、列出文件。
 - **任务**：`/background-agent-jobs`（列出、读取、取消）。
 - **AI 活动**：`/ai-gateway/conversations`，按会话读取消息。


### PR DESCRIPTION
## Summary
- The Console API guide ("Agents in flight" bullet) and the Automation blueprints pages described cron schedules and checkbacks as per-session; the real Console routes are agent-scoped: `GET/POST /api/v1/agents/:agent_uid/cron-schedules` and `GET/DELETE /api/v1/agents/:agent_uid/checkbacks[/:scheduled_event_id]` (`app/control_plane/lib/ankole_web/router.ex`). Corrected in all four locales (en-US, ja-JP, ko-KR, zh-Hans-CN).
- The daily-digest curl example now targets the agent-scoped route and carries the required body fields — `owner_session_id` (moved out of the URL), `delivery`, and `idempotency_key` — per `Ankole.Schedule.Normalizer.cron_schedule_attrs/3` and the Console OpenAPI `ScheduleCronWriteRequest` schema; the old example would fail validation.
- CHANGELOG version 0.67.1 (docs-only PATCH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Automation Blueprint examples to use agent-level cron schedules and checkbacks.
  * Added required schedule fields, including delivery targets, ownership details, and idempotency keys.
  * Clarified across English, Japanese, Korean, and Simplified Chinese guides that schedules and checkbacks are organized by agent rather than session.
  * Added the Version 0.67.1 changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->