### PR TITLE
fix(kernel): preserve streamed tool IDs and names across empty deltas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.72.1 (2026-08-14)
+
+- Preserve a streamed Chat Completions tool call's non-empty ID and name when later argument fragments repeat either field as an empty string, so OpenAI-compatible Providers cannot turn an otherwise valid client tool call into a partial completion.
+
 ## Version 0.72.0 (2026-08-14)
 
 - Always write compaction summaries with the Agent's light model profile. A conversation that asked for high or extra-high reasoning effort skipped that profile and summarized with the primary model instead, so an Agent whose primary Provider was unreachable could not compact at all and lost the turn. An Agent that configures no light profile now resolves it to its primary profile, the way the coding profile already resolves to heavy.

--- a/app/kernel/src/universal_ai_client/api_resolver/openai_chat.rs
+++ b/app/kernel/src/universal_ai_client/api_resolver/openai_chat.rs
@@ -378,6 +378,7 @@ impl ChatState {
                 call_id: delta
                     .get("id")
                     .and_then(Value::as_str)
+                    .filter(|call_id| !call_id.is_empty())
                     .map(ToOwned::to_owned)
                     .unwrap_or_else(|| generated_id("call")),
                 name: "unknown".to_string(),
@@ -385,10 +386,18 @@ impl ChatState {
                 output_index,
             });
 
-        if let Some(call_id) = delta.get("id").and_then(Value::as_str) {
+        if let Some(call_id) = delta
+            .get("id")
+            .and_then(Value::as_str)
+            .filter(|call_id| !call_id.is_empty())
+        {
             call.call_id = call_id.to_string();
         }
-        if let Some(name) = function.get("name").and_then(Value::as_str) {
+        if let Some(name) = function
+            .get("name")
+            .and_then(Value::as_str)
+            .filter(|name| !name.is_empty())
+        {
             call.name = name.to_string();
         }
 

--- a/app/kernel/src/universal_ai_client/api_resolver/tests.rs
+++ b/app/kernel/src/universal_ai_client/api_resolver/tests.rs
@@ -1099,7 +1099,8 @@ fn openai_chat_accumulates_tool_calls() {
             "choices": [{
                 "delta": {"tool_calls": [{
                     "index": 0,
-                    "function": {"arguments": ":\"Shanghai\"}"}
+                    "id": "",
+                    "function": {"name": "", "arguments": ":\"Shanghai\"}"}
                 }]},
                 "finish_reason": "tool_calls"
             }]
@@ -1114,6 +1115,7 @@ fn openai_chat_accumulates_tool_calls() {
         .find(|item| item["type"] == "function_call")
         .unwrap();
 
+    assert_eq!(call["call_id"], "call_1");
     assert_eq!(call["name"], "get_weather");
     assert_eq!(call["arguments"], "{\"city\":\"Shanghai\"}");
 }


### PR DESCRIPTION
## Problem

Some OpenAI-compatible relays include the function name in the first tool-call delta, then repeat `function.name` as an empty string while streaming arguments for the same tool-call index.

A direct relay probe produced this sequence:

```json
{"tool_calls":[{"index":0,"id":"call_REDACTED","type":"function","function":{"name":"diagnose_stream","arguments":""}}]}
{"tool_calls":[{"index":0,"function":{"name":"","arguments":"{\""}}]}
{"content":"","finish_reason":"tool_calls"}
```

The resolver treated the empty string as a new name and overwrote the valid name from the first delta. The completed call retained its arguments but had an empty name, so downstream processing failed with `partial_tool_call_completed`.

The same last-write-wins behavior also let a later empty `id` erase a valid call ID. Tool-call IDs and names are sparse, stable identity fields in a streamed Chat Completions response: an empty continuation value is absence, not cancellation.

## Change

- Ignore empty `id` and `function.name` deltas, preserving the last non-empty value for the same tool-call index.
- Treat an empty initial `id` like an omitted ID and use the existing generated fallback.
- Keep the existing behavior for later non-empty IDs and names.
- Extend the existing tool-call accumulation test with empty ID and name continuation fields instead of adding a duplicate test.

This follows the identity-field accumulation used by [OpenAI's Node SDK](https://github.com/openai/openai-node/blob/486e1917b013c1d711dc8f1933748422bb1c3df5/src/lib/ChatCompletionStream.ts) and the empty-continuation-ID coverage in [Vercel AI's shared tracker](https://github.com/vercel/ai/blob/02af8834b8c66cdf6573d5ff3cc5381be7e5791d/packages/provider-utils/src/streaming-tool-call-tracker.test.ts). The change does not synthesize a name when the stream never supplies one.

## Validation

- `bun run --filter @ankole/kernel lint`
- `bun run --filter @ankole/kernel test`
  - Rust suites: 72 passed, 72 passed, and 246 passed
  - Bun: 14 passed
  - ExUnit: 36 passed
- `git diff --check`

Not run: the dedicated real-provider end-to-end suite. The regression uses captured, sanitized relay frames, and the direct relay probe completed five tool-call streams with `finish_reason: "tool_calls"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streamed Chat Completions tool calls so empty IDs or names in later fragments no longer overwrite previously received values.
  * Tool calls now retain their original identifiers and names while arguments arrive across multiple streamed fragments, allowing valid calls to complete and execute correctly.

* **Documentation**
  * Added a changelog entry for version 0.72.1 dated August 14, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->