### PR TITLE
Allow Skill-backed HTTP MCP servers to pin protocol versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 0.71.2 (2026-08-14)
+
+- Let Skill-backed HTTP MCP declarations pin protocol negotiation, so modern
+  POST-only servers do not fall back to the legacy SSE receive channel.
+
 ## Version 0.71.1 (2026-08-14)
 
 - Keep the Background Agent Job board within the desktop viewport with independently scrolling columns. Its five health cards now keep their space while loading, show request failures, and use one wide-screen row. Assistive technology can identify each Job column and the health loading state.

--- a/app/agent_computer/src/tools/mcp/config.ts
+++ b/app/agent_computer/src/tools/mcp/config.ts
@@ -29,6 +29,7 @@ const ServerName = z
 const Description = z.string().trim().min(1).max(1024)
 const EnvironmentVariableName = z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/)
 const ToolFilter = z.array(z.string().min(1).max(1024)).max(MAX_FILTERED_TOOLS_PER_SERVER)
+const MCPProtocolVersion = z.enum(['auto', 'legacy', '2026-07-28'])
 const HTTPURL = z
   .string()
   .url()
@@ -42,6 +43,7 @@ const StreamableHTTPDependency = z
     transport: z.literal('streamable_http'),
     url: HTTPURL,
     command: z.never().optional(),
+    protocol_version: MCPProtocolVersion.optional(),
     bearer_token_env_var: EnvironmentVariableName.optional(),
     enabled_tools: ToolFilter.optional(),
     disabled_tools: ToolFilter.optional()
@@ -87,6 +89,7 @@ interface MCPServerBase {
 export interface StreamableHTTPMCPServer extends MCPServerBase {
   transport: 'streamable_http'
   url: string
+  protocolVersion?: z.infer<typeof MCPProtocolVersion>
   bearerTokenEnvVar?: string
 }
 
@@ -205,6 +208,7 @@ function serverConfigFromDependency(skillName: string, dependency: ParsedMCPDepe
       ...(dependency.description ? { description: dependency.description } : {}),
       transport: dependency.transport,
       url: dependency.url,
+      ...(dependency.protocol_version ? { protocolVersion: dependency.protocol_version } : {}),
       ...(dependency.bearer_token_env_var ? { bearerTokenEnvVar: dependency.bearer_token_env_var } : {}),
       ...(dependency.enabled_tools ? { enabledTools: dependency.enabled_tools } : {}),
       ...(dependency.disabled_tools ? { disabledTools: dependency.disabled_tools } : {}),
@@ -232,6 +236,7 @@ function serverConnectionIdentity(server: MCPServerConfig): string {
           description: server.description ?? null,
           transport: server.transport,
           url: server.url,
+          protocolVersion: server.protocolVersion ?? null,
           bearerTokenEnvVar: server.bearerTokenEnvVar ?? null,
           enabledTools: normalizedToolFilter(server.enabledTools),
           disabledTools: normalizedToolFilter(server.disabledTools)

--- a/app/agent_computer/src/tools/mcp/mcporter-config.ts
+++ b/app/agent_computer/src/tools/mcp/mcporter-config.ts
@@ -16,6 +16,7 @@ export type MaterializedMCPorterConfig = {
 type MCPorterServer = {
   description?: string
   baseUrl?: string
+  protocolVersion?: 'auto' | 'legacy' | '2026-07-28'
   bearerToken?: string
   command?: string
   args?: string[]
@@ -41,6 +42,7 @@ export function renderMCPorterConfig(servers: readonly MCPorterConfiguredServer[
         ? {
             ...(server.description ? { description: server.description } : {}),
             baseUrl: server.url,
+            ...(server.protocolVersion ? { protocolVersion: server.protocolVersion } : {}),
             ...(server.bearerTokenEnvVar ? { bearerToken: `\${${server.bearerTokenEnvVar}}` } : {}),
             ...filters
           }

--- a/app/agent_computer/test/mcporter-config.test.ts
+++ b/app/agent_computer/test/mcporter-config.test.ts
@@ -35,6 +35,7 @@ describe('@ankole/agent-computer Skill MCPorter config', () => {
         sourceSkills: ['remote-skill'],
         transport: 'streamable_http',
         url: 'https://mcp.example.test/rpc',
+        protocolVersion: '2026-07-28',
         bearerTokenEnvVar: 'REMOTE_MCP_TOKEN',
         enabledTools: ['quote', 'news', 'quote'],
         disabledTools: ['news']
@@ -53,6 +54,7 @@ describe('@ankole/agent-computer Skill MCPorter config', () => {
           'a-remote': {
             description: 'Remote data',
             baseUrl: 'https://mcp.example.test/rpc',
+            protocolVersion: '2026-07-28',
             bearerToken: '${REMOTE_MCP_TOKEN}',
             allowedTools: ['quote']
           },
@@ -92,7 +94,11 @@ describe('@ankole/agent-computer Skill MCPorter config', () => {
     const root = temporaryRoot('ankole-mcporter-skills-')
     const builtinSkillsRoot = join(root, 'builtin')
     const agentInstalledSkillsRoot = join(root, 'installed')
-    writeSkill(builtinSkillsRoot, 'background-data', 'shared-data', 'https://mcp.example.test/rpc')
+    writeMetadata(
+      builtinSkillsRoot,
+      'background-data',
+      'dependencies:\n  tools:\n    - type: mcp\n      value: shared-data\n      transport: streamable_http\n      url: https://mcp.example.test/rpc\n      protocol_version: 2026-07-28\n'
+    )
     writeSkill(agentInstalledSkillsRoot, 'installed-data', 'installed-data', 'https://installed.example.test/rpc')
 
     const backgroundSkill = create(RuntimeSkillSummarySchema, {
@@ -117,7 +123,7 @@ describe('@ankole/agent-computer Skill MCPorter config', () => {
     ).toEqual([expect.objectContaining({ name: 'installed-data', sourceSkills: ['installed-data'] })])
     expect(await loadEnabledSkillMCPServers({ enabledSkills: [backgroundSkill, installedSkill], skillRoots })).toEqual([
       expect.objectContaining({ name: 'installed-data' }),
-      expect.objectContaining({ name: 'shared-data' })
+      expect.objectContaining({ name: 'shared-data', protocolVersion: '2026-07-28' })
     ])
   })
 
@@ -200,6 +206,24 @@ describe('@ankole/agent-computer Skill MCPorter config', () => {
         skillRoots
       })
     ).rejects.toThrow('invalid MCP dependency for Skill obsolete-timeout')
+
+    writeMetadata(
+      builtinSkillsRoot,
+      'unknown-protocol',
+      'dependencies:\n  tools:\n    - type: mcp\n      value: modern\n      transport: streamable_http\n      url: https://modern.example.test/rpc\n      protocol_version: 2027-01-01\n'
+    )
+    await expect(
+      loadEnabledSkillMCPServers({
+        enabledSkills: [
+          create(RuntimeSkillSummarySchema, {
+            skillName: 'unknown-protocol',
+            sourceKind: 'builtin',
+            relativePath: 'unknown-protocol'
+          })
+        ],
+        skillRoots
+      })
+    ).rejects.toThrow('invalid MCP dependency for Skill unknown-protocol')
   })
 
   it('resolves internal Skills and rejects metadata symlinks outside the Skill root', async () => {

--- a/app/website/src/content/docs/mcp/en-US.md
+++ b/app/website/src/content/docs/mcp/en-US.md
@@ -21,6 +21,7 @@ dependencies:
       description: "Lookup service"
       transport: streamable_http
       url: https://mcp.example.com/mcp
+      protocol_version: 2026-07-28
       bearer_token_env_var: MCP_HTTP_TOKEN
       enabled_tools:
         - lookup
@@ -40,11 +41,12 @@ One Skill can declare at most 64 dependencies. The schema is strict and rejects 
 | Field | Meaning |
 | --- | --- |
 | `url` | HTTP or HTTPS server URL |
+| `protocol_version` | Optional protocol mode: `auto`, `legacy`, or `2026-07-28`; the default is `auto` |
 | `bearer_token_env_var` | Environment variable name that contains the bearer token |
 | `enabled_tools` | Optional exact raw-name allowlist |
 | `disabled_tools` | Optional exact raw-name denylist |
 
-Store the token in [Environment variables](../worker-env/). Put only its variable name in the Skill.
+Pin `protocol_version` only when the server requires one protocol era. Store the token in [Environment variables](../worker-env/). Put only its variable name in the Skill.
 
 ### `stdio`
 

--- a/app/website/src/content/docs/mcp/ja-JP.md
+++ b/app/website/src/content/docs/mcp/ja-JP.md
@@ -21,6 +21,7 @@ dependencies:
       description: "Lookup service"
       transport: streamable_http
       url: https://mcp.example.com/mcp
+      protocol_version: 2026-07-28
       bearer_token_env_var: MCP_HTTP_TOKEN
       enabled_tools:
         - lookup
@@ -40,11 +41,12 @@ dependencies:
 | フィールド | 意味 |
 | --- | --- |
 | `url` | HTTP または HTTPS の server URL |
+| `protocol_version` | 任意のプロトコルモード: `auto`、`legacy`、または `2026-07-28`。デフォルトは `auto` |
 | `bearer_token_env_var` | bearer token を保持する環境変数の名前 |
 | `enabled_tools` | 任意。正確な raw 名の allowlist |
 | `disabled_tools` | 任意。正確な raw 名の denylist |
 
-token は [環境変数](../worker-env/) に保存してください。Skill には変数名だけを置きます。
+server が特定のプロトコル世代を必要とする場合にだけ `protocol_version` を固定してください。token は [環境変数](../worker-env/) に保存してください。Skill には変数名だけを置きます。
 
 ### `stdio`
 

--- a/app/website/src/content/docs/mcp/ko-KR.md
+++ b/app/website/src/content/docs/mcp/ko-KR.md
@@ -21,6 +21,7 @@ dependencies:
       description: "Lookup service"
       transport: streamable_http
       url: https://mcp.example.com/mcp
+      protocol_version: 2026-07-28
       bearer_token_env_var: MCP_HTTP_TOKEN
       enabled_tools:
         - lookup
@@ -40,11 +41,12 @@ dependencies:
 | 필드 | 의미 |
 | --- | --- |
 | `url` | HTTP 또는 HTTPS 서버 URL |
+| `protocol_version` | 선택적 프로토콜 모드: `auto`, `legacy`, `2026-07-28`; 기본값은 `auto` |
 | `bearer_token_env_var` | bearer token을 담고 있는 environment variable 이름 |
 | `enabled_tools` | 선택적, 정확한 raw-name allowlist |
 | `disabled_tools` | 선택적, 정확한 raw-name denylist |
 
-token은 [Environment variables](../worker-env/)에 저장하십시오. Skill에는 변수 이름만 넣으십시오.
+서버가 특정 프로토콜 세대를 요구할 때만 `protocol_version`을 고정하십시오. token은 [Environment variables](../worker-env/)에 저장하십시오. Skill에는 변수 이름만 넣으십시오.
 
 ### `stdio`
 

--- a/app/website/src/content/docs/mcp/zh-Hans-CN.md
+++ b/app/website/src/content/docs/mcp/zh-Hans-CN.md
@@ -21,6 +21,7 @@ dependencies:
       description: "查询服务"
       transport: streamable_http
       url: https://mcp.example.com/mcp
+      protocol_version: 2026-07-28
       bearer_token_env_var: MCP_HTTP_TOKEN
       enabled_tools:
         - lookup
@@ -40,11 +41,12 @@ dependencies:
 | 字段 | 含义 |
 | --- | --- |
 | `url` | HTTP 或 HTTPS server URL |
+| `protocol_version` | 可选协议模式：`auto`、`legacy` 或 `2026-07-28`；默认值是 `auto` |
 | `bearer_token_env_var` | 保存 bearer token 的环境变量名称 |
 | `enabled_tools` | 可选的原始工具名 allowlist |
 | `disabled_tools` | 可选的原始工具名 denylist |
 
-token 值放在 Console 的 [环境变量](../worker-env/) 中。Skill 只保存变量名。
+只有 server 要求特定协议代际时才固定 `protocol_version`。token 值放在 Console 的 [环境变量](../worker-env/) 中。Skill 只保存变量名。
 
 ### `stdio`
 

--- a/docs/design-docs/BullXSkillMcporterProposal.zh-Hans.md
+++ b/docs/design-docs/BullXSkillMcporterProposal.zh-Hans.md
@@ -1,6 +1,6 @@
 # BullX Financial Data 的 Skill-first MCP 执行方案
 
-状态：**已实现；mcporter 0.13.0 已验证，真实 BullX 路径被 legacy transport 互操作问题阻塞；不是规范性合同**
+状态：**已实现；mcporter 0.13.0 已通过 `2026-07-28` 协议连接真实 BullX；不是规范性合同**
 日期：2026-08-04
 
 范围说明：本文只决定 BullX Financial Data 的 Skill-first 路径。现行平台合同见
@@ -234,7 +234,8 @@ BullX 的生成结果等价于：
     "bullx-financial-data": {
       "description": "BullX Financial Data MCP server",
       "baseUrl": "https://ai-terminal.yuma.host/api/v1/financial-data/mcp",
-      "bearerToken": "${BULLX_FINANCIAL_DATA_MCP_API_KEY}"
+      "bearerToken": "${BULLX_FINANCIAL_DATA_MCP_API_KEY}",
+      "protocolVersion": "2026-07-28"
     }
   }
 }
@@ -246,8 +247,8 @@ BullX 的生成结果等价于：
   配置。
 - 必须设置 `MCPORTER_CONFIG`，禁止依赖 cwd 或 `~/.mcporter/mcporter.json` 的偶然内容。
 - 文件只保存 WorkerEnv 变量 placeholder，不保存解析后的 secret。
-- `streamable_http` 映射为 `baseUrl` 和 `bearerToken` placeholder。mcporter 在执行时解析变量并添加
-  `Bearer` authorization scheme。
+- `streamable_http` 映射为 `baseUrl`、`bearerToken` placeholder 和可选的 `protocolVersion`。
+  mcporter 在执行时解析变量并添加 `Bearer` authorization scheme。
 - `stdio` 如仍保留支持，使用 `command: "/bin/sh"` 和 `args: ["-lc", <声明命令>]` 保持当前语义。
 - 只有 `enabled_tools` 时生成 `allowedTools`；只有 `disabled_tools` 时生成 `blockedTools`；两者同时存在
   时生成 `enabled_tools - disabled_tools` 的最终 `allowedTools`，因为 mcporter 不允许两种字段同时存在。
@@ -581,6 +582,12 @@ Automation 还要验证真实 trigger → run → BullX → `emitEvent` 或静�
 声明，而是 BullX 的同步 POST-only 2025-era 实现与 mcporter SDK v2 legacy path 不能互操作。可行修复是 BullX
 实现 `2026-07-28`、BullX 提供 legacy receive stream，或 mcporter/SDK 容忍规范允许的 405 后继续 POST。不要把 raw
 HTTP 成功或 fixture 结果冒充真实 mcporter 验收。
+
+2026-08-13 的重新验证已解除上述 transport 阻塞。BullX 本地 Terminal server 支持
+`2026-07-28`；Skill 声明显式设置 `protocol_version: "2026-07-28"`，Agent Computer 将它严格转换为
+mcporter 的 `protocolVersion`。真实 mcporter 调用已读取 `bullx_semantic_query` schema，并完成
+`describe`：`contract_version` 为 `1`，`catalog_revision` 为 `dd2120798a480184`，返回 51 个模型和
+5 个领域，无 warning。这个结果取代上一段的当时状态；第 11.5 节的三运行时业务对照仍是单独验收项。
 
 ## 12. 风险和改变决定的条件
 

--- a/docs/design-docs/MCPBackedSkills.md
+++ b/docs/design-docs/MCPBackedSkills.md
@@ -44,6 +44,7 @@ dependencies:
       description: "Remote data service"
       transport: streamable_http
       url: https://example.com/mcp
+      protocol_version: 2026-07-28
       bearer_token_env_var: REMOTE_DATA_API_KEY
       enabled_tools:
         - quote
@@ -61,8 +62,11 @@ dependencies:
 must be `streamable_http` or `stdio`.
 
 A `streamable_http` entry requires an HTTP or HTTPS `url`. It can set
-`bearer_token_env_var`, `enabled_tools`, and `disabled_tools`. The bearer field
-contains an environment variable name. It must never contain a secret value.
+`protocol_version`, `bearer_token_env_var`, `enabled_tools`, and
+`disabled_tools`. `protocol_version` accepts `auto`, `legacy`, or
+`2026-07-28`; its default is `auto`. Pin a version only when the server's
+declared protocol requires it. The bearer field contains an environment
+variable name. It must never contain a secret value.
 
 A `stdio` entry requires `command`. It can set `enabled_tools` and
 `disabled_tools`. It cannot set `url` or `bearer_token_env_var`. Agent Computer
@@ -115,7 +119,9 @@ The generated file always contains `imports: []`. The explicit
 `MCPORTER_CONFIG` path and this empty import list prevent mcporter from reading
 an Agent Home, project, Codex, editor, or host MCP config.
 
-An HTTP entry becomes `baseUrl` plus a `bearerToken` `${VARIABLE}` placeholder.
+A pinned HTTP entry becomes `baseUrl`, `protocolVersion`, and a `bearerToken`
+`${VARIABLE}` placeholder. An unpinned entry omits `protocolVersion` so
+mcporter uses automatic negotiation.
 A stdio entry becomes `command: /bin/sh` plus
 `args: [-lc, <declared command>]`. Credential values are not read while the
 file is generated and cannot enter the file. mcporter resolves the placeholder


### PR DESCRIPTION
## Summary

- Accept an optional `protocol_version` for Skill-backed Streamable HTTP MCP declarations, restricted to `auto`, `legacy`, or `2026-07-28`.
- Preserve the selected mode in connection identity and render it as mcporter `protocolVersion`, while rejecting unknown values.
- Document the field in all four website locales and update the MCP design and BullX verification notes.

## Scope

This keeps the existing invocation-scoped mcporter execution adapter. It does not expose Skill servers as native Codex `mcp__...` tools.

## Validation

- `bun run lint` in `app/agent_computer` — passed.
- `bun run build` in `app/website` — passed; 281 pages built.
- `bun run test` in `app/agent_computer` — the first run stopped before the suite because local Hex dependencies lagged the updated lock. `MIX_ENV=dev mix deps.get` then completed; the suite was not rerun before PR creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional MCP protocol version settings for streamable HTTP connections.
  * Supports automatic negotiation, legacy handling, and protocol version `2026-07-28`.
  * Pinned versions are preserved in generated connection settings.

* **Bug Fixes**
  * Improved compatibility with modern POST-only MCP servers by preventing unintended fallback to legacy SSE connections.

* **Documentation**
  * Updated MCP configuration guidance and examples in supported languages.
  * Clarified when protocol versions should be explicitly pinned.

* **Tests**
  * Added validation for supported and unsupported protocol versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->