### PR TITLE
fix: repair runtime regressions found by E2E testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 0.67.1 (2026-08-13)
+
+- Remove the obsolete per-Job Agent Plugin selection column from upgraded databases. Pause legacy direct-Agent cron schedules without a complete task, cancel their pending fires, and block resume or manual fire until repair; schedule coverage now uses explicit clocks and payload or delivery updates preserve run history.
+- Move Codex runtime state to Worker-local shards, bind each shard into its Job sandbox, and retire only an unlocked, real legacy config directory. Pin local Worker builds to Codex 0.147, keep app-server timeouts retryable, redact bounded startup diagnostics, and roll back a successful terminal Job commit if its steer successor cannot be stored.
+- Keep provider-hosted web search on standard Responses without a competing local tool, and persist whether each search was provider-hosted or local. Preserve frozen provider options across model and tool-result rounds, keep generic caller metadata local, retain configured WebSockets through hosted image fallback, and restore omitted terminal output from completed stream items.
+- Keep OIDC login buttons usable after browser back navigation, and stop stale Feishu CardKit recovery from replacing a durable terminal presentation or retrying a provider binding-limit fallback forever.
+
 ## Version 0.67.0 (2026-08-12)
 
 - Make BackgroundAgentJob retries honest and bounded: a retryable attempt failure returns the Job to `queued` and frees its Agent slot and Worker assignment, the new `execution_failures` budget (5) counts only real execution failures while total claims cap at 25, and infrastructure interruptions retry within minutes while provider-class failures keep the hours-spanning ladder. Operators see `execution_failures` beside `attempts`, and the per-Agent running cap becomes the `agent_computer.background_agent_job.max_running_per_agent` setting (default 3; confirm provider quota before raising it).

--- a/app/agent_computer/README.md
+++ b/app/agent_computer/README.md
@@ -39,7 +39,6 @@ The durable shared writable runtime mount is `/agents`:
 
 ```text
 /agents/<agent-key>/
-├── .codex/
 ├── SOUL.md
 ├── MISSION.md
 ├── DESIGN.md
@@ -69,12 +68,13 @@ For every turn:
 
 ```text
 HOME=/agents/<agent-key>
-CODEX_HOME=/agents/<agent-key>/.codex
+CODEX_HOME=/var/lib/ankole/codex/<agent-key>/.codex
 ```
 
-No separate SQLite home is configured. A Job's `.codex/config.toml` is project
-configuration. The Agent `.codex` directory owns auth, Codex sessions, SQLite,
-caches, and other official state.
+The Agent Home is shared durable storage. The Codex Home is a rebuildable
+Worker-local shard because SQLite WAL needs same-host shared memory. A Job's
+`.codex/config.toml` is project configuration. The Worker-local Codex Home owns
+auth, Codex sessions, SQLite, caches, and other official runtime state.
 
 PostgreSQL is authoritative for SOUL, MISSION, and DESIGN. The uppercase files
 are read-only projections. Startup and document-change events rebuild them;

--- a/app/agent_computer/base-image.lock
+++ b/app/agent_computer/base-image.lock
@@ -1,1 +1,1 @@
-ghcr.io/agentbull/ankole-agent-os-base@sha256:739aa7e48d50caf0a64c9f280847939177f974db53cbc9e78fc7bc09b8e37592
+ghcr.io/agentbull/ankole-agent-os-base@sha256:2576b3f072ee4078bbbc265cc35e09a966c90565e8b856a6447900565ba95b86

--- a/app/agent_computer/src/core/ai_gateway_transport.ts
+++ b/app/agent_computer/src/core/ai_gateway_transport.ts
@@ -44,6 +44,7 @@ export function modelConfigFromAIGatewayAPIKey(
     selector,
     name: modelRef.model,
     provider: modelRef.provider_id,
+    providerOptions: modelRef.provider_options,
     fetch: gatewayFetch as never,
     responseWebSocket: {
       kind: 'aigateway-websocket',

--- a/app/agent_computer/src/core/codex-runner/agent-runtime-manager.ts
+++ b/app/agent_computer/src/core/codex-runner/agent-runtime-manager.ts
@@ -17,10 +17,12 @@ import {
   materializeAgentPluginPackages,
   type PreparedAgentPlugins
 } from './agent-plugin-materializer'
+import { retireLegacySharedCodexConfig } from './retire-legacy-shared-codex-config'
 
 const INITIALIZE_SLOW_DIAGNOSTIC_MS = 60_000
 const CLEANUP_REQUEST_TIMEOUT_MS = 5_000
 const MAX_PENDING_THREAD_NOTIFICATIONS = 256
+const MAX_RUNTIME_STDERR_DIAGNOSTIC_LENGTH = 2_048
 
 export interface AgentCodexRuntimeSession {
   prepareForRuntimeCleanup(): void
@@ -31,6 +33,7 @@ export interface AgentCodexRuntimeSession {
 
 export type AgentCodexRuntimeAcquireInput = {
   agentUID: string
+  agentHome: string
   codexHome: string
   aiGatewayBaseURL: string
   aiGatewayAPIKey: string
@@ -146,6 +149,11 @@ export class AgentCodexRuntimeManager {
     input: AgentCodexRuntimeAcquireInput,
     onExit: (error: Error) => void
   ): Promise<AgentCodexRuntime> {
+    const legacyConfigRetirement = await retireLegacySharedCodexConfig(input.agentHome)
+    input.logger?.info('worker.codex_legacy_shared_config_retired', 'Legacy shared Codex config checked', {
+      agent_uid: input.agentUID,
+      status: legacyConfigRetirement
+    })
     const runtimeRef: { current?: AgentCodexRuntime } = {}
     const client = new CodexAppServerClient({
       cwd: input.sandbox.cwd,
@@ -392,10 +400,12 @@ export class AgentCodexRuntime {
       return
     }
 
+    const stderrDiagnostic = runtimeStderrDiagnostic(message)
     this.logger?.info('worker.codex_runtime_unscoped_event', 'Codex runtime emitted an unscoped event', {
       agent_uid: this.agentUID,
       method: message.method ?? 'unknown',
-      ...(threadID ? { thread_id: threadID } : {})
+      ...(threadID ? { thread_id: threadID } : {}),
+      ...(stderrDiagnostic ? { diagnostic: stderrDiagnostic } : {})
     })
   }
 
@@ -666,6 +676,20 @@ export class AgentCodexRuntime {
     )
     await current
   }
+}
+
+function runtimeStderrDiagnostic(message: JSONRPCMessage): string | undefined {
+  if (message.method !== '$stderr') return undefined
+  const text = stringValue(jsonObject(message.params).text)?.trim()
+  if (!text) return undefined
+
+  return text
+    .replace(/(authorization\s*[:=]\s*)(?:(?:bearer|basic)\s+)?\S+/gi, '$1[REDACTED]')
+    .replace(/((?:api[_-]?key|token|secret|password)\s*[:=]\s*)\S+/gi, '$1[REDACTED]')
+    .replace(/\b(?:bx_mcp|sk)[_-][A-Za-z0-9_-]+\b/g, '[REDACTED]')
+    .replace(/\b[A-Za-z0-9_-]{48,}\b/g, '[REDACTED]')
+    .replace(/\s+/g, ' ')
+    .slice(0, MAX_RUNTIME_STDERR_DIAGNOSTIC_LENGTH)
 }
 
 function childThreadLink(

--- a/app/agent_computer/src/core/codex-runner/codex-home-lock.ts
+++ b/app/agent_computer/src/core/codex-runner/codex-home-lock.ts
@@ -61,6 +61,23 @@ export function codexHomeLockedLogsDeleteArgv(codexHome: string): string[] {
   ]
 }
 
+export function legacySharedCodexConfigDeleteArgv(agentHome: string): string[] {
+  const legacyCodexHome = join(agentHome, '.codex')
+  return [
+    flockCommand(),
+    '-n',
+    '-E',
+    String(CODEX_HOME_LOCK_BUSY_EXIT_CODE),
+    '-F',
+    codexHomeRuntimeLockPath(legacyCodexHome),
+    '/bin/sh',
+    '-c',
+    'legacy_home=$1; find -P "$legacy_home" -mindepth 1 -maxdepth 1 -name config.toml ! -type d -print -delete',
+    'ankole-legacy-codex-config-retirement',
+    legacyCodexHome
+  ]
+}
+
 function lockedRuntimeScript(writeRuntimeFiles: boolean, deleteLogs: boolean): string {
   const statements = ['set -eu', 'umask 077']
 

--- a/app/agent_computer/src/core/codex-runner/retire-legacy-shared-codex-config.ts
+++ b/app/agent_computer/src/core/codex-runner/retire-legacy-shared-codex-config.ts
@@ -1,0 +1,45 @@
+import { existsSync, lstatSync } from 'node:fs'
+import { join } from 'node:path'
+import { CODEX_HOME_LOCK_BUSY_EXIT_CODE, legacySharedCodexConfigDeleteArgv } from './codex-home-lock'
+
+export type LegacySharedCodexConfigRetirement = 'config_missing' | 'removed' | 'skipped_legacy_runtime_active'
+
+/**
+ * Removes the obsolete project config from the former shared Codex Home.
+ *
+ * The old app-server held this same lock for its full lifetime. A rolling
+ * deployment can therefore leave the file until the old runtime exits. Remove
+ * this migration after all retained Agent Homes have completed one unlocked
+ * Worker-local Codex runtime start.
+ */
+export async function retireLegacySharedCodexConfig(agentHome: string): Promise<LegacySharedCodexConfigRetirement> {
+  const legacyCodexHome = join(agentHome, '.codex')
+  try {
+    if (!lstatSync(legacyCodexHome).isDirectory()) return 'config_missing'
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 'config_missing'
+    throw error
+  }
+
+  const configPath = join(legacyCodexHome, 'config.toml')
+  if (!existsSync(configPath)) return 'config_missing'
+
+  const child = Bun.spawn(legacySharedCodexConfigDeleteArgv(agentHome), {
+    cwd: agentHome,
+    env: { PATH: process.env.PATH || '/usr/local/bin:/usr/bin:/bin' },
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe'
+  })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text()
+  ])
+
+  if (exitCode === CODEX_HOME_LOCK_BUSY_EXIT_CODE) return 'skipped_legacy_runtime_active'
+  if (exitCode !== 0) {
+    throw new Error(`Legacy shared Codex config retirement failed with exit ${exitCode}: ${stderr.trim()}`)
+  }
+  return stdout.trim() ? 'removed' : 'config_missing'
+}

--- a/app/agent_computer/src/core/codex-runner/sandbox.ts
+++ b/app/agent_computer/src/core/codex-runner/sandbox.ts
@@ -23,6 +23,10 @@ export function codexAgentRuntimeSandboxSpec(input: {
     cwd: input.materialized.agentHome,
     env,
     extraBinds: [
+      {
+        source: input.materialized.codexHome,
+        target: input.materialized.codexHome
+      },
       ...(existsSync(SANDBOX_KERNEL_ROOT)
         ? [{ source: SANDBOX_KERNEL_ROOT, target: SANDBOX_KERNEL_ROOT, readonly: true }]
         : []),

--- a/app/agent_computer/src/core/codex-runner/session.ts
+++ b/app/agent_computer/src/core/codex-runner/session.ts
@@ -218,6 +218,7 @@ class CodexJobSession implements AgentCodexRuntimeSession {
     const expectedSkills = expectedSkillNames(this.input)
     this.runtimeLease = await agentCodexRuntimeManager.acquire({
       agentUID: this.input.job.agentUid,
+      agentHome: this.input.materialized.agentHome,
       codexHome: this.input.materialized.codexHome,
       aiGatewayBaseURL: this.input.runtimeConfig.aiGatewayKey.baseUrl,
       aiGatewayAPIKey: this.input.runtimeConfig.aiGatewayKey.apiKey,

--- a/app/agent_computer/src/core/codex-runner/setup.ts
+++ b/app/agent_computer/src/core/codex-runner/setup.ts
@@ -122,9 +122,10 @@ export async function prepareCodexJobExecution(input: CodexJobSetupInput) {
     agentsRoot: opts.agentsRoot,
     agentUID: job.agentUid
   })
+  const hostedWebSearch = (turnStart.hosted_tools ?? []).some(tool => tool.type === 'web_search')
   materializeCodexJobProjectConfig({
     projectRoot: jobProject.root,
-    hostedWebSearch: (turnStart.hosted_tools ?? []).some(tool => tool.type === 'web_search')
+    hostedWebSearch
   })
   const projectionAPIKey = runtimeConfig.aiGatewayKey
   opts.abortSignal?.throwIfAborted()
@@ -147,7 +148,7 @@ export async function prepareCodexJobExecution(input: CodexJobSetupInput) {
   })
   opts.abortSignal?.throwIfAborted()
   const projectedTools = [
-    ...baseWebTools,
+    ...baseWebTools.filter(tool => !hostedWebSearch || tool.name !== 'web_search'),
     // Brain attributes job-issued memory operations to the job because the
     // turn fence session is the job session; no extra scope payload is needed.
     ...createMemoryTools({

--- a/app/agent_computer/src/core/codex-runner/turn-recorder.ts
+++ b/app/agent_computer/src/core/codex-runner/turn-recorder.ts
@@ -44,6 +44,7 @@ type RuntimeTurn = {
   anchoredItemKeys: Set<string>
   completedItemIDs: Set<string>
   toolItemNames: Map<string, string>
+  toolItemExecutionMechanisms: Map<string, ToolExecutionMechanism>
   usedSkillNames: Set<string>
   filesChanged: Set<string>
   initialItemKey?: string
@@ -66,6 +67,11 @@ type SanitizeState = {
 type ItemEntry = {
   key: string
   item: JSONObject
+}
+
+type ToolExecutionMechanism = {
+  name: string
+  execution_mechanism: 'provider_hosted' | 'local_dynamic'
 }
 
 type CollabAgentToolCall = Extract<ThreadItem, { type: 'collabAgentToolCall' }>
@@ -242,6 +248,7 @@ export class BackgroundAgentJobTurnRecorder {
         anchoredItemKeys: new Set(),
         completedItemIDs: new Set(),
         toolItemNames: new Map(),
+        toolItemExecutionMechanisms: new Map(),
         usedSkillNames: new Set(),
         filesChanged: new Set(),
         error: {},
@@ -540,6 +547,10 @@ export class BackgroundAgentJobTurnRecorder {
     turn.completedItemIDs.add(id)
     const name = toolName(item)
     if (name) turn.toolItemNames.set(id, name)
+    const mechanism = toolExecutionMechanism(item)
+    if (name && mechanism) {
+      turn.toolItemExecutionMechanisms.set(id, { name, execution_mechanism: mechanism })
+    }
     if (item.type === 'fileChange') {
       const handoff = boundedBackgroundAgentJobPaths([...turn.filesChanged, ...fileChangePaths(item.changes)])
       turn.filesChanged = new Set(handoff.paths)
@@ -663,16 +674,34 @@ function progress(turn: RuntimeTurn): BackgroundAgentJobTurnProgress {
   const toolsUsed = [...counts.entries()]
     .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
     .map(([name, calls]) => ({ name, calls }))
+  const executionCounts = new Map<string, ToolExecutionMechanism & { calls: number }>()
+  for (const execution of turn.toolItemExecutionMechanisms.values()) {
+    const key = `${execution.name}\u0000${execution.execution_mechanism}`
+    const existing = executionCounts.get(key)
+    executionCounts.set(key, { ...execution, calls: (existing?.calls ?? 0) + 1 })
+  }
+  const toolExecutionMechanisms = [...executionCounts.values()].sort((left, right) => {
+    const nameOrder = left.name < right.name ? -1 : left.name > right.name ? 1 : 0
+    if (nameOrder !== 0) return nameOrder
+    return left.execution_mechanism < right.execution_mechanism ? -1 : 1
+  })
 
   return {
     completed_items: turn.completedItemIDs.size,
     tool_calls: turn.toolItemNames.size,
     tools_used: toolsUsed,
+    ...(toolExecutionMechanisms.length > 0 ? { tool_execution_mechanisms: toolExecutionMechanisms } : {}),
     files_changed: [...turn.filesChanged].sort(),
     ...(turn.usedSkillNames.size > 0 ? { skills_used: [...turn.usedSkillNames].sort() } : {}),
     ...(turn.plan ? { plan: turn.plan } : {}),
     ...(turn.activeItem ? { active_item: turn.activeItem } : {})
   }
+}
+
+function toolExecutionMechanism(item: JSONObject): ToolExecutionMechanism['execution_mechanism'] | undefined {
+  if (item.type === 'webSearch') return 'provider_hosted'
+  if (item.type === 'dynamicToolCall' || item.type === 'collabAgentToolCall') return 'local_dynamic'
+  return undefined
 }
 
 function planStatus(value: unknown): BackgroundAgentJobTurnPlan['steps'][number]['status'] | undefined {

--- a/app/agent_computer/src/core/llm/model.ts
+++ b/app/agent_computer/src/core/llm/model.ts
@@ -7,6 +7,7 @@ export function createModel(opts: {
   selector: string
   name?: string
   provider?: string
+  providerOptions?: ModelConfig['providerOptions']
   fetch?: typeof fetch
   responseWebSocket?: ResponseWebSocketTransport
 }): ModelConfig {
@@ -21,6 +22,7 @@ export function createModel(opts: {
     selector: opts.selector,
     name: opts.name ?? (opts.selector.includes('/') ? opts.selector.split('/').pop()! : opts.selector),
     provider: opts.provider ?? 'ai-gateway',
+    providerOptions: opts.providerOptions,
     responseWebSocket: opts.responseWebSocket
   }
 }

--- a/app/agent_computer/src/core/llm/types.ts
+++ b/app/agent_computer/src/core/llm/types.ts
@@ -79,6 +79,7 @@ export interface ModelConfig {
   selector: string
   name: string
   provider: string
+  providerOptions?: JSONObject
   responseWebSocket?: ResponseWebSocketTransport
 }
 

--- a/app/agent_computer/src/core/llm/wire.ts
+++ b/app/agent_computer/src/core/llm/wire.ts
@@ -33,13 +33,14 @@ export function buildResponseCreateParams(model: ModelConfig, options: CallModel
   return {
     model: model.selector,
     input,
+    ...providerOptionsParam(model),
     ...(options.instructions ? { instructions: options.instructions } : {}),
     ...(tools.length ? { tools: tools as ResponseCreateParams['tools'] } : {}),
     ...(promptCacheKey ? { prompt_cache_key: promptCacheKey } : {}),
     ...(options.maxOutputTokens ? { max_output_tokens: options.maxOutputTokens } : {}),
     ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
     ...(options.text ? { text: options.text } : {})
-  }
+  } as ResponseCreateParams
 }
 
 /**
@@ -206,6 +207,7 @@ export function statefulToolResultsRecordParams(
   return {
     model: model.selector,
     input,
+    ...providerOptionsParam(model),
     store: true,
     previous_response_id: stateful.previousResponseID,
     metadata: {
@@ -213,6 +215,11 @@ export function statefulToolResultsRecordParams(
       actor_event_id: stateful.actorEventID
     }
   } as ResponseCreateParams
+}
+
+function providerOptionsParam(model: ModelConfig): JSONObject {
+  if (!model.providerOptions || Object.keys(model.providerOptions).length === 0) return {}
+  return { provider_options: model.providerOptions }
 }
 
 function responseInputContentParts(parts: ContentPart[]): ResponseInputMessageContentList {

--- a/app/agent_computer/src/lanes/rpc_lane.ts
+++ b/app/agent_computer/src/lanes/rpc_lane.ts
@@ -918,6 +918,12 @@ export type BackgroundAgentJobTurnToolUsage = JSONObject & {
   calls: number
 }
 
+export type BackgroundAgentJobTurnToolExecutionMechanism = JSONObject & {
+  name: string
+  execution_mechanism: 'provider_hosted' | 'local_dynamic'
+  calls: number
+}
+
 export type BackgroundAgentJobTurnActiveItem = JSONObject & {
   id: string
   name: string
@@ -927,6 +933,7 @@ export type BackgroundAgentJobTurnProgress = JSONObject & {
   completed_items: number
   tool_calls: number
   tools_used: BackgroundAgentJobTurnToolUsage[]
+  tool_execution_mechanisms?: BackgroundAgentJobTurnToolExecutionMechanism[]
   files_changed: string[]
   skills_used?: string[]
   plan?: BackgroundAgentJobTurnPlan

--- a/app/agent_computer/src/tools/background-agent-job/show-background-job-details.ts
+++ b/app/agent_computer/src/tools/background-agent-job/show-background-job-details.ts
@@ -41,6 +41,15 @@ const ExecutionProgressSchema = z.object({
       calls: NonNegativeIntegerSchema
     })
   ),
+  tool_execution_mechanisms: z
+    .array(
+      z.object({
+        name: z.string(),
+        execution_mechanism: z.enum(['provider_hosted', 'local_dynamic']),
+        calls: NonNegativeIntegerSchema
+      })
+    )
+    .default([]),
   files_changed: z.array(z.string()),
   skills_used: z.array(z.string()).optional(),
   active_items: z.array(
@@ -143,7 +152,7 @@ export function createShowBackgroundJobDetailsTool(
   return {
     name: 'show_background_job_details',
     description: [
-      'Show job status, progress, usage, attempt history, and the latest trajectory page.',
+      'Show job status, progress, tool execution mechanisms, usage, attempt history, and the latest trajectory page.',
       'For an exact persisted result from a succeeded job, set result_offset to 0, concatenate result.output_text, and pass result.next_offset to the next call until it is null.',
       'Result offsets are stable and can be resumed in a later turn.'
     ].join(' '),

--- a/app/agent_computer/src/tools/schedule/schedule-tools.ts
+++ b/app/agent_computer/src/tools/schedule/schedule-tools.ts
@@ -26,7 +26,7 @@ const CRON_DESCRIPTION = [
   'Each schedule runs in its own scheduled-task session, not in this conversation: fires never see this transcript, and Ankole delivers their replies to the configured channel.',
   'payload.task must therefore carry the complete standing instruction (goal, inputs, constraints, output form) unless automation_job_id consumes the trigger.',
   'Supports kind=every/cron only. For bounded repetitions ("ten times", "until Sept"), set schedule.occurrences with count/until (auto-completes when spent).',
-  "Updating payload or delivery clears the schedule's own run history; schedule/timezone changes keep it.",
+  'Updating payload or delivery starts a new scheduled-task conversation on the next fire; existing run history remains. Schedule or timezone changes keep the current conversation.',
   'After add/update, summarize in visible reply: name, schedule/timezone, and quiet_success status.',
   'Use quiet_success=true for monitors to stay quiet on success and report only failures, blockers, or state changes.',
   AUTOMATION_JOB_POINTER,

--- a/app/agent_computer/test/codex-agent-runtime-manager.test.ts
+++ b/app/agent_computer/test/codex-agent-runtime-manager.test.ts
@@ -24,6 +24,7 @@ describe('@ankole/agent-computer Agent Codex runtime manager', () => {
       const [first, second] = await Promise.all([
         manager.acquire({
           agentUID: 'agent-1',
+          agentHome: fixture.agentHome,
           codexHome: fixture.codexHome,
           aiGatewayBaseURL: 'http://control.test/api/v1/ai-gateway',
           aiGatewayAPIKey: 'initial-agent-token',
@@ -31,6 +32,7 @@ describe('@ankole/agent-computer Agent Codex runtime manager', () => {
         }),
         manager.acquire({
           agentUID: 'agent-1',
+          agentHome: fixture.agentHome,
           codexHome: fixture.codexHome,
           aiGatewayBaseURL: 'http://control.test/api/v1/ai-gateway',
           aiGatewayAPIKey: 'initial-agent-token',
@@ -44,6 +46,7 @@ describe('@ankole/agent-computer Agent Codex runtime manager', () => {
 
       const refreshed = await manager.acquire({
         agentUID: 'agent-1',
+        agentHome: fixture.agentHome,
         codexHome: fixture.codexHome,
         aiGatewayBaseURL: 'http://control.test/api/v1/ai-gateway',
         aiGatewayAPIKey: 'refreshed-agent-token',
@@ -69,6 +72,7 @@ describe('@ankole/agent-computer Agent Codex runtime manager', () => {
     try {
       const cancelled = manager.acquire({
         agentUID: 'agent-1',
+        agentHome: fixture.agentHome,
         codexHome: fixture.codexHome,
         aiGatewayBaseURL: 'http://control.test/api/v1/ai-gateway',
         aiGatewayAPIKey: 'agent-token',
@@ -77,6 +81,7 @@ describe('@ankole/agent-computer Agent Codex runtime manager', () => {
       })
       const retained = manager.acquire({
         agentUID: 'agent-1',
+        agentHome: fixture.agentHome,
         codexHome: fixture.codexHome,
         aiGatewayBaseURL: 'http://control.test/api/v1/ai-gateway',
         aiGatewayAPIKey: 'agent-token',
@@ -123,6 +128,7 @@ describe('@ankole/agent-computer Agent Codex runtime manager', () => {
       await expect(
         manager.acquire({
           agentUID: 'agent-1',
+          agentHome: fixture.agentHome,
           codexHome: fixture.codexHome,
           aiGatewayBaseURL: 'http://replacement.test/api/v1/ai-gateway',
           aiGatewayAPIKey: 'replacement-token',
@@ -146,6 +152,7 @@ describe('@ankole/agent-computer Agent Codex runtime manager', () => {
       const [first, second, third] = await Promise.all([
         manager.acquire({
           agentUID: 'agent-1',
+          agentHome: fixture.agentHome,
           codexHome: fixture.codexHome,
           aiGatewayBaseURL: 'http://control.test/api/v1/ai-gateway',
           aiGatewayAPIKey: 'agent-token',
@@ -153,6 +160,7 @@ describe('@ankole/agent-computer Agent Codex runtime manager', () => {
         }),
         manager.acquire({
           agentUID: 'agent-1',
+          agentHome: fixture.agentHome,
           codexHome: fixture.codexHome,
           aiGatewayBaseURL: 'http://control.test/api/v1/ai-gateway',
           aiGatewayAPIKey: 'agent-token',
@@ -160,6 +168,7 @@ describe('@ankole/agent-computer Agent Codex runtime manager', () => {
         }),
         manager.acquire({
           agentUID: 'agent-1',
+          agentHome: fixture.agentHome,
           codexHome: fixture.codexHome,
           aiGatewayBaseURL: 'http://control.test/api/v1/ai-gateway',
           aiGatewayAPIKey: 'agent-token',
@@ -201,6 +210,7 @@ describe('@ankole/agent-computer Agent Codex runtime manager', () => {
       await Promise.all([second.release(), third.release()])
       const replacement = await manager.acquire({
         agentUID: 'agent-1',
+        agentHome: fixture.agentHome,
         codexHome: fixture.codexHome,
         aiGatewayBaseURL: 'http://control.test/api/v1/ai-gateway',
         aiGatewayAPIKey: 'replacement-agent-token',
@@ -320,6 +330,32 @@ describe('@ankole/agent-computer Agent Codex runtime manager', () => {
 })
 
 describe('@ankole/agent-computer Agent Codex thread router', () => {
+  it('keeps a bounded redacted stderr diagnostic for unscoped runtime failures', () => {
+    const records: Array<Record<string, unknown> | undefined> = []
+    const fakeClient = { async closeAndWait() {} } as unknown as CodexAppServerClient
+    const runtime = new AgentCodexRuntime('agent-1', fakeClient, {
+      info(_event, _message, fields) {
+        records.push(fields)
+      },
+      warning() {}
+    })
+
+    runtime.routeNotification({
+      method: '$stderr',
+      params: {
+        text: `startup failed Authorization: Bearer sk-${'c'.repeat(24)} token=top-secret bx_mcp_${'a'.repeat(60)} ${'b'.repeat(60)}`
+      }
+    })
+
+    expect(records).toEqual([
+      {
+        agent_uid: 'agent-1',
+        method: '$stderr',
+        diagnostic: 'startup failed Authorization: [REDACTED] token=[REDACTED] [REDACTED] [REDACTED]'
+      }
+    ])
+  })
+
   it('buffers start races, inherits child ownership, fails unknown requests closed, and cleans one Job tree', async () => {
     const calls: Array<{ method: string; params: Record<string, unknown> }> = []
     const responses: Array<{ id: string | number; code: number; message: string }> = []
@@ -704,6 +740,7 @@ function messageMethodThread(message: JSONRPCMessage): string {
 }
 
 function runtimeFixture(options: { initializeDelayMs?: number } = {}): {
+  agentHome: string
   codexHome: string
   initializeMarker: string
   sandbox: CodexAppServerSandboxSpec
@@ -747,6 +784,7 @@ process.stdin.resume()
 `
   )
   return {
+    agentHome: root,
     codexHome,
     initializeMarker,
     sandbox: {

--- a/app/agent_computer/test/codex-config.test.ts
+++ b/app/agent_computer/test/codex-config.test.ts
@@ -121,6 +121,8 @@ describe('@ankole/agent-computer Codex config', () => {
 
   it('keeps shared config model-free and sends each frozen binding through thread config', () => {
     const agentsRoot = mkdtempSync(join(tmpdir(), 'ankole-codex-config-aigateway-'))
+    const previousStateRoot = process.env.ANKOLE_CODEX_STATE_ROOT
+    process.env.ANKOLE_CODEX_STATE_ROOT = join(agentsRoot, 'codex-state')
     try {
       const materialized = materializeCodexConfig({
         agentsRoot,
@@ -174,6 +176,8 @@ describe('@ankole/agent-computer Codex config', () => {
       expect(threadConfig.model_reasoning_effort).toBe('xhigh')
       expect(threadConfig.shell_environment_policy).toEqual({ inherit: 'all', set: { JOB: 'one' } })
     } finally {
+      if (previousStateRoot === undefined) delete process.env.ANKOLE_CODEX_STATE_ROOT
+      else process.env.ANKOLE_CODEX_STATE_ROOT = previousStateRoot
       rmSync(agentsRoot, { recursive: true, force: true })
     }
   })

--- a/app/agent_computer/test/codex-home-lock.test.ts
+++ b/app/agent_computer/test/codex-home-lock.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'bun:test'
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -8,6 +8,7 @@ import {
   codexHomeLockedCommandArgv,
   codexHomeLockedLogsDeleteArgv
 } from '../src/core/codex-runner/codex-home-lock'
+import { retireLegacySharedCodexConfig } from '../src/core/codex-runner/retire-legacy-shared-codex-config'
 
 const previousFlockBinary = process.env.ANKOLE_FLOCK_BINARY
 
@@ -76,6 +77,77 @@ describe('@ankole/agent-computer Codex Home physical lock', () => {
       expect(existsSync(unrelated)).toBe(true)
     } finally {
       runtime?.kill()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('retires only an unlocked legacy shared config and retries after an old runtime exits', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ankole-legacy-codex-config-'))
+    const agentHome = join(root, 'agent-home')
+    const legacyCodexHome = join(agentHome, '.codex')
+    const configPath = join(legacyCodexHome, 'config.toml')
+    const retainedState = join(legacyCodexHome, 'state_5.sqlite')
+    const ready = join(root, 'ready')
+    const release = join(root, 'release')
+    const lockHelper = join(root, 'flock')
+    let oldRuntime: ReturnType<typeof Bun.spawn> | undefined
+
+    try {
+      writePortableFlock(lockHelper)
+      process.env.ANKOLE_FLOCK_BINARY = lockHelper
+      mkdirSync(legacyCodexHome, { recursive: true })
+      writeFileSync(configPath, 'legacy config')
+      writeFileSync(retainedState, 'keep')
+
+      oldRuntime = Bun.spawn(
+        codexHomeLockedCommandArgv({
+          codexHome: legacyCodexHome,
+          commandArgv: [
+            '/bin/sh',
+            '-c',
+            'touch "$1"; while [ ! -e "$2" ]; do sleep 0.02; done',
+            'ankole-old-runtime',
+            ready,
+            release
+          ]
+        })
+      )
+      await waitForFile(ready)
+
+      await expect(retireLegacySharedCodexConfig(agentHome)).resolves.toBe('skipped_legacy_runtime_active')
+      expect(existsSync(configPath)).toBe(true)
+      expect(existsSync(retainedState)).toBe(true)
+
+      writeFileSync(release, 'release')
+      expect(await oldRuntime.exited).toBe(0)
+      oldRuntime = undefined
+
+      await expect(retireLegacySharedCodexConfig(agentHome)).resolves.toBe('removed')
+      expect(existsSync(configPath)).toBe(false)
+      expect(existsSync(retainedState)).toBe(true)
+      await expect(retireLegacySharedCodexConfig(agentHome)).resolves.toBe('config_missing')
+    } finally {
+      oldRuntime?.kill()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not follow a legacy Codex Home symlink', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ankole-legacy-codex-symlink-'))
+    const agentHome = join(root, 'agent-home')
+    const outsideCodexHome = join(root, 'outside-codex-home')
+    const outsideConfig = join(outsideCodexHome, 'config.toml')
+
+    try {
+      mkdirSync(agentHome)
+      mkdirSync(outsideCodexHome)
+      writeFileSync(outsideConfig, 'keep')
+      symlinkSync(outsideCodexHome, join(agentHome, '.codex'), 'dir')
+
+      await expect(retireLegacySharedCodexConfig(agentHome)).resolves.toBe('config_missing')
+      expect(existsSync(outsideConfig)).toBe(true)
+      expect(existsSync(join(outsideCodexHome, '.ankole-app-server.lock'))).toBe(false)
+    } finally {
       rmSync(root, { recursive: true, force: true })
     }
   })

--- a/app/agent_computer/test/codex-runner-turn-recorder.test.ts
+++ b/app/agent_computer/test/codex-runner-turn-recorder.test.ts
@@ -233,6 +233,10 @@ describe('@ankole/agent-computer durable BackgroundAgentJob Turn recorder', () =
         }
       })
     ])
+    expect(upserts.at(-1)?.progress.tool_execution_mechanisms).toEqual([
+      { name: 'web_search', execution_mechanism: 'local_dynamic', calls: 1 },
+      { name: 'web_search', execution_mechanism: 'provider_hosted', calls: 1 }
+    ])
   })
 
   it('records the exact MultiAgentV2 calls, outputs, and stable child identities', async () => {

--- a/app/agent_computer/test/codex-runner.test.ts
+++ b/app/agent_computer/test/codex-runner.test.ts
@@ -168,6 +168,33 @@ describe('@ankole/agent-computer Codex job runner', () => {
     }
   })
 
+  it('uses provider-hosted web search without projecting the local duplicate', async () => {
+    const fixture = prepareFixture('searched')
+    const statusUpdates: RecordedStatusUpdate[] = []
+    const start = turnStart()
+    start.hosted_tools = [{ type: 'web_search' }]
+
+    try {
+      const result = await runCodexJob(start, options(fixture.root, statusUpdates, []))
+
+      expect(result).toEqual({ kind: 'noop_completed', reason: 'background_agent_job_committed' })
+      expect(parsedJSON(statusUpdates[0]?.metadataJson)?.projected_tool_names).toEqual([
+        'web_fetch',
+        'memory_search',
+        'memory_open',
+        'memory_update',
+        'memory_browse',
+        'memory_health_check',
+        'request_parent_input'
+      ])
+      expect(readFileSync(join(jobProjectFor(fixture.root), '.codex', 'config.toml'), 'utf8')).toContain(
+        'web_search = "live"'
+      )
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
   it('keeps a committed terminal Job successful when app-server cleanup fails', async () => {
     const fixture = prepareFixture('done before cleanup failure', { cleanupError: true })
     const statusUpdates: RecordedStatusUpdate[] = []

--- a/app/agent_computer/test/integration/codex-app-server-contract.integration.test.ts
+++ b/app/agent_computer/test/integration/codex-app-server-contract.integration.test.ts
@@ -69,6 +69,73 @@ describe('@ankole/agent-computer Codex app-server protocol contract', () => {
     expect(`${stdout}${stderr}`.trim()).toBe('codex-cli 0.147.0')
   })
 
+  it('carries a Job hosted web search through standard Responses', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ankole-codex-hosted-web-search-'))
+    const workspace = join(root, 'workspace')
+    const codexHome = join(root, 'codex-home')
+    const requests: JSONObject[] = []
+    const bindings: JSONObject[] = []
+    const notifications: JSONRPCMessage[] = []
+    const provider = createHostedWebSearchResponsesProvider(requests, bindings)
+    if (typeof provider.port !== 'number') throw new Error('Hosted web search provider did not bind a TCP port')
+    let client: CodexAppServerClient | undefined
+
+    try {
+      mkdirSync(workspace, { recursive: true })
+      mkdirSync(codexHome, { recursive: true })
+      const baseURL = `http://127.0.0.1:${provider.port}/v1`
+      resetCodexAgentRuntimeConfig(codexHome, baseURL)
+      refreshCodexAgentRuntimeCredential(codexHome, 'contract-key')
+      materializeCodexJobProjectConfig({ projectRoot: workspace, hostedWebSearch: true })
+
+      const runtime = pluginTestRuntime(baseURL, 'gpt-5.6-sol')
+      const config = codexJobThreadConfig({
+        cwd: workspace,
+        codexHome,
+        env: {},
+        runtime,
+        projectConfig: readCodexJobProjectConfig(workspace)
+      }) as Record<string, any>
+      client = new CodexAppServerClient({
+        cwd: workspace,
+        env: {
+          PATH: process.env.PATH ?? '/usr/local/bin:/usr/bin:/bin',
+          HOME: workspace,
+          CODEX_HOME: codexHome,
+          CODEX_UNSAFE_ALLOW_NO_SANDBOX: '1',
+          LANG: 'C.UTF-8'
+        },
+        onNotification: notification => notifications.push(notification)
+      })
+
+      await client.initialize()
+      const thread = (await client.request('thread/start', {
+        cwd: workspace,
+        model: runtime.modelProfile.model,
+        modelProvider: 'ankole_aigateway',
+        approvalPolicy: 'never',
+        sandbox: 'danger-full-access',
+        config
+      })) as ThreadStartResponse
+      const turn = (await client.request('turn/start', {
+        threadId: thread.thread.id,
+        input: [{ type: 'text', text: 'Use live web search for this probe.', text_elements: [] }],
+        cwd: workspace,
+        approvalPolicy: 'never',
+        sandboxPolicy: { type: 'dangerFullAccess' }
+      })) as { turn: { id: string } }
+      await waitForPluginTurn(notifications, turn.turn.id)
+
+      expect(requests).toHaveLength(1)
+      expect(requests[0]?.tools).toEqual(expect.arrayContaining([expect.objectContaining({ type: 'web_search' })]))
+      expect(bindings).toHaveLength(1)
+    } finally {
+      await client?.close()
+      provider.stop(true)
+      rmSync(root, { recursive: true, force: true })
+    }
+  }, 60_000)
+
   it('routes MultiAgentV2 children from sub-agent activity and exposes their raw tool calls', async () => {
     const root = mkdtempSync(join(tmpdir(), 'ankole-codex-multi-agent-v2-'))
     const workspace = join(root, 'workspace')
@@ -287,14 +354,25 @@ describe('@ankole/agent-computer Codex app-server protocol contract', () => {
   it('releases the Agent Codex Home lock after each real sandboxed app-server exit', async () => {
     const agentsRoot = mkdtempSync('/agents/ankole-codex-lock-contract-')
     const materialized = materializeCodexConfig({ agentsRoot, agentUID: 'agent-1' })
+    mkdirSync(materialized.agentHome, { recursive: true })
     const sandbox = codexAgentRuntimeSandboxSpec({ materialized })
     const manager = new AgentCodexRuntimeManager()
     let lease: AgentCodexRuntimeLease | undefined
 
     try {
+      expect(
+        sandbox.commandArgv.some(
+          (value, index) =>
+            value === '--bind' &&
+            sandbox.commandArgv[index + 1] === materialized.codexHome &&
+            sandbox.commandArgv[index + 2] === materialized.codexHome
+        )
+      ).toBe(true)
+
       for (let index = 0; index < 6; index += 1) {
         lease = await manager.acquire({
           agentUID: 'agent-1',
+          agentHome: materialized.agentHome,
           codexHome: materialized.codexHome,
           aiGatewayBaseURL: 'http://control.test/api/v1/ai-gateway',
           aiGatewayAPIKey: `contract-key-${index}`,
@@ -1107,6 +1185,96 @@ function createExecOutputResponsesProvider(requests: JSONObject[]) {
           content: [{ type: 'output_text', text: 'Output contract checked.', annotations: [] }]
         }
       ])
+    }
+  })
+}
+
+function createHostedWebSearchResponsesProvider(requests: JSONObject[], bindings: JSONObject[]) {
+  return Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    async fetch(request, server) {
+      const url = new URL(request.url)
+      if (request.method === 'GET' && url.pathname === '/v1/models') {
+        return Response.json({
+          models: [execOutputModelCard('gpt-5.6-sol')]
+        })
+      }
+      if (request.method === 'GET' && url.pathname === '/v1/responses') {
+        const encodedBinding = request.headers.get('x-ankole-aigateway-model-binding')
+        if (encodedBinding) {
+          bindings.push(JSON.parse(Buffer.from(encodedBinding, 'base64url').toString('utf8')) as JSONObject)
+        }
+        if (server.upgrade(request)) return
+      }
+      if (request.method !== 'POST' || url.pathname !== '/v1/responses') {
+        return Response.json({ error: { message: 'not found' } }, { status: 404 })
+      }
+
+      const body = (await request.json()) as JSONObject
+      requests.push(body)
+      const encodedBinding = request.headers.get('x-ankole-aigateway-model-binding')
+      if (encodedBinding) {
+        bindings.push(JSON.parse(Buffer.from(encodedBinding, 'base64url').toString('utf8')) as JSONObject)
+      }
+      return execOutputResponse('hosted-web-search-done', 'gpt-5.6-sol', [
+        {
+          id: 'hosted-web-search-message',
+          type: 'message',
+          status: 'completed',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Hosted web search contract checked.', annotations: [] }]
+        }
+      ])
+    },
+    websocket: {
+      message(ws, message) {
+        const request = JSON.parse(
+          typeof message === 'string' ? message : new TextDecoder().decode(message)
+        ) as JSONObject
+        if (request.generate !== false) requests.push(request)
+        const response = {
+          id: 'hosted-web-search-done',
+          object: 'response',
+          created_at: 1_764_967_971,
+          completed_at: null,
+          status: 'in_progress',
+          model: 'gpt-5.6-sol',
+          previous_response_id: null,
+          output: [],
+          usage: null
+        }
+        const item = {
+          id: 'hosted-web-search-message',
+          type: 'message',
+          status: 'completed',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Hosted web search contract checked.', annotations: [] }]
+        }
+        for (const event of [
+          { type: 'response.created', sequence_number: 0, response },
+          { type: 'response.output_item.done', sequence_number: 1, output_index: 0, item },
+          {
+            type: 'response.completed',
+            sequence_number: 2,
+            response: {
+              ...response,
+              completed_at: 1_764_967_972,
+              status: 'completed',
+              output: [item],
+              usage: {
+                input_tokens: 1,
+                input_tokens_details: { cached_tokens: 0 },
+                output_tokens: 1,
+                output_tokens_details: { reasoning_tokens: 0 },
+                total_tokens: 2
+              }
+            }
+          }
+        ]) {
+          ws.send(JSON.stringify(event))
+        }
+      }
     }
   })
 }

--- a/app/agent_computer/test/llm/responses-wire.test.ts
+++ b/app/agent_computer/test/llm/responses-wire.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import type { JsonObject as JSONObject } from '@agentbull/active-support'
+import type { ResponseCreateParams } from 'openai/resources/responses/responses'
 import { z } from 'zod'
 import { runAgentLoop } from '../../src/core/agent-loop'
 import { callModel, createModel } from '../../src/core/llm'
@@ -10,11 +11,42 @@ import {
   responseEventStaleTimeoutMs,
   responseFrameRefreshesStaleDeadline
 } from '../../src/core/llm/session'
-import { buildResponseCreateParams, toResponseInput } from '../../src/core/llm/wire'
+import { buildResponseCreateParams, statefulToolResultsRecordParams, toResponseInput } from '../../src/core/llm/wire'
 
 import { fakeResponseSocket } from '../support/llm'
 
 describe('@ankole/agent-computer llm helpers: Responses HTTP and WebSocket wire shape', () => {
+  it('forwards frozen provider options on model calls and tool-result recording', () => {
+    const model = createModel({
+      apiKey: 'unused',
+      baseURL: 'http://aigateway.invalid/api/v1/ai-gateway',
+      selector: 'openai-compatible/gpt-5.6-sol',
+      providerOptions: { reasoningEffort: 'high', serviceTier: 'fast' }
+    })
+    const providerOptions = { reasoningEffort: 'high', serviceTier: 'fast' }
+
+    const request = buildResponseCreateParams(model, {
+      messages: [{ role: 'user', content: 'run one command' }]
+    }) as ResponseCreateParams & JSONObject
+    const toolResults = statefulToolResultsRecordParams(
+      model,
+      toResponseInput([
+        {
+          role: 'tool',
+          toolCallID: 'call_1',
+          result: '{"counter":1}'
+        }
+      ]),
+      {
+        actorEventID: '00000000-0000-0000-0000-000000000301',
+        previousResponseID: 'resp_1'
+      }
+    ) as ResponseCreateParams & JSONObject
+
+    expect(request.provider_options).toEqual(providerOptions)
+    expect(toolResults.provider_options).toEqual(providerOptions)
+  })
+
   it('uses a 300-second post-output stale window only above 100k estimated request tokens', () => {
     expect(responseEventStaleTimeoutMs(100_000)).toBe(180_000)
     expect(responseEventStaleTimeoutMs(100_001)).toBe(300_000)

--- a/app/agent_computer/test/llm/runtime-and-content.test.ts
+++ b/app/agent_computer/test/llm/runtime-and-content.test.ts
@@ -83,13 +83,15 @@ describe('@ankole/agent-computer llm helpers: transport and actor content', () =
       {
         profile: 'primary',
         provider_id: 'openrouter',
-        model: 'z-ai/glm-5.2'
+        model: 'z-ai/glm-5.2',
+        provider_options: { reasoningEffort: 'high', serviceTier: 'fast' }
       },
       aiGatewayKeyForTest('agent-1', 'agent-key')
     )
 
     expect(model.selector).toBe('openrouter/z-ai/glm-5.2')
     expect(model.provider).toBe('openrouter')
+    expect(model.providerOptions).toEqual({ reasoningEffort: 'high', serviceTier: 'fast' })
     expect(model.responseWebSocket?.url).toBe('wss://control.test/api/v1/ai-gateway/responses')
     await expect(model.responseWebSocket?.authorization()).resolves.toBe('Bearer agent-key')
   })

--- a/app/agent_computer/test/schedule-tools.test.ts
+++ b/app/agent_computer/test/schedule-tools.test.ts
@@ -8,6 +8,16 @@ import type { z } from 'zod'
 import { createScheduleTools } from '../src/tools/schedule/schedule-tools'
 
 describe('schedule tools', () => {
+  it('describes conversation resets without claiming that run history is cleared', () => {
+    const cron = createScheduleTools({
+      turnStart: turnStartForScheduleTool(),
+      requestScheduleRPC: async () => ({})
+    }).find(tool => tool.name === 'cron')
+
+    expect(cron?.description).toContain('existing run history remains')
+    expect(cron?.description).not.toContain("clears the schedule's own run history")
+  })
+
   it('uses a stable default check_back_later idempotency key across provider tool call retries', async () => {
     const requests: JSONObject[] = []
     const tools = createScheduleTools({

--- a/app/agent_computer/test/show-background-job-details.test.ts
+++ b/app/agent_computer/test/show-background-job-details.test.ts
@@ -67,8 +67,10 @@ describe('@ankole/agent-computer show background job details tool', () => {
         tool_calls: 3,
         tools_used: [
           { name: 'context_compaction', calls: 1 },
-          { name: 'shell', calls: 2 }
+          { name: 'shell', calls: 1 },
+          { name: 'web_search', calls: 1 }
         ],
+        tool_execution_mechanisms: [{ name: 'web_search', execution_mechanism: 'provider_hosted', calls: 1 }],
         files_changed: ['report.md'],
         skills_used: ['deep-research'],
         active_items: [],
@@ -151,6 +153,7 @@ describe('@ankole/agent-computer show background job details tool', () => {
         completed_items: 0,
         tool_calls: 0,
         tools_used: [],
+        tool_execution_mechanisms: [],
         files_changed: [],
         active_items: []
       },
@@ -179,6 +182,7 @@ describe('@ankole/agent-computer show background job details tool', () => {
       completed_items: 0,
       tool_calls: 0,
       tools_used: [],
+      tool_execution_mechanisms: [],
       files_changed: [],
       active_items: []
     })
@@ -350,8 +354,10 @@ function response(outputText = 'complete') {
         tool_calls: 3,
         tools_used: [
           { name: 'context_compaction', calls: 1 },
-          { name: 'shell', calls: 2 }
+          { name: 'shell', calls: 1 },
+          { name: 'web_search', calls: 1 }
         ],
+        tool_execution_mechanisms: [{ name: 'web_search', execution_mechanism: 'provider_hosted', calls: 1 }],
         files_changed: ['report.md'],
         skills_used: ['deep-research'],
         active_items: [],

--- a/app/control_plane/lib/ankole/ai_gateway/codex_models.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/codex_models.ex
@@ -6,10 +6,11 @@ defmodule Ankole.AIGateway.CodexModels do
   command auth, and applies each returned card with full-card replacement
   semantics (`construct_model_info_from_candidates`, codex
   rust-v0.147.0). Every card therefore supplies the complete pinned card shape.
-  AIGateway owns selector-specific modalities, Responses Lite selection, the
-  native search gate, and one model-visible tool-output limit. Base instructions
-  contain the prompt vendored from the same codex pin and the readable form of
-  that output limit.
+  AIGateway owns selector-specific modalities, the native search gate, and one
+  model-visible tool-output limit. Base instructions contain the prompt vendored
+  from the same codex pin and the readable form of that output limit. Cards keep
+  Responses Lite disabled because Codex 0.147 omits configured hosted web search
+  from that private carrier; standard Responses preserves the native tool.
 
   Cards must stay in lockstep with the pinned codex version. Re-vendor
   `priv/codex/base_instructions.md` and re-check the card baseline when the
@@ -19,7 +20,6 @@ defmodule Ankole.AIGateway.CodexModels do
   alias Ankole.AIAgent.ModelProfiles
   alias Ankole.AIGateway.Models
 
-  @responses_lite_models MapSet.new(~w(gpt-5.6-sol gpt-5.6-terra gpt-5.6-luna))
   @tool_output_limit_tokens 10_000
 
   @external_resource Path.join(:code.priv_dir(:ankole), "codex/base_instructions.md")
@@ -103,7 +103,7 @@ defmodule Ankole.AIGateway.CodexModels do
       "experimental_supported_tools" => [],
       "input_modalities" => codex_input_modalities(input_modalities),
       "supports_search_tool" => true,
-      "use_responses_lite" => MapSet.member?(@responses_lite_models, slug)
+      "use_responses_lite" => false
     }
   end
 

--- a/app/control_plane/lib/ankole/ai_gateway/providers/openai_compatible.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/providers/openai_compatible.ex
@@ -61,6 +61,7 @@ defmodule Ankole.AIGateway.Providers.OpenAICompatible do
   and response normalization remain in the shared native UniversalAIClient path.
   """
   def prepare_language_model(ctx) do
+    ctx = keep_metadata_local(ctx)
     endpoint = endpoint_kind(ctx)
 
     case {endpoint, ctx.stream?, ctx.settings[:upstream_transport]} do
@@ -88,6 +89,12 @@ defmodule Ankole.AIGateway.Providers.OpenAICompatible do
         |> ReasoningEffort.put_provider_options(ctx, target: :reasoning_effort)
         |> OpenAIRequestOptions.put_provider_options(:chat_completions)
     end
+  end
+
+  # Generic compatible endpoints do not consistently implement OpenAI's
+  # metadata field. AIGateway retains caller metadata in its local Response.
+  defp keep_metadata_local(%{request: request} = ctx) when is_map(request) do
+    %{ctx | request: Map.delete(request, "metadata")}
   end
 
   @doc """

--- a/app/control_plane/lib/ankole/ai_gateway/responses_preparation.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/responses_preparation.ex
@@ -226,9 +226,7 @@ defmodule Ankole.AIGateway.ResponsesPreparation do
          upstream_stream?
        ) do
     with {:ok, main_spec} <-
-           Providers.build_response_request(runtime, provider_request,
-             stream?: upstream_stream? and is_nil(image_generation)
-           ) do
+           build_main_spec(runtime, provider_request, image_generation, upstream_stream?) do
       spec =
         main_spec
         |> composite_spec(public_request, image_generation)
@@ -246,6 +244,27 @@ defmodule Ankole.AIGateway.ResponsesPreparation do
       end
 
       {:ok, CredentialAttempts.reattach(spec, rebuild, provider_request)}
+    end
+  end
+
+  defp build_main_spec(runtime, provider_request, nil, upstream_stream?) do
+    Providers.build_response_request(runtime, provider_request, stream?: upstream_stream?)
+  end
+
+  defp build_main_spec(runtime, provider_request, _image_generation, false) do
+    Providers.build_response_request(runtime, provider_request, stream?: false)
+  end
+
+  defp build_main_spec(runtime, provider_request, _image_generation, true) do
+    case Providers.build_response_request(runtime, provider_request, stream?: true) do
+      {:ok, %{upstream: %{kind: :websocket_text}} = spec} ->
+        {:ok, spec}
+
+      {:ok, _stream_spec} ->
+        Providers.build_response_request(runtime, provider_request, stream?: false)
+
+      {:error, _reason} = error ->
+        error
     end
   end
 

--- a/app/control_plane/lib/ankole/background_agent_jobs.ex
+++ b/app/control_plane/lib/ankole/background_agent_jobs.ex
@@ -30,6 +30,7 @@ defmodule Ankole.BackgroundAgentJobs do
     background_agent_job_runtime_exception
     agent_codex_runtime_busy
     background_agent_job_steer_delivery_failed
+    codex_app_server_request_timeout
   )
 
   @doc """

--- a/app/control_plane/lib/ankole/background_agent_jobs/dispatch.ex
+++ b/app/control_plane/lib/ankole/background_agent_jobs/dispatch.ex
@@ -377,20 +377,6 @@ defmodule Ankole.BackgroundAgentJobs.Dispatch do
   defp ensure_seedable_task(""), do: {:error, :background_agent_job_steer_text_missing}
   defp ensure_seedable_task(task) when is_binary(task), do: :ok
 
-  @doc false
-  @spec bounded_steer_texts([ActorEvent.t()]) :: [String.t()]
-  def bounded_steer_texts(steers) do
-    steers
-    |> Enum.map(&steer_text/1)
-    |> Enum.reject(&is_nil/1)
-    |> Enum.map(fn text ->
-      if byte_size(text) > 2_000,
-        do: Ankole.BackgroundAgentJobs.Text.truncate_utf8(text, 2_000, "...[truncated]"),
-        else: text
-    end)
-    |> Enum.take(8)
-  end
-
   defp steer_text(%ActorEvent{payload: payload}) do
     case get_in(payload || %{}, ["data", "command", "argsText"]) do
       text when is_binary(text) and text != "" -> text

--- a/app/control_plane/lib/ankole/background_agent_jobs/lifecycle.ex
+++ b/app/control_plane/lib/ankole/background_agent_jobs/lifecycle.ex
@@ -302,37 +302,26 @@ defmodule Ankole.BackgroundAgentJobs.Lifecycle do
     end
   end
 
-  # A terminal commit never waits for steering. Open steers on a succeeded Job
-  # become one successor Job seeded with every message in order, so the reply
-  # to those messages is visible follow-up work instead of a blocked commit.
+  # Open steers on a succeeded Job become one successor Job seeded with every
+  # message in order. Successor storage and steer completion are one
+  # transaction, so a storage failure leaves the source Job and steers open.
   # Failed and stopped commits, and an external completion, answer open steers
-  # with the terminal notice itself. When the successor cannot be created (for
-  # example a manual respawn already exists), the messages travel in the wakeup
-  # payload instead of vanishing.
+  # with the terminal notice itself.
   defp resolve_open_steers_after_commit(repo, %Job{status: "succeeded"} = job, now, opts) do
     case Dispatch.open_steer_events_in_tx(repo, job.id, job.agent_uid) do
       [] ->
         {:ok, nil}
 
       steers ->
-        outcome =
-          if Keyword.get(opts, :external_completion, false) do
-            nil
-          else
-            case Dispatch.seed_steer_successor_in_tx(repo, job, steers, now) do
-              {:ok, successor} ->
-                %{successor_job_id: successor.id}
-
-              {:error, {:background_agent_job_already_respawned, successor_id}} ->
-                %{successor_job_id: successor_id}
-
-              {:error, _reason} ->
-                %{unapplied_messages: Dispatch.bounded_steer_texts(steers)}
-            end
+        if Keyword.get(opts, :external_completion, false) do
+          with :ok <- complete_steer_events_in_tx(repo, steers, now) do
+            {:ok, nil}
           end
-
-        with :ok <- complete_steer_events_in_tx(repo, steers, now) do
-          {:ok, outcome}
+        else
+          with {:ok, successor} <- Dispatch.seed_steer_successor_in_tx(repo, job, steers, now),
+               :ok <- complete_steer_events_in_tx(repo, steers, now) do
+            {:ok, %{successor_job_id: successor.id}}
+          end
         end
     end
   end
@@ -750,8 +739,7 @@ defmodule Ankole.BackgroundAgentJobs.Lifecycle do
           "project_path" => Map.get(job.result || %{}, "project_path"),
           "reply_route" => job.reply_route || %{},
           "pending_user_input" => get_in(job.metadata || %{}, ["pending_user_input"]),
-          "successor_job_id" => steer_outcome[:successor_job_id],
-          "unapplied_messages" => steer_outcome[:unapplied_messages]
+          "successor_job_id" => steer_outcome[:successor_job_id]
         })
     }
   end

--- a/app/control_plane/lib/ankole/background_agent_jobs/schemas/turn.ex
+++ b/app/control_plane/lib/ankole/background_agent_jobs/schemas/turn.ex
@@ -24,6 +24,8 @@ defmodule Ankole.BackgroundAgentJobs.Schemas.Turn do
   @terminal_statuses ~w(completed failed interrupted)
   @plan_statuses ~w(pending in_progress completed)
   @max_tools_used 128
+  @max_tool_execution_mechanisms 256
+  @tool_execution_mechanisms ~w(local_dynamic provider_hosted)
   @max_skills_used 128
   @max_files_changed 1_024
   @max_plan_steps 100
@@ -177,12 +179,17 @@ defmodule Ankole.BackgroundAgentJobs.Schemas.Turn do
            "files_changed" => files_changed
          } = progress
        ) do
-    allowed = ~w(completed_items tool_calls tools_used files_changed skills_used plan active_item)
+    allowed =
+      ~w(completed_items tool_calls tools_used tool_execution_mechanisms files_changed skills_used plan active_item)
 
     Map.keys(progress) -- allowed == [] and
       nonnegative_integer?(completed_items) and
       nonnegative_integer?(tool_calls) and
       valid_tools_used?(tools_used, tool_calls) and
+      valid_optional_tool_execution_mechanisms?(
+        Map.get(progress, "tool_execution_mechanisms"),
+        tools_used
+      ) and
       string_list?(files_changed, @max_files_changed) and
       files_changed == Enum.sort(files_changed) and files_changed == Enum.uniq(files_changed) and
       valid_optional_skills_used?(Map.get(progress, "skills_used")) and
@@ -204,6 +211,35 @@ defmodule Ankole.BackgroundAgentJobs.Schemas.Turn do
   end
 
   defp valid_tools_used?(_tools_used, _tool_calls), do: false
+
+  defp valid_optional_tool_execution_mechanisms?(nil, _tools_used), do: true
+
+  defp valid_optional_tool_execution_mechanisms?(executions, tools_used)
+       when is_list(executions) and is_list(tools_used) do
+    if length(executions) <= @max_tool_execution_mechanisms and
+         Enum.all?(executions, &valid_tool_execution_mechanism?/1) do
+      tool_calls = Map.new(tools_used, &{&1["name"], &1["calls"]})
+      pairs = Enum.map(executions, &{&1["name"], &1["execution_mechanism"]})
+
+      pairs == Enum.sort(pairs) and pairs == Enum.uniq(pairs) and
+        executions
+        |> Enum.group_by(& &1["name"], & &1["calls"])
+        |> Enum.all?(fn {name, calls} -> Enum.sum(calls) <= Map.get(tool_calls, name, -1) end)
+    else
+      false
+    end
+  end
+
+  defp valid_optional_tool_execution_mechanisms?(_executions, _tools_used), do: false
+
+  defp valid_tool_execution_mechanism?(execution) when is_map(execution) do
+    Map.keys(execution) -- ~w(name execution_mechanism calls) == [] and
+      nonempty_string?(execution["name"]) and
+      execution["execution_mechanism"] in @tool_execution_mechanisms and
+      is_integer(execution["calls"]) and execution["calls"] > 0
+  end
+
+  defp valid_tool_execution_mechanism?(_execution), do: false
 
   defp valid_optional_skills_used?(nil), do: true
 

--- a/app/control_plane/lib/ankole/background_agent_jobs/turns.ex
+++ b/app/control_plane/lib/ankole/background_agent_jobs/turns.ex
@@ -748,6 +748,7 @@ defmodule Ankole.BackgroundAgentJobs.Turns do
           completed_items: 0,
           tool_calls: 0,
           tools: %{},
+          tool_execution_mechanisms: %{},
           files: MapSet.new(),
           skills: MapSet.new()
         },
@@ -757,6 +758,11 @@ defmodule Ankole.BackgroundAgentJobs.Turns do
               completed_items: acc.completed_items + nonnegative(progress["completed_items"]),
               tool_calls: acc.tool_calls + nonnegative(progress["tool_calls"]),
               tools: merge_tool_usage(acc.tools, progress["tools_used"]),
+              tool_execution_mechanisms:
+                merge_tool_execution_mechanisms(
+                  acc.tool_execution_mechanisms,
+                  progress["tool_execution_mechanisms"]
+                ),
               files: merge_files(acc.files, progress["files_changed"]),
               skills: merge_files(acc.skills, progress["skills_used"])
             }
@@ -774,6 +780,12 @@ defmodule Ankole.BackgroundAgentJobs.Turns do
           totals.tools
           |> Enum.sort_by(fn {name, _calls} -> name end)
           |> Enum.map(fn {name, calls} -> %{name: name, calls: calls} end),
+        tool_execution_mechanisms:
+          totals.tool_execution_mechanisms
+          |> Enum.sort_by(fn {{name, mechanism}, _calls} -> {name, mechanism} end)
+          |> Enum.map(fn {{name, mechanism}, calls} ->
+            %{name: name, execution_mechanism: mechanism, calls: calls}
+          end),
         files_changed: totals.files |> MapSet.to_list() |> Enum.sort(),
         active_items: active_items(turns, job)
       }
@@ -799,6 +811,20 @@ defmodule Ankole.BackgroundAgentJobs.Turns do
   end
 
   defp merge_tool_usage(acc, _tools), do: acc
+
+  defp merge_tool_execution_mechanisms(acc, executions) when is_list(executions) do
+    Enum.reduce(executions, acc, fn
+      %{"name" => name, "execution_mechanism" => mechanism, "calls" => calls}, result
+      when is_binary(name) and mechanism in ~w(local_dynamic provider_hosted) and
+             is_integer(calls) and calls > 0 ->
+        Map.update(result, {name, mechanism}, calls, &(&1 + calls))
+
+      _execution, result ->
+        result
+    end)
+  end
+
+  defp merge_tool_execution_mechanisms(acc, _executions), do: acc
 
   defp merge_files(acc, files) when is_list(files) do
     Enum.reduce(files, acc, fn

--- a/app/control_plane/lib/ankole/schedule/cron.ex
+++ b/app/control_plane/lib/ankole/schedule/cron.ex
@@ -152,7 +152,8 @@ defmodule Ankole.Schedule.Cron do
     Repo.transact(fn repo ->
       case Store.lock_cron_schedule(repo, cron_schedule_id) do
         %CronSchedule{status: "paused"} = schedule ->
-          with {:ok, next_fire_at} <-
+          with :ok <- Normalizer.validate_cron_task(schedule.payload, schedule.automation_job_id),
+               {:ok, next_fire_at} <-
                  Planner.next_fire_after(schedule.schedule, schedule.timezone, now) do
             # A bound that ran out while the schedule was paused makes resume
             # complete it: that is the schedule's true state, not an error.
@@ -166,7 +167,8 @@ defmodule Ankole.Schedule.Cron do
           end
 
         %CronSchedule{status: "active"} = schedule ->
-          with :ok <- assert_recurring_invariant_in_tx(repo, schedule) do
+          with :ok <- Normalizer.validate_cron_task(schedule.payload, schedule.automation_job_id),
+               :ok <- assert_recurring_invariant_in_tx(repo, schedule) do
             {:ok, schedule}
           end
 
@@ -210,6 +212,7 @@ defmodule Ankole.Schedule.Cron do
     Repo.transact(fn repo ->
       with %CronSchedule{} = schedule <- Store.lock_cron_schedule(repo, cron_schedule_id),
            :ok <- Store.reject_terminal(schedule),
+           :ok <- Normalizer.validate_cron_task(schedule.payload, schedule.automation_job_id),
            {:ok, request_id} <- manual_request_id(opts),
            {:ok, result} <- arm_manual_cron_fire_in_tx(repo, schedule, request_id, now, opts) do
         {:ok, result}
@@ -221,12 +224,19 @@ defmodule Ankole.Schedule.Cron do
   end
 
   @spec validate_fire_schedule(CronSchedule.t(), ScheduledEvent.t()) ::
-          :ok | {:cancel, :cron_schedule_not_active}
-  def validate_fire_schedule(%CronSchedule{status: status}, %ScheduledEvent{} = event) do
+          :ok | {:cancel, :cron_schedule_not_active | :cron_task_required}
+  def validate_fire_schedule(%CronSchedule{status: status} = schedule, %ScheduledEvent{} = event) do
     case {event_trigger(event), status} do
-      {"scheduled", "active"} -> :ok
-      {"manual", status} when status in ["active", "paused"] -> :ok
+      {"scheduled", "active"} -> validate_fire_task(schedule)
+      {"manual", status} when status in ["active", "paused"] -> validate_fire_task(schedule)
       {_trigger, _status} -> {:cancel, :cron_schedule_not_active}
+    end
+  end
+
+  defp validate_fire_task(%CronSchedule{} = schedule) do
+    case Normalizer.validate_cron_task(schedule.payload, schedule.automation_job_id) do
+      :ok -> :ok
+      {:error, reason} -> {:cancel, reason}
     end
   end
 

--- a/app/control_plane/lib/ankole/schedule/normalizer.ex
+++ b/app/control_plane/lib/ankole/schedule/normalizer.ex
@@ -232,7 +232,9 @@ defmodule Ankole.Schedule.Normalizer do
   # on the owner conversation's transcript, so its stored input has to carry
   # the whole repeatable instruction. An AutomationJob consumer brings its own
   # committed script instead.
-  defp validate_cron_task(payload, automation_job_id) do
+  @doc false
+  @spec validate_cron_task(map(), integer() | nil) :: :ok | {:error, :cron_task_required}
+  def validate_cron_task(payload, automation_job_id) do
     cond do
       is_integer(automation_job_id) -> :ok
       is_map(payload) and is_binary(payload["task"]) and String.trim(payload["task"]) != "" -> :ok

--- a/app/control_plane/lib/ankole_web/schemas/console_api.ex
+++ b/app/control_plane/lib/ankole_web/schemas/console_api.ex
@@ -3246,6 +3246,29 @@ defmodule AnkoleWeb.Schemas.ConsoleAPI do
     )
   end
 
+  defmodule BackgroundAgentJobTurnToolExecutionMechanism do
+    @moduledoc false
+    require OpenAPISpex
+
+    OpenAPISpex.schema(
+      %{
+        title: "BackgroundAgentJobTurnToolExecutionMechanism",
+        type: :object,
+        properties: %{
+          name: %Schema{type: :string, minLength: 1},
+          execution_mechanism: %Schema{
+            type: :string,
+            enum: ["local_dynamic", "provider_hosted"]
+          },
+          calls: %Schema{type: :integer, minimum: 1}
+        },
+        required: [:name, :execution_mechanism, :calls],
+        additionalProperties: false
+      },
+      struct?: false
+    )
+  end
+
   defmodule BackgroundAgentJobTurnPlanStep do
     @moduledoc false
     require OpenAPISpex
@@ -3315,6 +3338,11 @@ defmodule AnkoleWeb.Schemas.ConsoleAPI do
           completed_items: %Schema{type: :integer, minimum: 0},
           tool_calls: %Schema{type: :integer, minimum: 0},
           tools_used: %Schema{type: :array, items: BackgroundAgentJobTurnToolUsage, maxItems: 128},
+          tool_execution_mechanisms: %Schema{
+            type: :array,
+            items: BackgroundAgentJobTurnToolExecutionMechanism,
+            maxItems: 256
+          },
           files_changed: %Schema{type: :array, items: %Schema{type: :string}, maxItems: 1024},
           plan: BackgroundAgentJobTurnPlan,
           active_item: BackgroundAgentJobTurnActiveItem

--- a/app/control_plane/priv/repo/migrations/20260812141549_remove_background_agent_job_agent_plugin_ids.exs
+++ b/app/control_plane/priv/repo/migrations/20260812141549_remove_background_agent_job_agent_plugin_ids.exs
@@ -1,0 +1,12 @@
+defmodule Ankole.Repo.Migrations.RemoveBackgroundAgentJobAgentPluginIds do
+  use Ecto.Migration
+
+  def up do
+    execute("ALTER TABLE background_agent_jobs DROP COLUMN IF EXISTS agent_plugin_ids")
+  end
+
+  # Current code does not read this old column, and its values cannot be restored.
+  def down do
+    :ok
+  end
+end

--- a/app/control_plane/priv/repo/migrations/20260812145614_pause_invalid_direct_cron_schedules.exs
+++ b/app/control_plane/priv/repo/migrations/20260812145614_pause_invalid_direct_cron_schedules.exs
@@ -1,0 +1,43 @@
+defmodule Ankole.Repo.Migrations.PauseInvalidDirectCronSchedules do
+  use Ecto.Migration
+
+  @invalid_direct_schedule """
+  schedule.automation_job_id IS NULL
+    AND (
+      jsonb_typeof(schedule.payload->'task') IS DISTINCT FROM 'string'
+      OR COALESCE(schedule.payload->>'task', '') !~ '[^[:space:]]'
+    )
+  """
+
+  def up do
+    Enum.each(up_sqls(), &execute/1)
+  end
+
+  def down, do: :ok
+
+  @doc false
+  def up_sqls do
+    [
+      """
+      UPDATE actor_cron_schedules AS schedule
+      SET status = 'paused',
+          next_fire_at = NULL,
+          updated_at = NOW()
+      WHERE schedule.status = 'active'
+        AND #{@invalid_direct_schedule}
+      """,
+      """
+      UPDATE actor_scheduled_events AS event
+      SET status = 'cancelled',
+          cancelled_at = NOW(),
+          last_fire_error = '{"reason":"cron_task_required"}'::jsonb,
+          updated_at = NOW()
+      FROM actor_cron_schedules AS schedule
+      WHERE event.cron_schedule_id = schedule.id
+        AND event.kind = 'cron_fire'
+        AND event.status IN ('scheduled', 'firing')
+        AND #{@invalid_direct_schedule}
+      """
+    ]
+  end
+end

--- a/app/control_plane/test/ankole/ai_gateway/chatgpt_auth_test.exs
+++ b/app/control_plane/test/ankole/ai_gateway/chatgpt_auth_test.exs
@@ -55,7 +55,7 @@ defmodule Ankole.AIGateway.ChatGPTAuthTest do
       end)
 
     create_chatgpt_provider!("chatgpt-device", issuer)
-    now = ~U[2026-07-29 08:00:00Z]
+    now = DateTime.utc_now(:second)
 
     assert {:ok, login} =
              ChatGPTAuth.start_login(

--- a/app/control_plane/test/ankole/ai_gateway/codex_models_test.exs
+++ b/app/control_plane/test/ankole/ai_gateway/codex_models_test.exs
@@ -57,9 +57,9 @@ defmodule Ankole.AIGateway.CodexModelsTest do
              "Model-visible tool output is limited to 10000 tokens."
   end
 
-  test "cards follow the pinned Codex responses-lite model set" do
+  test "cards keep the configured search tool on standard Responses" do
     for slug <- ~w(gpt-5.6-sol gpt-5.6-terra gpt-5.6-luna) do
-      assert CodexModels.card(slug, ["text"])["use_responses_lite"]
+      refute CodexModels.card(slug, ["text"])["use_responses_lite"]
     end
 
     refute CodexModels.card("gpt-5.5", ["text"])["use_responses_lite"]

--- a/app/control_plane/test/ankole/ai_gateway/hosted_image_generation_test.exs
+++ b/app/control_plane/test/ankole/ai_gateway/hosted_image_generation_test.exs
@@ -127,6 +127,95 @@ defmodule Ankole.AIGateway.HostedImageGenerationTest do
     assert error.message =~ "native image generation"
   end
 
+  test "hosted image fallback keeps a configured main-model WebSocket" do
+    %{principal: agent} = agent_fixture()
+    suffix = System.unique_integer([:positive])
+    main_provider_id = "compatible-hosted-websocket-#{suffix}"
+    image_provider_id = "image-hosted-websocket-#{suffix}"
+
+    assert {:ok, _provider} =
+             ProviderConfigs.create_provider(%{
+               provider_id: main_provider_id,
+               provider_kind: "openai_compatible",
+               base_url: "https://compatible.test/v1",
+               connection_options: %{
+                 "endpoint_kind" => "responses",
+                 "upstream_transport" => "websocket"
+               },
+               credential_pool: %{
+                 "entries" => [%{"label" => "Main", "api_key" => "sk-main"}]
+               }
+             })
+
+    assert {:ok, _profile} =
+             ModelProfiles.put_model_profile(agent.uid, "primary", %{
+               provider_id: main_provider_id,
+               model: "compatible-main-model",
+               provider_options: %{"serviceTier" => "fast"}
+             })
+
+    assert {:ok, _provider} =
+             ProviderConfigs.create_provider(%{
+               provider_id: image_provider_id,
+               provider_kind: "openrouter",
+               base_url: "http://127.0.0.1:1/api/v1",
+               credential_pool: %{
+                 "entries" => [%{"label" => "Image", "api_key" => "sk-image"}]
+               }
+             })
+
+    :ok =
+      ModelMetadataCache.put(
+        {:image_model_catalog, image_provider_id, "images/models"},
+        [%{"id" => "openai/gpt-image-2"}],
+        60_000
+      )
+
+    :ok =
+      ModelMetadataCache.put(
+        {:image_model_endpoints, image_provider_id, "images/models/openai/gpt-image-2/endpoints"},
+        [
+          %{
+            "provider_slug" => "openai",
+            "provider_tag" => "openai/gpt-image-2:openai",
+            "supported_parameters" => %{}
+          }
+        ],
+        60_000
+      )
+
+    assert {:ok, _profile} =
+             ModelProfiles.put_model_profile(agent.uid, "image_generate", %{
+               provider_id: image_provider_id,
+               model: "openai/gpt-image-2"
+             })
+
+    assert {:ok, request} =
+             AIGateway.prepare_websocket_request(agent.uid, %{
+               "model" => "primary",
+               "input" => "Run one tool.",
+               "metadata" => %{"actor_event_id" => "hosted-websocket-event"},
+               "tools" => [
+                 %{"type" => "function", "name" => "command", "parameters" => %{}},
+                 %{"type" => "image_generation"}
+               ]
+             })
+
+    assert request.upstream.kind == :websocket_text
+    assert request.upstream.method == "GET"
+    assert request.upstream.url == "wss://compatible.test/v1/responses"
+    assert request.response_context.stream == true
+    assert request.response_context.provider_options["service_tier"] == "fast"
+    refute Map.has_key?(request.response_context.request, "metadata")
+
+    assert request.hosted_tools.public_request["metadata"] == %{
+             "actor_event_id" => "hosted-websocket-event"
+           }
+
+    assert request.hosted_tools.image_generation["selected_model"] == "openai/gpt-image-2"
+    refute Map.has_key?(request, :body)
+  end
+
   test "requires JPEG or WebP when image output compression is set" do
     %{principal: agent} = agent_fixture()
 

--- a/app/control_plane/test/ankole/background_agent_jobs_test.exs
+++ b/app/control_plane/test/ankole/background_agent_jobs_test.exs
@@ -80,7 +80,14 @@ defmodule Ankole.BackgroundAgentJobsTest do
       progress: %{
         "completed_items" => 2,
         "tool_calls" => 1,
-        "tools_used" => [%{"name" => "shell", "calls" => 1}],
+        "tools_used" => [%{"name" => "web_search", "calls" => 1}],
+        "tool_execution_mechanisms" => [
+          %{
+            "name" => "web_search",
+            "execution_mechanism" => "provider_hosted",
+            "calls" => 1
+          }
+        ],
         "files_changed" => ["a.ts"],
         "plan" => %{
           "steps" => [%{"step" => "Run tests", "status" => "completed"}]
@@ -107,6 +114,15 @@ defmodule Ankole.BackgroundAgentJobsTest do
       })
 
     refute Turn.changeset(%Turn{}, invalid_progress).valid?
+
+    invalid_execution_mechanism =
+      put_in(
+        attrs,
+        [:progress, "tool_execution_mechanisms"],
+        [%{"name" => "web_search", "execution_mechanism" => "guessed", "calls" => 1}]
+      )
+
+    refute Turn.changeset(%Turn{}, invalid_execution_mechanism).valid?
   end
 
   test "forward migration installs the runtime snapshot columns and removes activity timestamps" do
@@ -441,6 +457,74 @@ defmodule Ankole.BackgroundAgentJobsTest do
     assert active_child.status == "interrupted"
     assert active_child.error["code"] == "background_agent_job_succeeded"
     assert %DateTime{} = active_child.completed_at
+  end
+
+  test "success rolls back when an existing successor cannot carry an open steer" do
+    %{principal: agent} = background_agent_fixture()
+    job = create_job!(agent.uid, "steer-successor-conflict")
+
+    assert {:ok, %{job: running}} =
+             BackgroundAgentJobs.commit_status_with_wakeup(job.id, agent.uid, %{
+               "status" => "running",
+               "runtime_thread_id" => "thread-steer-successor-conflict"
+             })
+
+    running = set_attempts!(running, 1)
+
+    _turn =
+      insert_turn!(
+        running,
+        1,
+        "thread-steer-successor-conflict",
+        "turn-steer-successor-conflict",
+        "completed"
+      )
+
+    # Public lifecycle locks prevent this order. Build the durable conflict
+    # directly to prove that its defensive branch does not complete the steer.
+    failed_at = DateTime.utc_now(:microsecond)
+
+    running
+    |> Ecto.Changeset.change(status: "failed", completed_at: failed_at)
+    |> Repo.update!()
+
+    assert {:ok, %{job: manual_successor}} =
+             BackgroundAgentJobs.respawn_with_dispatch(job.id, %{
+               "agent_uid" => agent.uid,
+               "owner_session_id" => job.owner_session_id,
+               "source_tool_call_id" => "manual-steer-successor-conflict",
+               "message" => "Continue with the manual follow-up.",
+               "reply_route" => job.reply_route
+             })
+
+    job
+    |> Repo.reload!()
+    |> Ecto.Changeset.change(status: "running", completed_at: nil)
+    |> Repo.update!()
+
+    assert {:ok, %{command_event: steer}} =
+             BackgroundAgentJobs.send_message(job.id, %{
+               "agent_uid" => agent.uid,
+               "message" => "Preserve this late instruction.",
+               "request_id" => "late-steer-successor-conflict"
+             })
+
+    assert {:error, {:background_agent_job_already_respawned, successor_id}} =
+             BackgroundAgentJobs.commit_status_with_wakeup(job.id, agent.uid, %{
+               "status" => "succeeded",
+               "result" => %{"summary" => "Done"}
+             })
+
+    assert successor_id == manual_successor.id
+    assert Repo.reload!(job).status == "running"
+    assert Repo.reload!(steer).completed_at == nil
+    assert Repo.reload!(steer).input_state == "open"
+    assert Repo.reload!(manual_successor).task == "Continue with the manual follow-up."
+
+    refute Repo.get_by(ActorEvent,
+             session_id: job.owner_session_id,
+             type: "background_agent_job.completed"
+           )
   end
 
   test "success cannot bypass the current-attempt trajectory by omitting the runtime thread anchor" do
@@ -1729,6 +1813,13 @@ defmodule Ankole.BackgroundAgentJobsTest do
       trajectory_groups: [[assistant_message("child-report-must-not-appear")]],
       progress:
         progress_snapshot(2, "web_search", ["child.tmp"])
+        |> Map.put("tool_execution_mechanisms", [
+          %{
+            "name" => "web_search",
+            "execution_mechanism" => "provider_hosted",
+            "calls" => 1
+          }
+        ])
         |> Map.put("active_item", %{"id" => "child-search", "name" => "web_search"}),
       usage: usage_snapshot(999)
     })
@@ -1780,6 +1871,10 @@ defmodule Ankole.BackgroundAgentJobsTest do
              %{name: "context_compaction", calls: 1},
              %{name: "shell", calls: 1},
              %{name: "web_search", calls: 1}
+           ]
+
+    assert execution.progress.tool_execution_mechanisms == [
+             %{name: "web_search", execution_mechanism: "provider_hosted", calls: 1}
            ]
 
     assert execution.progress.files_changed == ["a.ts", "b.ts", "child.tmp"]
@@ -2592,8 +2687,24 @@ defmodule Ankole.BackgroundAgentJobsTest do
         "details_json" => %{"error_code" => "codex_job_transient", "retryable" => true}
       }
 
+      app_server_timeout = %{
+        "code" => "worker_turn_failed",
+        "message" => "app-server request timed out",
+        "details_json" => %{
+          "error_code" => "codex_app_server_request_timeout",
+          "retryable" => true
+        }
+      }
+
+      assert BackgroundAgentJobs.turn_error_class(app_server_timeout) == :infrastructure
+
       assert DateTime.diff(BackgroundAgentJobs.turn_error_retry_at(infrastructure, 1, now), now) ==
                15
+
+      assert DateTime.diff(
+               BackgroundAgentJobs.turn_error_retry_at(app_server_timeout, 1, now),
+               now
+             ) == 15
 
       assert DateTime.diff(BackgroundAgentJobs.turn_error_retry_at(infrastructure, 5, now), now) ==
                300

--- a/app/control_plane/test/ankole/ecto/pause_invalid_direct_cron_schedules_migration_test.exs
+++ b/app/control_plane/test/ankole/ecto/pause_invalid_direct_cron_schedules_migration_test.exs
@@ -1,0 +1,116 @@
+defmodule Ankole.Ecto.PauseInvalidDirectCronSchedulesMigrationTest do
+  use Ankole.DataCase, async: false
+
+  alias Ankole.Repo
+
+  @migration Ankole.Repo.Migrations.PauseInvalidDirectCronSchedules
+
+  unless Code.ensure_loaded?(@migration) do
+    Code.require_file(
+      Path.expand(
+        "../../../priv/repo/migrations/20260812145614_pause_invalid_direct_cron_schedules.exs",
+        __DIR__
+      )
+    )
+  end
+
+  setup do
+    schema = "invalid_direct_cron_#{System.unique_integer([:positive])}"
+    Repo.query!("CREATE SCHEMA #{schema}")
+    Repo.query!("SET LOCAL search_path TO #{schema}")
+
+    Repo.query!("""
+    CREATE TABLE actor_cron_schedules (
+      id text PRIMARY KEY,
+      status text NOT NULL,
+      next_fire_at timestamptz,
+      payload jsonb NOT NULL,
+      automation_job_id bigint,
+      updated_at timestamptz NOT NULL
+    )
+    """)
+
+    Repo.query!("""
+    CREATE TABLE actor_scheduled_events (
+      id text PRIMARY KEY,
+      cron_schedule_id text NOT NULL,
+      kind text NOT NULL,
+      status text NOT NULL,
+      cancelled_at timestamptz,
+      last_fire_error jsonb NOT NULL,
+      updated_at timestamptz NOT NULL
+    )
+    """)
+
+    :ok
+  end
+
+  test "pauses unsafe direct schedules and cancels only their live fires" do
+    now = DateTime.utc_now(:microsecond)
+    next_fire_at = DateTime.add(now, 1, :hour)
+
+    schedules = [
+      ["missing", "active", next_fire_at, %{}, nil, now],
+      ["blank", "paused", nil, %{"task" => "\n\t"}, nil, now],
+      ["valid", "active", next_fire_at, %{"task" => "Prepare the report."}, nil, now],
+      ["automation", "active", next_fire_at, %{}, 42, now]
+    ]
+
+    Enum.each(schedules, fn values ->
+      Repo.query!(
+        """
+        INSERT INTO actor_cron_schedules
+          (id, status, next_fire_at, payload, automation_job_id, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        """,
+        values
+      )
+    end)
+
+    events = [
+      ["missing-live", "missing", "scheduled", now],
+      ["blank-live", "blank", "firing", now],
+      ["valid-live", "valid", "scheduled", now],
+      ["automation-live", "automation", "scheduled", now],
+      ["missing-history", "missing", "fired", now]
+    ]
+
+    Enum.each(events, fn [id, schedule_id, status, updated_at] ->
+      Repo.query!(
+        """
+        INSERT INTO actor_scheduled_events
+          (id, cron_schedule_id, kind, status, last_fire_error, updated_at)
+        VALUES ($1, $2, 'cron_fire', $3, '{}'::jsonb, $4)
+        """,
+        [id, schedule_id, status, updated_at]
+      )
+    end)
+
+    Enum.each(@migration.up_sqls(), &Repo.query!/1)
+
+    assert [
+             ["automation", "active", false],
+             ["blank", "paused", true],
+             ["missing", "paused", true],
+             ["valid", "active", false]
+           ] =
+             Repo.query!("""
+             SELECT id, status, next_fire_at IS NULL
+             FROM actor_cron_schedules
+             ORDER BY id
+             """).rows
+
+    assert [
+             ["automation-live", "scheduled", false, nil],
+             ["blank-live", "cancelled", true, "cron_task_required"],
+             ["missing-history", "fired", false, nil],
+             ["missing-live", "cancelled", true, "cron_task_required"],
+             ["valid-live", "scheduled", false, nil]
+           ] =
+             Repo.query!("""
+             SELECT id, status, cancelled_at IS NOT NULL, last_fire_error->>'reason'
+             FROM actor_scheduled_events
+             ORDER BY id
+             """).rows
+  end
+end

--- a/app/control_plane/test/ankole/plugins/lark_cardkit_recovery_test.exs
+++ b/app/control_plane/test/ankole/plugins/lark_cardkit_recovery_test.exs
@@ -220,6 +220,134 @@ defmodule Ankole.Plugins.LarkAdapter.CardKitRecoveryTest do
     refute persisted.reply_preview_cleanup_at
   end
 
+  test "terminal recovery uses the durable outbox presentation instead of the stale checkpoint",
+       %{event: event} do
+    working = ReplyPresentation.new() |> ReplyPresentation.append_answer("正在理解请求")
+
+    terminal =
+      working
+      |> ReplyPresentation.terminal("failed", "AI 服务返回了错误，请重试。")
+
+    [page] = CardChain.pages(working)
+
+    checkpoint =
+      %{
+        "schema_version" => 1,
+        "adapter" => "lark",
+        "subject_uid" => event.agent_uid,
+        "conversation_id" => Ecto.UUID.generate(),
+        "presentation" => ReplyPresentation.checkpoint(working),
+        "refresh_pending" => true,
+        "refresh_reason" => "terminal_recovery"
+      }
+      |> CardChain.initialize(
+        CardChain.card_record(
+          0,
+          "card-terminal-recovery",
+          "card-terminal-recovery-uuid",
+          page,
+          "open",
+          ["state", "answer"]
+        )
+      )
+
+    assert {:ok, stored} = Actors.put_reply_preview_checkpoint(event.id, checkpoint)
+    parent = self()
+
+    request_fun = fn
+      _client, :post, path, opts
+      when path in ["im/v1/messages", "im/v1/messages/:message_id/reply"] ->
+        send(parent, {:terminal_reference_sent, opts})
+        {:ok, %{"data" => %{"message_id" => "message-terminal-recovery"}}}
+
+      _client, :patch, "im/v1/messages/:message_id", opts ->
+        send(parent, {:terminal_message_patched, opts})
+        {:ok, %{"data" => %{}}}
+    end
+
+    assert {:ok, result} =
+             CardKit.refresh(
+               %Request{
+                 actor_event: stored,
+                 presentation: terminal,
+                 previous_presentation: checkpoint["presentation"],
+                 checkpoint: checkpoint,
+                 mode: :terminal
+               },
+               client: :recording_client,
+               request_fun: request_fun
+             )
+
+    assert_receive {:terminal_reference_sent, _opts}
+    assert_receive {:terminal_message_patched, patch_opts}
+    card = Ankole.JSON.decode!(patch_opts[:body][:content])
+    answer = Enum.find(card["body"]["elements"], &(&1["element_id"] == "answer"))
+    assert answer["content"] == "AI 服务返回了错误，请重试。"
+    assert result.reply_preview_checkpoint["presentation"]["state"] == "failed"
+    assert result.reply_preview_checkpoint["streaming_state"] == "closed"
+  end
+
+  test "terminal recovery returns a non-retry fallback when the provider rejects a card reference",
+       %{event: event} do
+    working = ReplyPresentation.new() |> ReplyPresentation.append_answer("正在理解请求")
+    terminal = working |> ReplyPresentation.terminal("failed", "最终错误")
+    [page] = CardChain.pages(working)
+
+    checkpoint =
+      %{
+        "schema_version" => 1,
+        "adapter" => "lark",
+        "subject_uid" => event.agent_uid,
+        "conversation_id" => Ecto.UUID.generate(),
+        "presentation" => ReplyPresentation.checkpoint(working),
+        "refresh_pending" => true,
+        "refresh_reason" => "terminal_recovery"
+      }
+      |> CardChain.initialize(
+        CardChain.card_record(
+          0,
+          "card-terminal-binding-limit",
+          "card-terminal-binding-limit-uuid",
+          page,
+          "open",
+          ["state", "answer"]
+        )
+      )
+
+    assert {:ok, stored} = Actors.put_reply_preview_checkpoint(event.id, checkpoint)
+
+    request_fun = fn _client, :post, path, _opts
+                     when path in ["im/v1/messages", "im/v1/messages/:message_id/reply"] ->
+      {:error,
+       %Error{
+         code: 230_099,
+         msg:
+           "Failed to create card content; ErrCode: 200780; ErrMsg: card binding biz count over limit",
+         http_status: 400
+       }}
+    end
+
+    assert {:error,
+            {:cardkit_plain_text_fallback,
+             %{
+               "code" => 230_099,
+               "message" => message
+             }}} =
+             CardKit.refresh(
+               %Request{
+                 actor_event: stored,
+                 presentation: terminal,
+                 previous_presentation: checkpoint["presentation"],
+                 checkpoint: checkpoint,
+                 mode: :terminal
+               },
+               client: :recording_client,
+               request_fun: request_fun
+             )
+
+    assert message =~ "card binding biz count over limit"
+  end
+
   test "a refreshed answer over the page table budget completes the card chain", %{event: event} do
     answer =
       Enum.map_join(1..6, "\n\n", fn index ->

--- a/app/control_plane/test/ankole/schedule_test.exs
+++ b/app/control_plane/test/ankole/schedule_test.exs
@@ -1156,6 +1156,40 @@ defmodule Ankole.ScheduleTest do
                Schedule.update_cron_schedule(schedule.id, %{"payload" => %{"task" => "new task"}})
 
       assert updated.payload == %{"task" => "new task"}
+
+      assert {:ok, %{scheduled_event: manual_event}} =
+               Schedule.run_cron_schedule(schedule.id,
+                 now: @base_time,
+                 tool_call_id: "legacy-task-guard"
+               )
+
+      CronSchedule
+      |> where([cron_schedule], cron_schedule.id == ^schedule.id)
+      |> Repo.update_all(set: [payload: %{}])
+
+      assert {:error, :cron_task_required} =
+               Schedule.resume_cron_schedule(schedule.id, now: @base_time)
+
+      assert {:error, :cron_task_required} =
+               Schedule.run_cron_schedule(schedule.id,
+                 now: @base_time,
+                 tool_call_id: "legacy-task-guard-retry"
+               )
+
+      assert {:ok, %{status: :cancelled, scheduled_event: cancelled}} =
+               Schedule.fire_due_event(manual_event.id, now: @base_time)
+
+      assert cancelled.last_fire_error == %{"reason" => ":cron_task_required"}
+
+      assert {:ok, repaired} =
+               Schedule.update_cron_schedule(schedule.id, %{
+                 "payload" => %{"task" => "restored task"}
+               })
+
+      assert repaired.payload == %{"task" => "restored task"}
+
+      assert {:ok, %{status: "active"}} =
+               Schedule.resume_cron_schedule(schedule.id, now: @base_time)
     end
 
     test "payload and delivery changes end the execution conversation and terminal states end it too" do
@@ -2278,11 +2312,16 @@ defmodule Ankole.ScheduleTest do
                ActorRuntime.handle_turn_accepted(turn_accepted_payload(cron_turn_ref))
 
       # A second fire of the same schedule waits for the first turn.
+      manual_fire_at = DateTime.add(first_slot, 2, :second)
+
       assert {:ok, %{scheduled_event: manual_event}} =
-               Schedule.run_cron_schedule(schedule.id, idempotency_key: "manual-while-running")
+               Schedule.run_cron_schedule(schedule.id,
+                 idempotency_key: "manual-while-running",
+                 now: manual_fire_at
+               )
 
       assert {:ok, %{actor_event: manual_input}} =
-               Schedule.fire_due_event(manual_event.id, now: DateTime.add(first_slot, 2, :second))
+               Schedule.fire_due_event(manual_event.id, now: manual_fire_at)
 
       assert manual_input.session_id == execution_actor.session_id
 

--- a/app/control_plane/test/ankole_web/controllers/ai_gateway_controller_test.exs
+++ b/app/control_plane/test/ankole_web/controllers/ai_gateway_controller_test.exs
@@ -552,7 +552,7 @@ defmodule AnkoleWeb.AIGatewayControllerTest do
     refute Enum.any?(admin_models, &(&1["id"] == "kimi"))
   end
 
-  test "Codex models manifest includes the runtime slug and its responses-lite switch", %{
+  test "Codex models manifest keeps the runtime slug on standard Responses", %{
     conn: conn
   } do
     %{principal: agent} = agent_fixture()
@@ -589,7 +589,7 @@ defmodule AnkoleWeb.AIGatewayControllerTest do
     assert %{"models" => models} = json_response(conn, 200)
     assert runtime = Enum.find(models, &(&1["slug"] == "gpt-5.6-sol"))
     assert runtime["supports_search_tool"]
-    assert runtime["use_responses_lite"]
+    refute runtime["use_responses_lite"]
   end
 
   test "models endpoint includes non-LLM selectors by default", %{conn: conn} do

--- a/app/kernel/src/universal_ai_client/client/mod.rs
+++ b/app/kernel/src/universal_ai_client/client/mod.rs
@@ -9,4 +9,4 @@ pub use core::{
     start_stream,
 };
 pub(super) use core::{StreamCommand, run_model_request_once};
-pub(super) use stream::Delivery;
+pub(super) use stream::{Delivery, run_websocket_model_request_once};

--- a/app/kernel/src/universal_ai_client/client/stream.rs
+++ b/app/kernel/src/universal_ai_client/client/stream.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, VecDeque};
 use std::future::Future;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -524,6 +524,259 @@ async fn run_websocket_stream(
     }
 }
 
+pub(in crate::universal_ai_client) async fn run_websocket_model_request_once(
+    mut spec: StreamSpec,
+) -> Result<Value, StreamError> {
+    if spec.upstream.kind != UpstreamKind::WebSocketText {
+        return Err(StreamError::new(
+            "invalid_websocket_model_request",
+            "hosted_responses",
+            "hosted WebSocket model execution requires a websocket_text upstream",
+        ));
+    }
+
+    spec.hosted_tools = None;
+    let spec = request_builder::prepare_stream_spec(spec)?;
+    let (mut websocket, status, response_headers) = transport::open_websocket(&spec).await?;
+
+    if status != 101 {
+        return Err(StreamError::new(
+            "websocket_status_rejected",
+            "connect",
+            format!("upstream WebSocket returned status {status}"),
+        )
+        .provider_status(status)
+        .provider_headers(&response_headers));
+    }
+
+    let initial_messages = websocket_initial_messages(&spec);
+    for payload in &initial_messages {
+        if payload.len() > spec.limits.max_websocket_text_bytes {
+            return Err(StreamError::new(
+                "websocket_message_too_large",
+                "connect",
+                format!(
+                    "initial WebSocket text payload exceeded {} bytes",
+                    spec.limits.max_websocket_text_bytes
+                ),
+            )
+            .provider_status(413));
+        }
+
+        websocket
+            .send(Message::text(payload.clone()))
+            .await
+            .map_err(|reason| {
+                StreamError::new(
+                    "websocket_send_failed",
+                    "connect",
+                    format!("failed to send initial WebSocket payload: {reason}"),
+                )
+            })?;
+    }
+
+    let mut resolver =
+        api_resolver::APIResolver::new(spec.api_resolver, spec.response_context.clone());
+    let mut completed_items = BTreeMap::new();
+    let mut raw_body_bytes = 0usize;
+
+    loop {
+        match timeout(spec.upstream.timeout.idle_duration(), websocket.next()).await {
+            Ok(Some(Ok(Message::Text(text)))) => {
+                if text.len() > spec.limits.max_websocket_text_bytes {
+                    return Err(StreamError::new(
+                        "websocket_message_too_large",
+                        "wire",
+                        format!(
+                            "upstream WebSocket text payload exceeded {} bytes",
+                            spec.limits.max_websocket_text_bytes
+                        ),
+                    )
+                    .provider_status(413));
+                }
+
+                raw_body_bytes = raw_body_bytes.saturating_add(text.len());
+                if text == "[DONE]" {
+                    resolver.finish()?;
+                    return Err(missing_websocket_terminal_error());
+                }
+
+                let value = sonic_rs::from_str::<Value>(&text).map_err(|reason| {
+                    StreamError::new(
+                        "invalid_provider_event",
+                        "api_resolver",
+                        format!("WebSocket text payload was not valid JSON: {reason}"),
+                    )
+                })?;
+                let events = resolver.ingest(value)?;
+                remember_completed_items(&events, &mut completed_items);
+
+                if let Some(body) = collected_terminal_body(&events, &completed_items) {
+                    ensure_collected_body_size(&body, spec.limits.max_pending_bytes)?;
+                    return Ok(json!({
+                        "status": status,
+                        "headers": response_headers,
+                        "body": body,
+                        "raw_body_bytes": raw_body_bytes,
+                        "upstream_kind": spec.upstream.kind.as_str(),
+                        "websocket_initial_messages": initial_messages.len()
+                    }));
+                }
+            }
+            Ok(Some(Ok(Message::Close(Some(frame))))) if frame.code == CloseCode::Size => {
+                return Err(StreamError::new(
+                    "websocket_message_too_large",
+                    "wire",
+                    "upstream WebSocket closed because a message was too large",
+                )
+                .provider_status(413));
+            }
+            Ok(Some(Ok(Message::Close(_)))) | Ok(None) => {
+                resolver.finish()?;
+                return Err(missing_websocket_terminal_error());
+            }
+            Ok(Some(Ok(Message::Ping(_)))) | Ok(Some(Ok(Message::Pong(_)))) => {}
+            Ok(Some(Ok(Message::Binary(bytes)))) => {
+                return Err(StreamError::new(
+                    "unsupported_websocket_frame",
+                    "wire",
+                    format!(
+                        "upstream WebSocket binary frame is unsupported ({} bytes)",
+                        bytes.len()
+                    ),
+                ));
+            }
+            Ok(Some(Ok(Message::Frame(_)))) => {}
+            Ok(Some(Err(reason))) => return Err(websocket_read_error(reason)),
+            Err(_) => {
+                return Err(StreamError::new(
+                    "idle_timeout",
+                    "read",
+                    "upstream WebSocket idle timeout",
+                )
+                .retry_through_credential_pool());
+            }
+        }
+    }
+}
+
+fn remember_completed_items(events: &[Value], completed_items: &mut BTreeMap<usize, Value>) {
+    for event in events {
+        if event.get("type").and_then(Value::as_str) != Some("response.output_item.done") {
+            continue;
+        }
+        let Some(output_index) = event
+            .get("output_index")
+            .and_then(Value::as_u64)
+            .and_then(|value| usize::try_from(value).ok())
+        else {
+            continue;
+        };
+        let Some(item) = event.get("item").filter(|item| item.is_object()) else {
+            continue;
+        };
+        completed_items.insert(output_index, item.clone());
+    }
+}
+
+fn collected_terminal_body(
+    events: &[Value],
+    completed_items: &BTreeMap<usize, Value>,
+) -> Option<Value> {
+    events.iter().find_map(|event| {
+        let event_type = event.get("type").and_then(Value::as_str)?;
+        if !matches!(
+            event_type,
+            "response.completed" | "response.failed" | "response.incomplete"
+        ) {
+            return None;
+        }
+
+        let mut response = event
+            .get("response")
+            .filter(|value| value.is_object())?
+            .clone();
+        reconcile_terminal_items(&mut response, completed_items);
+        Some(response)
+    })
+}
+
+fn reconcile_terminal_items(response: &mut Value, completed_items: &BTreeMap<usize, Value>) {
+    let Some(response) = response.as_object_mut() else {
+        return;
+    };
+    let items = response
+        .entry("output".to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    let Some(items) = items.as_array_mut() else {
+        return;
+    };
+
+    for (output_index, item) in items.iter_mut().enumerate() {
+        let Some(recorded_item) = completed_items.get(&output_index) else {
+            continue;
+        };
+        if terminal_item_subset(item, recorded_item) {
+            *item = recorded_item.clone();
+        }
+    }
+
+    while let Some(recorded_item) = completed_items.get(&items.len()) {
+        items.push(recorded_item.clone());
+    }
+}
+
+fn terminal_item_subset(item: &Value, recorded_item: &Value) -> bool {
+    let (Some(item), Some(recorded_item)) = (item.as_object(), recorded_item.as_object()) else {
+        return false;
+    };
+    if item.get("id").and_then(Value::as_str).is_some() {
+        return false;
+    }
+    let Some(item_type) = item.get("type").and_then(Value::as_str) else {
+        return false;
+    };
+    if recorded_item.get("type").and_then(Value::as_str) != Some(item_type) {
+        return false;
+    }
+
+    let snapshot = item
+        .iter()
+        .filter(|(key, _value)| key.as_str() != "id")
+        .collect::<Vec<_>>();
+    !snapshot.is_empty()
+        && snapshot
+            .into_iter()
+            .all(|(key, value)| recorded_item.get(key) == Some(value))
+}
+
+fn ensure_collected_body_size(body: &Value, max_response_bytes: usize) -> Result<(), StreamError> {
+    let body_bytes = sonic_rs::to_vec(body).map_err(|reason| {
+        StreamError::new(
+            "response_encode_failed",
+            "hosted_responses",
+            format!("collected WebSocket response could not be encoded: {reason}"),
+        )
+    })?;
+    if body_bytes.len() <= max_response_bytes.max(1) {
+        Ok(())
+    } else {
+        Err(StreamError::new(
+            "response_body_too_large",
+            "hosted_responses",
+            "collected WebSocket response exceeded the configured response byte limit",
+        ))
+    }
+}
+
+fn missing_websocket_terminal_error() -> StreamError {
+    StreamError::new(
+        "upstream_stream_closed_before_terminal_event",
+        "api_resolver",
+        "upstream WebSocket closed before a terminal response event",
+    )
+}
+
 fn websocket_read_error(reason: WebSocketError) -> StreamError {
     match reason {
         WebSocketError::Capacity(CapacityError::MessageTooLong { size, max_size }) => {
@@ -929,6 +1182,71 @@ fn websocket_initial_messages(spec: &StreamSpec) -> Vec<String> {
         spec.upstream.body.clone().into_iter().collect()
     } else {
         spec.upstream.websocket_initial_messages.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_output_uses_completed_items_when_the_provider_omits_it() {
+        let completed_items = BTreeMap::from([
+            (
+                0,
+                json!({
+                    "id": "msg_complete",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "done"}]
+                }),
+            ),
+            (
+                1,
+                json!({
+                    "id": "fc_complete",
+                    "type": "function_call",
+                    "call_id": "call_complete",
+                    "name": "command",
+                    "arguments": "{}",
+                    "status": "completed"
+                }),
+            ),
+        ]);
+        let mut response = json!({"id": "resp_complete", "status": "completed", "output": []});
+
+        reconcile_terminal_items(&mut response, &completed_items);
+
+        assert_eq!(response["output"].as_array().unwrap().len(), 2);
+        assert_eq!(response["output"][0], completed_items[&0]);
+        assert_eq!(response["output"][1], completed_items[&1]);
+    }
+
+    #[test]
+    fn terminal_output_does_not_replace_a_conflicting_authoritative_item() {
+        let completed_items = BTreeMap::from([(
+            0,
+            json!({
+                "id": "msg_streamed",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "streamed"}]
+            }),
+        )]);
+        let terminal_item = json!({
+            "id": "msg_terminal",
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "terminal"}]
+        });
+        let mut response = json!({"output": [terminal_item.clone()]});
+
+        reconcile_terminal_items(&mut response, &completed_items);
+
+        assert_eq!(response["output"][0], terminal_item);
     }
 }
 

--- a/app/kernel/src/universal_ai_client/hosted_responses.rs
+++ b/app/kernel/src/universal_ai_client/hosted_responses.rs
@@ -15,7 +15,7 @@ use super::downstream::DownstreamEncoder;
 use super::error::{PROVIDER_BODY_EXCERPT_LIMIT, StreamError};
 use super::spec::{
     DownstreamKind, HostedImageGenerationSpec, HostedToolsSpec, ModelRequestSpec,
-    PreparedHTTPRequestSpec, RequestLimits, ResponseContext, StreamSpec,
+    PreparedHTTPRequestSpec, RequestLimits, ResponseContext, StreamSpec, UpstreamKind,
 };
 
 mod events;
@@ -176,7 +176,7 @@ pub(super) async fn run_hosted_model_request(
             "hosted image generation spec was missing",
         )
     })?;
-    let execution = execute_hosted_with_timeout(&spec, &hosted, None)
+    let execution = execute_hosted_with_timeout(&spec, None, &hosted, None)
         .await
         .map_err(redact_hosted_error)?;
     let mut wrapper = execution.wrapper;
@@ -269,9 +269,11 @@ pub(super) async fn run_hosted_stream(
         .map(|duration| TokioInstant::now() + duration);
     let mut streamed_output = StreamedHostedOutput::default();
     let mut progress_open = true;
+    let websocket_spec = (spec.upstream.kind == UpstreamKind::WebSocketText).then_some(&spec);
 
     let result = {
-        let execution = execute_hosted_with_timeout(&base_spec, &hosted, Some(progress_tx));
+        let execution =
+            execute_hosted_with_timeout(&base_spec, websocket_spec, &hosted, Some(progress_tx));
         tokio::pin!(execution);
 
         loop {
@@ -439,17 +441,18 @@ fn ensure_downstream_event_size(
 
 async fn execute_hosted_with_timeout(
     base_spec: &ModelRequestSpec,
+    websocket_spec: Option<&StreamSpec>,
     hosted: &HostedToolsSpec,
     progress: Option<mpsc::Sender<HostedProgress>>,
 ) -> Result<HostedExecution, StreamError> {
     match base_spec.upstream.timeout.total_duration() {
         Some(duration) => timeout(
             duration,
-            execute_hosted(base_spec, hosted, progress.as_ref()),
+            execute_hosted(base_spec, websocket_spec, hosted, progress.as_ref()),
         )
         .await
         .map_err(|_| hosted_total_timeout_error())?,
-        None => execute_hosted(base_spec, hosted, progress.as_ref()).await,
+        None => execute_hosted(base_spec, websocket_spec, hosted, progress.as_ref()).await,
     }
 }
 
@@ -568,6 +571,7 @@ async fn deliver_hosted_progress(
 
 async fn execute_hosted(
     base_spec: &ModelRequestSpec,
+    websocket_spec: Option<&StreamSpec>,
     hosted: &HostedToolsSpec,
     progress: Option<&mpsc::Sender<HostedProgress>>,
 ) -> Result<HostedExecution, StreamError> {
@@ -613,12 +617,22 @@ async fn execute_hosted(
     let (wrapper, final_body) = loop {
         main_model_rounds = main_model_rounds.saturating_add(1);
         send_hosted_progress(progress, HostedProgress::MainModelRound).await?;
-        let mut round_spec = base_spec.clone();
-        round_spec.hosted_tools = None;
-        round_spec.response_context.request = Value::Object(private_request.clone());
-        round_spec.response_context.stream = Some(false);
-
-        let wrapper = super::client::run_model_request_once(round_spec).await?;
+        let wrapper = match websocket_spec {
+            Some(websocket_spec) => {
+                let mut round_spec = websocket_spec.clone();
+                round_spec.hosted_tools = None;
+                round_spec.response_context.request = Value::Object(private_request.clone());
+                round_spec.response_context.stream = Some(true);
+                super::client::run_websocket_model_request_once(round_spec).await?
+            }
+            None => {
+                let mut round_spec = base_spec.clone();
+                round_spec.hosted_tools = None;
+                round_spec.response_context.request = Value::Object(private_request.clone());
+                round_spec.response_context.stream = Some(false);
+                super::client::run_model_request_once(round_spec).await?
+            }
+        };
         let body = wrapper.get("body").cloned().ok_or_else(|| {
             StreamError::new(
                 "invalid_main_model_response",
@@ -1995,6 +2009,7 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+    use tokio_tungstenite::tungstenite::{Message, accept};
 
     const HIDDEN_TOOL: &str = "__ankole_hosted_image_generation";
 
@@ -2074,11 +2089,197 @@ mod tests {
             public_request,
         };
 
-        let error = execute_hosted_with_timeout(&base_spec, &hosted, None)
+        let error = execute_hosted_with_timeout(&base_spec, None, &hosted, None)
             .await
             .unwrap_err();
 
         assert_eq!(error.code, "total_timeout");
+    }
+
+    #[test]
+    fn hosted_stream_keeps_websocket_main_round_and_restores_terminal_tool_identity() {
+        let main_listener = TCPListener::bind("127.0.0.1:0").unwrap();
+        let main_address = main_listener.local_addr().unwrap();
+        let (initial_tx, initial_rx) = mpsc::channel();
+
+        thread::spawn(move || {
+            let (stream, _) = main_listener.accept().unwrap();
+            let mut websocket = accept(stream).unwrap();
+            let Message::Text(initial) = websocket.read().unwrap() else {
+                panic!("hosted main model must send a response.create message");
+            };
+            initial_tx.send(initial.to_string()).unwrap();
+
+            websocket
+                .send(Message::Text(
+                    json!({
+                        "type": "response.output_item.done",
+                        "sequence_number": 0,
+                        "output_index": 0,
+                        "item": {
+                            "id": "fc_command_once",
+                            "type": "function_call",
+                            "call_id": "call_command_once",
+                            "name": "command",
+                            "arguments": "{\"command\":\"true\"}",
+                            "status": "completed"
+                        }
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .unwrap();
+            websocket
+                .send(Message::Text(
+                    json!({
+                        "type": "response.completed",
+                        "sequence_number": 1,
+                        "response": {
+                            "id": "resp_command_once",
+                            "status": "completed",
+                            "output": [{
+                                "type": "function_call",
+                                "call_id": "call_command_once",
+                                "name": "command",
+                                "arguments": "{\"command\":\"true\"}"
+                            }],
+                            "usage": {
+                                "input_tokens": 2,
+                                "output_tokens": 1,
+                                "total_tokens": 3
+                            }
+                        }
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .unwrap();
+        });
+
+        let public_request = json!({
+            "model": "main-model",
+            "input": "Run one command.",
+            "tools": [
+                {"type": "function", "name": "command", "parameters": {"type": "object"}},
+                {"type": "image_generation"}
+            ],
+            "tool_choice": {"type": "function", "name": "command"}
+        });
+        let spec = json!({
+            "api_resolver": "openai_responses",
+            "upstream": {
+                "kind": "websocket_text",
+                "method": "GET",
+                "url": format!("ws://{main_address}/v1/responses"),
+                "headers": [],
+                "timeout": {
+                    "connect_ms": 2_000,
+                    "first_byte_ms": 2_000,
+                    "idle_ms": 2_000,
+                    "total_ms": 5_000
+                },
+                "transport": {"http_versions": ["h1"], "compression": []}
+            },
+            "downstream": "sse",
+            "response_context": {
+                "model": "main-model",
+                "request": public_request,
+                "provider_options": {"service_tier": "fast"},
+                "stream": true
+            },
+            "limits": {
+                "max_sse_event_bytes": 1_048_576,
+                "max_websocket_text_bytes": 1_048_576,
+                "max_pending_chunks": 32,
+                "max_pending_bytes": 1_048_576
+            },
+            "hosted_tools": {
+                "public_request": public_request,
+                "image_generation": {
+                    "tool_config": {"type": "image_generation"},
+                    "selected_model": "openai/gpt-image-2",
+                    "prepared_request": {
+                        "api_resolver": "openrouter_images",
+                        "upstream": test_upstream("http://127.0.0.1:1/images"),
+                        "response_context": {
+                            "model": "openai/gpt-image-2",
+                            "request": {"n": 1}
+                        },
+                        "limits": {"max_response_bytes": 1_048_576}
+                    },
+                    "endpoint_capabilities": {},
+                    "provider_tag": "openai/gpt-image-2:openai",
+                    "provider_slug": "openai",
+                    "resolved_references": [],
+                    "limits": {}
+                }
+            }
+        });
+        let (event_tx, event_rx) = mpsc::channel();
+        let sink: EventSink = Arc::new(move |event| {
+            event_tx.send(event).unwrap();
+        });
+        let handle = super::super::start_stream(&spec.to_string(), sink).unwrap();
+
+        assert!(matches!(
+            event_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            super::super::StreamEvent::Ready(_)
+        ));
+        let initial: Value = sonic_rs::from_str(
+            &initial_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("hosted WebSocket must receive response.create"),
+        )
+        .unwrap();
+        assert_eq!(initial["type"], "response.create");
+        assert_eq!(initial["stream"], true);
+        assert_eq!(initial["service_tier"], "fast");
+        assert!(initial["tools"].as_array().unwrap().iter().any(|tool| {
+            tool["name"]
+                .as_str()
+                .is_some_and(|name| name.starts_with(HIDDEN_TOOL))
+        }));
+
+        handle.read(32).unwrap();
+        let mut events = Vec::new();
+        loop {
+            match event_rx.recv_timeout(Duration::from_secs(2)).unwrap() {
+                super::super::StreamEvent::Chunk {
+                    kind: super::super::DownstreamKind::SSE,
+                    bytes,
+                    ..
+                } => {
+                    if let Some(event) = parse_hosted_sse_chunk(&bytes) {
+                        events.push(event);
+                    }
+                }
+                super::super::StreamEvent::Done(summary) => {
+                    assert_eq!(summary["reason"], "hosted_completed");
+                    break;
+                }
+                event => panic!("expected hosted stream chunk or done, got {event:?}"),
+            }
+        }
+
+        let done_items = events
+            .iter()
+            .filter(|event| event["type"] == "response.output_item.done")
+            .collect::<Vec<_>>();
+        assert_eq!(done_items.len(), 1);
+        assert!(
+            done_items[0]["item"]["id"]
+                .as_str()
+                .is_some_and(|id| id.starts_with("fc_"))
+        );
+        assert_eq!(done_items[0]["item"]["call_id"], "call_command_once");
+        assert_eq!(done_items[0]["item"]["status"], "completed");
+
+        let terminal = events
+            .iter()
+            .find(|event| event["type"] == "response.completed")
+            .unwrap();
+        assert_eq!(terminal["response"]["output"].as_array().unwrap().len(), 1);
+        assert_eq!(terminal["response"]["output"][0], done_items[0]["item"]);
     }
 
     #[test]

--- a/app/webapps/auth/app.tsx
+++ b/app/webapps/auth/app.tsx
@@ -64,8 +64,7 @@ export function AuthApp() {
                 className="ak-login-provider"
                 key={provider.providerID}
                 type="button"
-                onClick={event => {
-                  event.currentTarget.disabled = true
+                onClick={() => {
                   window.location.assign(oidcAuthorizationPath(provider.providerID))
                 }}>
                 <span>

--- a/docs/design-docs/AIGateway.md
+++ b/docs/design-docs/AIGateway.md
@@ -5,6 +5,9 @@ provider rows and credentials, selects a model and one credential, prepares the
 request, and records Responses. It also owns provider retry and the end of one
 model request.
 
+Caller `metadata` is local Response state. Generic OpenAI-compatible providers
+do not receive it because support for that OpenAI field is not portable.
+
 AIGateway does not run the Agent model loop and does not complete Actor work.
 Agent Computer runs the loop. SignalsGateway completes the ActorEvent and sends
 the final reply to the external platform.
@@ -92,11 +95,13 @@ the `ankole_aigateway` Codex provider. It sends the frozen binding in the
 `x-ankole-aigateway-model-binding` header. AIGateway applies this binding before
 provider resolution. The binding replaces a conflicting Codex model, provider
 option, reasoning effort, or parallel-tool-call choice. Responses Lite stays
-serial. Thus Codex receives the real model and effort that it needs for local
-execution, but AIGateway remains the authority for the upstream request. The
-runner removes `model_catalog_json` from the Job project configuration, so a
-workspace template cannot replace the AIGateway-owned model cards. The
-logical profile name never enters Codex as a model.
+serial. AIGateway model cards disable Responses Lite because Codex 0.147 omits
+configured hosted web search from that private carrier. Standard Responses
+keeps the native tool declaration. Thus Codex receives the real model and effort
+that it needs for local execution, but AIGateway remains the authority for the
+upstream request. The runner removes `model_catalog_json` from the Job project
+configuration, so a workspace template cannot replace the AIGateway-owned
+model cards. The logical profile name never enters Codex as a model.
 
 The AIGateway model card owns one model-visible tool-output limit of 10,000
 tokens. `max_output_tokens` is a requested upper limit. A smaller value reduces
@@ -783,6 +788,9 @@ AIGateway never adds an image tool that the caller did not declare.
 
 The hosted tool can run for 30 minutes.
 The prepared streaming limits allow 128 MiB for the generated upstream response.
+If the main provider uses a Responses WebSocket, each hosted fallback model
+round uses that WebSocket transport. Other streaming providers use one
+collected non-streaming main-model request for each round.
 Image persistence observes normalized image events from both execution paths.
 It stores the final image and accounts for native image usage. A hosted image
 attempt rotates only the image provider pool, while a main model attempt

--- a/docs/design-docs/BackgroundAgentJob.md
+++ b/docs/design-docs/BackgroundAgentJob.md
@@ -37,6 +37,10 @@ the stored Turn kind. The error projection keeps only `code`, `summary`,
 `retryable`, and `codex_turn_status`. It replaces UUID-shaped tokens in system
 failure diagnostics with `[internal-id]`. It does not rewrite successful results
 or assistant content.
+Aggregate progress keeps `tool_execution_mechanisms` for calls whose execution
+boundary is meaningful. Each entry contains the tool name, `provider_hosted` or
+`local_dynamic`, and the call count. This compact fact survives trajectory
+pagination, so the parent Agent does not infer the mechanism from tool prose.
 `recent_trajectory` is an `ankole_chatml` trajectory built from the latest three
 stored semantic trajectory groups on the Job root thread. It does not filter
 these groups by the stored Turn kind. It removes stored message IDs, maps
@@ -317,14 +321,24 @@ The runner sets these environment values:
 
 ```text
 HOME=/agents/<agent-key>
-CODEX_HOME=/agents/<agent-key>/.codex
+CODEX_HOME=/var/lib/ankole/codex/<agent-key>/.codex
 ```
 
-Each Agent owns one active Codex app-server process through
+The Agent Home is shared durable storage. The Codex Home is a rebuildable
+Worker-local shard because SQLite WAL cannot use the shared network filesystem.
+The Bubblewrap runtime mounts both paths and keeps the Codex Home writable.
+Before the first local app-server start after this migration, the Worker makes
+one non-blocking attempt to lock the former shared Codex Home. If no old runtime
+holds its lock, the Worker removes only its obsolete `config.toml`; otherwise it
+leaves all legacy state unchanged and retries at the next cold start. This stops
+Codex from treating the old runtime config as project configuration while a
+rolling deployment can still finish work on the old runtime.
+
+Each `(Agent, Worker)` pair owns one active Codex app-server process through
 `AgentCodexRuntime`. Each Background Agent Job owns one root thread in that
 process. A parent-scoped `subAgentActivity` assigns each child thread to the
-owning Job. Different Agents use different Codex Homes and different app-server
-processes.
+owning Job. Different Workers use different Codex Homes and app-server
+processes, including when they run Jobs for the same Agent.
 
 When a Job tree is removed, the runtime keeps retired child thread IDs until the
 app-server exits. If Codex reports a late child whose parent is retired, the
@@ -422,8 +436,13 @@ directly to AIGateway. A Job does not query or cache a separate web-tool catalog
 Codex built-in `web_search` follows the Job's frozen hosted-tool projection.
 When the Job's provider connection declares hosted `web_search`, the project
 config sets `web_search = "live"` and the provider executes that search inside
-the model request. Every other Job keeps `web_search = "disabled"`. The
-workspace template never decides this value.
+the model request. Agent Computer omits its dynamic `web_search` in this case,
+so the model cannot silently select the local path instead. Every other Job
+keeps `web_search = "disabled"` and receives the dynamic tool. The workspace
+template never decides this value. The dynamic `web_fetch` remains available
+in both cases. AIGateway model cards disable Responses Lite because the pinned
+Codex omits configured hosted search from that private carrier. Standard
+Responses sends the native `web_search` declaration.
 
 For AIGateway, the Agent Codex Home selects the `ankole_aigateway` provider.
 The Job configuration contains the real Codex model name and its supported
@@ -443,12 +462,12 @@ the same provider type and model ID, then persists that completed binding. If
 that identity cannot be proved, the legacy Job remains text-only; it never
 borrows visual capability from a different model.
 
-Worker placement selects the normal owner, and the per-Agent `flock` on the
-shared Codex Home is the final cross-process exclusion boundary. An app-server
-holds that lock until it exits. A second Worker that cannot acquire it reports a
-retryable busy result instead of starting another process. Production storage
-must provide reliable cross-host `flock`; deployment acceptance must verify
-that property with two Worker Pods.
+Worker placement selects the normal owner. The per-Agent `flock` on each
+Worker-local Codex Home is the final same-Worker exclusion boundary. An
+app-server holds that lock until it exits. A second process that cannot acquire
+it reports a retryable busy result instead of starting another app-server for
+that `(Agent, Worker)` pair. PostgreSQL placement and the Worker-local shard let
+different Workers run Jobs for the same Agent without sharing SQLite state.
 
 ## Compose the Project AGENTS.md
 
@@ -712,6 +731,12 @@ terminal trajectory with a `running` Job and no newer lead Turn is not ready;
 this rule covers the short interval between trajectory storage and Job-state
 commit. A completed, stopped, or dead-letter command that never appears in a
 trajectory returns a delivery error.
+
+If a succeeded commit finds open steer events, the same transaction creates
+one successor with those messages in order and then completes the events. If
+the successor cannot be stored, the transaction fails and leaves the source
+Job and steer events unchanged. A failed, stopped, or external completion
+answers open steers with the terminal notification instead.
 
 Background Codex gives child agents `request_parent_input`, not
 `request_user_input`. A child sends its question to the lead agent.

--- a/docs/design-docs/plugins/FeishuAdapter.md
+++ b/docs/design-docs/plugins/FeishuAdapter.md
@@ -208,6 +208,11 @@ Authentication and permission errors require operator action. A recovery
 refresh that fails with a not-retryable error records a blocked
 `recovery_state` on the checkpoint and stops; an operator update to the
 binding requeues blocked previews together with blocked outbox replies.
+Terminal recovery renders the terminal presentation from the durable outbox,
+even when the last confirmed CardKit checkpoint still contains a working
+presentation. If CardKit requires a plain-text fallback during that refresh,
+the preview records a non-retry fallback and stops; the outbox remains the sole
+owner of provider-visible terminal delivery.
 
 Preview updates can disappear. The final assistant reply remains in the outbox.
 SignalsGateway records that reply only after the provider confirms it.

--- a/plugins/lark_adapter/lib/ankole/plugins/lark_adapter/cardkit.ex
+++ b/plugins/lark_adapter/lib/ankole/plugins/lark_adapter/cardkit.ex
@@ -710,7 +710,11 @@ defmodule Ankole.Plugins.LarkAdapter.CardKit do
         rebuild_latest_active_message(event, request)
 
       :plain_text_fallback ->
-        plain_text_fallback(event, request)
+        if match?(%OutboxEntry{}, request.outbox) do
+          plain_text_fallback(event, request)
+        else
+          {:error, {:cardkit_plain_text_fallback, ErrorPolicy.provider_error(error)}}
+        end
 
       :operator_action_required ->
         {:error, {:reply_delivery, :operator_action_required, ErrorPolicy.provider_error(error)}}
@@ -1376,7 +1380,15 @@ defmodule Ankole.Plugins.LarkAdapter.CardKit do
   end
 
   defp refresh_request(request, event, checkpoint) do
-    presentation = ReplyPresentation.normalize(checkpoint["presentation"] || request.presentation)
+    requested_presentation = ReplyPresentation.normalize(request.presentation)
+
+    presentation =
+      if checkpoint["refresh_reason"] == "terminal_recovery" and
+           ReplyPresentation.terminal_state?(requested_presentation) do
+        requested_presentation
+      else
+        ReplyPresentation.normalize(checkpoint["presentation"] || request.presentation)
+      end
 
     %{
       request
@@ -1983,8 +1995,9 @@ defmodule Ankole.Plugins.LarkAdapter.CardKit do
     end
   end
 
-  defp plain_text_fallback(_event, _request),
-    do: {:error, :cardkit_plain_text_fallback_requires_outbox}
+  defp plain_text_fallback(_event, _request) do
+    {:error, {:cardkit_plain_text_fallback, %{"reason" => "outbox_required"}}}
+  end
 
   defp undelivered_plain_text(%ActorEvent{id: actor_event_id}, operation, text) do
     checkpoint =


### PR DESCRIPTION
## Summary

- Keep provider-hosted web search on standard Responses without a competing local tool, persist its execution mechanism, preserve frozen provider options across continuations, and keep configured WebSockets through hosted image fallback.
- Reconcile streamed and terminal Responses output so one tool call keeps one identity and executes once, including OpenAI-compatible WebSocket terminals that omit earlier output items.
- Isolate Codex state in Worker-local shards, retire legacy shared config only while safely locked, keep app-server infrastructure failures retryable, redact startup diagnostics, and keep terminal Job commits atomic with steer successors.
- Remove obsolete BackgroundAgentJob plugin state, pause invalid legacy direct cron schedules, preserve schedule history, and repair OIDC browser-back and Feishu CardKit recovery behavior.

## Real-path acceptance

- Real Feishu and real LLM background jobs recorded hosted web search as `execution_mechanism=provider_hosted`.
- A controlled real Feishu and real LLM Responses WebSocket run sent `service_tier=fast` on both rounds, executed the counter tool exactly once, and delivered exactly one final reply.
- A real BackgroundAgentJob completed through the production Codex adapter after Worker-local state and legacy-config retirement changes.

## Validation

- Control Plane: `MIX_ENV=test mix test` — 2063 passed, 9 excluded, 0 failed.
- Control Plane: warnings-as-errors compile, formatting, and 188 related targeted tests passed.
- AgentComputer: 555 unit tests passed; 24 integration tests passed, with 5 explicitly tagged browser-sandbox tests skipped; type-check and format checks passed.
- Rust universal AI client: 211 tests passed, 1 ignored, 0 failed; doc tests passed.
- Web app: 141 tests passed; type-check and production build passed. The build retained only the existing chunk-size advisory.
- `git diff --check` passed.

## Migration notes

- `20260812141549_remove_background_agent_job_agent_plugin_ids` removes the obsolete per-Job plugin-selection column.
- `20260812145614_pause_invalid_direct_cron_schedules` pauses active direct-Agent cron schedules without a complete task and cancels their pending fires. Operators must add a task before those schedules can resume or run manually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background job details now show whether tools ran through hosted or local execution, including call counts.
  * Provider-specific model options are preserved across requests.
  * Hosted web search uses the provider’s native search without creating duplicate local tools.
  * Scheduled-task updates clarify conversation and run-history behavior.
* **Bug Fixes**
  * Improved cron validation prevents invalid schedules from running.
  * Fixed provider sign-in navigation and WebSocket request handling.
  * Improved terminal message recovery with safer plain-text fallbacks.
* **Reliability**
  * Improved runtime isolation, error reporting, and retry handling for background jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->