### PR TITLE
Keep background job board within viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.71.1 (2026-08-14)
+
+- Keep the Background Agent Job board within the desktop viewport with independently scrolling columns. Its five health cards now keep their space while loading, show request failures, and use one wide-screen row. Assistive technology can identify each Job column and the health loading state.
+
 ## Version 0.71.0 (2026-08-14)
 
 - Re-enable a disabled model provider without rebuilding its credential pool. Re-enabling validates the stored configuration and retries credentials that failed before disablement, while enabling an active provider preserves current health. Credential replacement and disabled-provider re-enable use new internal health revisions, so a late response from an earlier secret cannot mark the current credential dead or rate-limited. Metadata changes and automatic OAuth token refresh preserve current health. Encrypted settings are limited to credential scope, and the endpoint uses the existing provider update permission.

--- a/app/webapps/console/pages/background-agent-jobs.tsx
+++ b/app/webapps/console/pages/background-agent-jobs.tsx
@@ -173,7 +173,10 @@ function BackgroundAgentJobsForScope({ scope }: { scope: AgentScope }) {
         <AgentFilter scope={{ ...scope, selectAgent }} />
       </ScopeBar>
 
-      {health.data ? <JobHealthStrip health={health.data} /> : null}
+      <div className="grid gap-3">
+        {health.data ? <JobHealthStrip health={health.data} /> : health.error ? null : <JobHealthStripSkeleton />}
+        {health.error ? <ErrorBlock error={health.error} /> : null}
+      </div>
 
       {list.error ? (
         <ErrorBlock error={list.error} />
@@ -203,12 +206,19 @@ function BackgroundAgentJobsForScope({ scope }: { scope: AgentScope }) {
       ) : (
         <div className="grid grid-cols-1 min-w-0 gap-4 xl:grid-cols-3">
           {columns.map(column => (
-            <section key={column.key} className="min-h-72 border border-border bg-muted/25">
+            <section
+              key={column.key}
+              className="min-h-72 border border-border bg-muted/25 xl:grid xl:max-h-[65dvh] xl:grid-rows-[auto_minmax(0,1fr)]">
               <header className="flex items-center justify-between border-b border-border bg-card px-4 py-3">
-                <h3 className="font-medium">{t(`console.background_agent_jobs.column_${column.key}`)}</h3>
+                <h3 id={`background-agent-jobs-column-${column.key}`} className="font-medium">
+                  {t(`console.background_agent_jobs.column_${column.key}`)}
+                </h3>
                 <Badge variant="secondary">{grouped[column.key].length}</Badge>
               </header>
-              <div className="grid gap-3 p-3">
+              <div
+                className="grid min-h-0 content-start gap-3 p-3 xl:overflow-y-auto"
+                role="region"
+                aria-labelledby={`background-agent-jobs-column-${column.key}`}>
                 {list.isLoading ? (
                   <>
                     <Skeleton className="h-36 w-full" />
@@ -381,12 +391,6 @@ export function backgroundAgentJobScopeParams(current: URLSearchParams, agentUID
   return next
 }
 
-/**
- * The four reliability signals from the 2026-08-12 incident review: queue
- * starvation, infrastructure churn against charged failures, terminal-steer
- * conversion, and delivery degradation. Ratios render beside their raw counts
- * so an empty denominator reads as "no data" instead of a fake 0%.
- */
 function JobHealthStrip({ health }: { health: BackgroundAgentJobHealthResponse }) {
   const { t } = useTranslation()
   const ratio = (numerator: number, denominator: number) =>
@@ -446,7 +450,7 @@ function JobHealthStrip({ health }: { health: BackgroundAgentJobHealthResponse }
   ]
 
   return (
-    <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
       {cells.map(cell => (
         <div key={cell.key} className="border border-border bg-card px-4 py-3">
           <p className="text-xs text-muted-foreground">{t(`console.background_agent_jobs.health_${cell.key}`)}</p>
@@ -454,6 +458,25 @@ function JobHealthStrip({ health }: { health: BackgroundAgentJobHealthResponse }
           <p className="mt-1 text-xs text-muted-foreground">{cell.hint}</p>
         </div>
       ))}
+    </div>
+  )
+}
+
+function JobHealthStripSkeleton() {
+  const { t } = useTranslation()
+
+  return (
+    <div role="status">
+      <span className="sr-only">{t('common.loading')}</span>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5" aria-hidden>
+        {Array.from({ length: 5 }, (_, index) => (
+          <div key={index} className="border border-border bg-card px-4 py-3">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="mt-2 h-7 w-16" />
+            <Skeleton className="mt-2 h-3 w-36 max-w-full" />
+          </div>
+        ))}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## What changed

- Bound each desktop Background Agent Job column to the available viewport and let long columns scroll independently.
- Keep all jobs in the loaded result instead of truncating the finished column.
- Keep five health-card placeholders visible during the initial request, show health request failures, and use a responsive five-card layout.
- Give each Job column an accessible name and announce the health loading state.

## Why

A large finished-job history made the whole page excessively tall. The fifth health card also appeared only after its request completed, so the top of the page shifted and request failures were silent.

## Validation

- `bun run --filter @ankole/webapps test` — 172 passed
- `bun run --filter @ankole/webapps type-check`
- `bun run --filter @ankole/webapps fmt:check`
- `bun run --filter @ankole/webapps build`
- `git diff --check origin/main --`
- Browser simulation with 8 queued, 6 active, and 34 finished jobs confirmed independent `overflow-y: auto` columns. The three content heights were 1,244 px, 1,056 px, and 4,344 px inside 464 px viewports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background Agent Job boards now stay within the viewport with independently scrollable columns.
  * Added responsive layouts for health cards, including wider-screen five-column displays.
  * Added loading placeholders that preserve layout while health information loads.
* **Bug Fixes**
  * Added clear error states when health information cannot be retrieved.
* **Accessibility**
  * Added descriptive labels for job-board columns and health loading regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->