### PR TITLE
fix(ai-gateway): stream compaction pass-through, preserve opaque state, drop retired residue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.74.1 (2026-08-16)
+
+- Remove the retired standalone-compaction wire from the kernel and the last documentation references to the removed `/responses/compact` endpoint. No behavior changes; the unified `compaction_trigger` protocol already serves every caller.
+
 ## Version 0.74.0 (2026-08-16)
 
 - Compaction now has one protocol and one owner. AIGateway answers the `compaction_trigger` item for every caller, so a Background Agent Job and a stored conversation compact the same way. The separate `/responses/compact` endpoint is gone, together with the per-Job switch that chose between the two protocols and the per-Provider request constructors that only that endpoint used; a Job frozen under the old switch keeps running.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 0.74.2 (2026-08-16)
+
+- Provider-forwarded compaction now streams its request like every other Responses request and collects the whole reply before the caller sees any of it. Upstreams that accept only streaming requests, such as the ChatGPT subscription backend, can now answer native compaction instead of always forcing the local fallback.
+- Compaction over history that already holds Provider-owned compaction state no longer fails when the Provider path is off or unavailable. The local checkpoint preserves the Provider items verbatim, summarizes only the items after them, replays the preserved state on later turns, and logs a warning. The reply still carries exactly one compaction item, and the retired `opaque_compaction_fallback_unavailable` error is removed.
+
 ## Version 0.74.1 (2026-08-16)
 
 - Remove the retired standalone-compaction wire from the kernel and the last documentation references to the removed `/responses/compact` endpoint. No behavior changes; the unified `compaction_trigger` protocol already serves every caller.

--- a/app/control_plane/lib/ankole/ai_gateway/compaction.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/compaction.ex
@@ -849,18 +849,14 @@ defmodule Ankole.AIGateway.Compaction do
          store_context,
          false
        ) do
-    if UpstreamCompaction.opaque_input?(resolved_input) do
-      {:error, :opaque_compaction_fallback_unavailable}
-    else
-      compact_standalone_locally(
-        subject_uid,
-        request,
-        original_input,
-        resolved_input,
-        store_context,
-        nil
-      )
-    end
+    compact_standalone_locally(
+      subject_uid,
+      request,
+      original_input,
+      resolved_input,
+      store_context,
+      nil
+    )
   end
 
   defp compact_standalone(
@@ -892,18 +888,14 @@ defmodule Ankole.AIGateway.Compaction do
           end
 
         {:fallback, _reason} ->
-          if UpstreamCompaction.opaque_input?(resolved_input) do
-            {:error, :opaque_compaction_fallback_unavailable}
-          else
-            compact_standalone_locally(
-              subject_uid,
-              request,
-              original_input,
-              resolved_input,
-              store_context,
-              runtime
-            )
-          end
+          compact_standalone_locally(
+            subject_uid,
+            request,
+            original_input,
+            resolved_input,
+            store_context,
+            runtime
+          )
       end
     end
   end
@@ -918,6 +910,7 @@ defmodule Ankole.AIGateway.Compaction do
        ) do
     with {:ok, candidate} <-
            standalone_compaction_candidate(subject_uid, original_input, resolved_input),
+         :ok <- warn_opaque_preserved(candidate),
          {:ok, runtime} <- standalone_local_runtime(runtime, subject_uid, request),
          threshold = threshold_spec(runtime, request),
          {:ok, summary} <- summarize_standalone(subject_uid, candidate),
@@ -934,6 +927,21 @@ defmodule Ankole.AIGateway.Compaction do
 
   defp standalone_local_runtime(nil, subject_uid, request),
     do: ResponsesPreparation.resolve_runtime(subject_uid, request)
+
+  # The local summary cannot read Provider ciphertext, so the checkpoint keeps
+  # it verbatim instead of failing the compaction. The warning is the operator
+  # fact: the summary covers only the items after the preserved Provider state.
+  defp warn_opaque_preserved(%{opaque_prefix: []}), do: :ok
+
+  defp warn_opaque_preserved(%{opaque_prefix: opaque_prefix}) do
+    Logging.warning(
+      "ai_gateway.compaction_opaque_prefix_preserved",
+      "local compaction preserved provider-owned compaction state verbatim",
+      %{opaque_prefix_items: length(opaque_prefix)}
+    )
+
+    :ok
+  end
 
   defp upstream_artifact_attrs(subject_uid, conversation_id, upstream) do
     %{
@@ -1087,6 +1095,7 @@ defmodule Ankole.AIGateway.Compaction do
       retained_items: candidate.retained_client_tool_search ++ candidate.retained_tail,
       retained_user_originals:
         candidate.retained_user_originals ++ candidate.retained_pending_clarify,
+      opaque_prefix: candidate.opaque_prefix,
       retention:
         %{
           "strategy" => "standalone_user_messages",
@@ -1098,6 +1107,10 @@ defmodule Ankole.AIGateway.Compaction do
         |> maybe_put(
           "previous_summary_discarded",
           if(candidate.previous_summary_discarded, do: true, else: nil)
+        )
+        |> maybe_put(
+          "opaque_prefix_items",
+          if(candidate.opaque_prefix != [], do: length(candidate.opaque_prefix), else: nil)
         ),
       usage: summary.usage
     })
@@ -2175,15 +2188,30 @@ defmodule Ankole.AIGateway.Compaction do
   defp standalone_input(_request), do: {:error, :missing_input}
 
   defp standalone_compaction_candidate(subject_uid, original_input, resolved_input) do
-    {region_start_index, previous_compaction_item} = items_after_last_compaction(original_input)
-    prefix_items = Enum.drop(resolved_input, region_start_index)
-    original_region = Enum.drop(original_input, region_start_index)
+    {original_start, previous_compaction_item} = items_after_last_compaction(original_input)
+    original_region = Enum.drop(original_input, original_start)
+
+    # The region after the last original compaction item holds no compaction
+    # items, so handle resolution leaves it unchanged: the resolved region is
+    # the resolved input's tail of the same length, and everything before it is
+    # the resolved form of the already-compacted head.
+    region_length = length(original_region)
+    prefix_items = Enum.take(resolved_input, -region_length)
+    resolved_head = Enum.drop(resolved_input, -region_length)
 
     if prefix_items == [] do
       {:error, :no_compaction_candidate}
     else
       {previous_chat_history, previous_summary_discarded} =
         previous_compaction_content(subject_uid, previous_compaction_item)
+
+      # A compaction item that survives resolution is Provider-owned ciphertext
+      # this summarizer cannot read. Keep the resolved head through its last
+      # such item verbatim, so the caller's next turn replays the Provider
+      # state instead of losing it. Readable head items after that point ride
+      # `previous_chat_history` instead.
+      {head_opaque_end, _head_compaction_item} = items_after_last_compaction(resolved_head)
+      opaque_prefix = Enum.take(resolved_head, head_opaque_end)
 
       {retained_user_originals, _used_tokens} =
         CompactionRetention.collect_user_originals(original_region, user_message_budget_tokens())
@@ -2198,7 +2226,8 @@ defmodule Ankole.AIGateway.Compaction do
            retained_pending_clarify: CompactionRetention.collect_pending_clarify(original_region),
            retained_client_tool_search: retained_client_tool_search,
            previous_chat_history: previous_chat_history,
-           previous_summary_discarded: previous_summary_discarded,
+           previous_summary_discarded: previous_summary_discarded and opaque_prefix == [],
+           opaque_prefix: opaque_prefix,
            tail_rows_requested: 0
          }}
       end
@@ -2371,7 +2400,8 @@ defmodule Ankole.AIGateway.Compaction do
 
   defp checkpoint_within_budget(candidate, summary, current_input, threshold) do
     checkpoint_items =
-      candidate.retained_user_originals ++
+      Map.get(candidate, :opaque_prefix, []) ++
+        candidate.retained_user_originals ++
         candidate.retained_pending_clarify ++
         [compaction_summary_item(summary.text)] ++
         candidate.retained_client_tool_search ++

--- a/app/control_plane/lib/ankole/ai_gateway/compaction_artifacts.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/compaction_artifacts.ex
@@ -2,9 +2,9 @@ defmodule Ankole.AIGateway.CompactionArtifacts do
   @moduledoc """
   Canonical storage and replay seam for AIGateway compaction artifacts.
 
-  `/responses/compact`, `/compress`, and automatic compaction all create an
-  artifact first. A checkpoint message row is only a response-chain continuation
-  pointer to one artifact.
+  The `compaction_trigger` protocol, `/compress`, and automatic compaction all
+  create an artifact first. A checkpoint message row is only a response-chain
+  continuation pointer to one artifact.
   """
 
   import Ecto.Query, warn: false

--- a/app/control_plane/lib/ankole/ai_gateway/compaction_artifacts.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/compaction_artifacts.ex
@@ -27,6 +27,7 @@ defmodule Ankole.AIGateway.CompactionArtifacts do
           optional(:output) => [term()],
           optional(:retained_items) => [map()],
           optional(:retained_user_originals) => [map()],
+          optional(:opaque_prefix) => [map()],
           optional(:retention) => map(),
           optional(:usage) => map()
         }
@@ -127,6 +128,13 @@ defmodule Ankole.AIGateway.CompactionArtifacts do
 
   def upstream_binding(_artifact), do: nil
 
+  @spec opaque_prefix(CompactionArtifact.t()) :: [map()]
+  def opaque_prefix(%CompactionArtifact{content: %{"opaque_prefix" => opaque_prefix}})
+      when is_list(opaque_prefix),
+      do: opaque_prefix
+
+  def opaque_prefix(_artifact), do: []
+
   @spec response_body(CompactionArtifact.t(), keyword()) :: map()
   def response_body(%CompactionArtifact{} = artifact, opts \\ []) do
     body = %{
@@ -145,6 +153,8 @@ defmodule Ankole.AIGateway.CompactionArtifacts do
 
   @doc """
   Materializes a checkpoint row into the artifact output it references.
+
+  A preserved opaque prefix replays ahead of the artifact output.
   """
   @spec output_for_checkpoint(String.t(), Message.t()) ::
           {:ok, [term()]} | {:error, :invalid_compaction_handle}
@@ -152,7 +162,7 @@ defmodule Ankole.AIGateway.CompactionArtifacts do
     case ref do
       %{"type" => "compaction_artifact", "id" => public_id} ->
         with {:ok, artifact} <- get_for_subject(subject_uid, public_id) do
-          {:ok, output(artifact)}
+          {:ok, opaque_prefix(artifact) ++ output(artifact)}
         end
 
       _invalid ->
@@ -196,8 +206,10 @@ defmodule Ankole.AIGateway.CompactionArtifacts do
   def summary_for_checkpoint(_subject_uid, _message), do: {:ok, nil}
 
   @doc """
-  Replaces Ankole compaction handles in Response input items with a user message.
+  Replaces Ankole compaction handles in Response input items.
 
+  A handle resolves to its stored opaque prefix, when the artifact preserved
+  Provider-owned compaction state, followed by one checkpoint user message.
   The checkpoint prompt is AIGateway policy. Provider-native compaction items
   remain unchanged for a Responses resolver.
   """
@@ -206,6 +218,7 @@ defmodule Ankole.AIGateway.CompactionArtifacts do
   def resolve_input_handles(subject_uid, items) when is_list(items) do
     Enum.reduce_while(items, {:ok, []}, fn item, {:ok, acc} ->
       case resolve_input_item_handle(subject_uid, item) do
+        {:ok, resolved} when is_list(resolved) -> {:cont, {:ok, Enum.reverse(resolved, acc)}}
         {:ok, resolved} -> {:cont, {:ok, [resolved | acc]}}
         {:error, _reason} = error -> {:halt, error}
       end
@@ -235,7 +248,7 @@ defmodule Ankole.AIGateway.CompactionArtifacts do
       @handle_prefix <> _rest = handle ->
         with {:ok, artifact} <- get_for_subject(subject_uid, handle),
              summary when is_binary(summary) <- summary_text(artifact) do
-          {:ok, checkpoint_message(summary)}
+          {:ok, opaque_prefix(artifact) ++ [checkpoint_message(summary)]}
         else
           _missing_or_invalid -> {:error, :invalid_compaction_handle}
         end
@@ -291,6 +304,7 @@ defmodule Ankole.AIGateway.CompactionArtifacts do
     summary_text = Map.fetch!(attrs, :summary_text)
     retained_items = Map.get(attrs, :retained_items, [])
     retained_user_originals = Map.get(attrs, :retained_user_originals, [])
+    opaque_prefix = Map.get(attrs, :opaque_prefix, [])
 
     cond do
       not is_binary(summary_text) or String.trim(summary_text) == "" ->
@@ -302,15 +316,27 @@ defmodule Ankole.AIGateway.CompactionArtifacts do
       not is_list(retained_user_originals) ->
         {:error, :invalid_compaction_artifact}
 
+      not is_list(opaque_prefix) ->
+        {:error, :invalid_compaction_artifact}
+
       true ->
-        {:ok,
-         %{
-           "version" => 2,
-           "summary" => %{"text" => String.trim(summary_text)},
-           "output" => retained_user_originals ++ [compaction_item(id)] ++ retained_items,
-           "retention" => artifact_retention(attrs, retained_items, retained_user_originals),
-           "usage" => response_usage(Map.get(attrs, :usage, %{}))
-         }}
+        content = %{
+          "version" => 2,
+          "summary" => %{"text" => String.trim(summary_text)},
+          "output" => retained_user_originals ++ [compaction_item(id)] ++ retained_items,
+          "retention" => artifact_retention(attrs, retained_items, retained_user_originals),
+          "usage" => response_usage(Map.get(attrs, :usage, %{}))
+        }
+
+        # Provider-owned compaction items the local summary could not read.
+        # They stay outside `output`, so the reply keeps exactly one compaction
+        # item; both replay surfaces emit them ahead of the local checkpoint.
+        content =
+          if opaque_prefix == [],
+            do: content,
+            else: Map.put(content, "opaque_prefix", opaque_prefix)
+
+        {:ok, content}
     end
   end
 
@@ -331,6 +357,7 @@ defmodule Ankole.AIGateway.CompactionArtifacts do
           "previous_summary_discarded",
           Map.get(retention, "previous_summary_discarded")
         )
+        |> maybe_put("opaque_prefix_items", Map.get(retention, "opaque_prefix_items"))
 
       _other ->
         %{

--- a/app/control_plane/lib/ankole/ai_gateway/schemas/compaction_artifact.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/schemas/compaction_artifact.ex
@@ -1,6 +1,6 @@
 defmodule Ankole.AIGateway.Schemas.CompactionArtifact do
   @moduledoc """
-  Stored compaction artifact for OpenResponses `/responses/compact`.
+  Stored compaction artifact for AIGateway history compaction.
 
   This table is the only durable source of compaction output. Message rows may
   point at an artifact through a checkpoint, but the summary and retained tail

--- a/app/control_plane/lib/ankole/ai_gateway/upstream_compaction.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/upstream_compaction.ex
@@ -8,10 +8,11 @@ defmodule Ankole.AIGateway.UpstreamCompaction do
   """
 
   alias Ankole.AIGateway.ModelMetadata.Cache
-  alias Ankole.AIGateway.CredentialAttempts
   alias Ankole.AIGateway.Observability
   alias Ankole.AIGateway.ProviderConfigs.Provider
   alias Ankole.AIGateway.Providers
+  alias Ankole.AIGateway.ResponsesPreparation
+  alias Ankole.AIGateway.ResponseStream
   alias Ankole.Logging
 
   @negative_ttl_ms :timer.hours(1)
@@ -70,14 +71,6 @@ defmodule Ankole.AIGateway.UpstreamCompaction do
 
   def binding_matches?(_stored_binding, _runtime), do: false
 
-  @spec opaque_input?([term()]) :: boolean()
-  def opaque_input?(input) when is_list(input) do
-    Enum.any?(input, fn
-      %{"type" => "compaction"} -> true
-      _item -> false
-    end)
-  end
-
   defp compact_responses(runtime, input, request, subject_uid) do
     with {:ok, binding} <- runtime_binding(runtime) do
       cache_key = cache_key(binding)
@@ -108,29 +101,45 @@ defmodule Ankole.AIGateway.UpstreamCompaction do
     end
   end
 
-  # The compaction trigger is the Provider-native request. The dedicated compact
-  # endpoint is being retired upstream, so this asks for compaction the way the
-  # surviving protocol does: a normal Responses request whose input ends with
-  # the trigger. It stays non-streaming, because the whole reply must be checked
-  # before any of it can reach a caller.
+  # The compaction trigger is the Provider-native request: a normal Responses
+  # request whose input ends with the trigger. Codex moved off the dedicated
+  # compact endpoint, and the trigger is the protocol both client generations
+  # share. The request uses the standard streaming preparation and stream
+  # owner, because some upstreams (the ChatGPT backend) accept nothing else;
+  # the stream is collected to its terminal Response and checked before any of
+  # it can reach a caller.
   defp execute(runtime, request, subject_uid) do
-    with {:ok, prepared_request} <-
-           Providers.build_response_request(runtime, request, stream?: false),
-         {:ok, response} <-
+    with {:ok, %{request: request, spec: prepared_request}} <-
+           ResponsesPreparation.prepare_with_runtime(subject_uid, runtime, request, stream?: true),
+         {:ok, %{body: body}} <-
            Observability.record_compact(subject_uid, runtime, request, fn ->
-             CredentialAttempts.request(prepared_request)
+             with {:ok, outcome, _meta} <-
+                    ResponseStream.collect(subject_uid, request, prepared_request,
+                      caller: "compaction.upstream"
+                    ),
+                  {:ok, body} <- terminal_body(outcome) do
+               {:ok, %{body: body}}
+             end
            end) do
-      compact_response(response)
+      compact_response(body)
     else
       {:error, reason} -> classify_error(reason)
     end
   end
 
+  defp terminal_body(%{terminal_error: nil, terminal_response: %{} = response}),
+    do: {:ok, response}
+
+  defp terminal_body(%{terminal_error: error}), do: {:error, error}
+
+  defp terminal_body(_outcome),
+    do: {:error, :upstream_compaction_missing_terminal_response}
+
   # Exactly one compaction item is the whole contract. Anything else means the
   # Provider answered a normal turn instead of compacting, and using that output
   # would silently replace the history with a model reply. The rest of the output
   # is kept, because the Provider decided what its compacted history retains.
-  defp compact_response(%{body: %{"output" => output} = body}) when is_list(output) do
+  defp compact_response(%{"output" => output} = body) when is_list(output) do
     case Enum.count(output, &compaction_item?/1) do
       1 ->
         usage = Map.get(body, "usage", %{})

--- a/app/control_plane/lib/ankole_web/ai_gateway_responses_socket.ex
+++ b/app/control_plane/lib/ankole_web/ai_gateway_responses_socket.ex
@@ -287,16 +287,6 @@ defmodule AnkoleWeb.AIGatewayResponsesSocket do
 
         {:push, {:text, Ankole.JSON.encode!(event)}, state}
 
-      {:error, :opaque_compaction_fallback_unavailable} ->
-        event =
-          error_event(
-            502,
-            "opaque_compaction_fallback_unavailable",
-            "provider-native compaction history cannot use the local fallback."
-          )
-
-        {:push, {:text, Ankole.JSON.encode!(event)}, state}
-
       {:error, reason}
       when reason in [:empty_compaction_summary, :invalid_summary_shape] ->
         event =

--- a/app/control_plane/lib/ankole_web/controllers/ai_gateway_controller.ex
+++ b/app/control_plane/lib/ankole_web/controllers/ai_gateway_controller.ex
@@ -412,11 +412,6 @@ defmodule AnkoleWeb.AIGatewayController do
   defp error_tuple(:invalid_compaction_handle),
     do: {400, "invalid_compaction_handle", "compaction encrypted_content handle is invalid"}
 
-  defp error_tuple(:opaque_compaction_fallback_unavailable),
-    do:
-      {502, "opaque_compaction_fallback_unavailable",
-       "provider-native compaction history cannot use the local fallback"}
-
   # The caller's request is well formed: the summarizer produced nothing usable
   # after its retry. That is an upstream fault, so it must not read as a client
   # error that the caller could fix by changing the request.

--- a/app/control_plane/test/ankole/ai_gateway/responses_dispatch_test.exs
+++ b/app/control_plane/test/ankole/ai_gateway/responses_dispatch_test.exs
@@ -580,24 +580,23 @@ defmodule Ankole.AIGateway.ResponsesDispatchTest do
 
     base_url =
       start_recording_upstream(self(), fn request ->
-        # Provider-native compaction is one non-streaming request that must
-        # carry the trigger; nothing else may reach this Provider.
+        # Provider-native compaction is one streaming request that must carry
+        # the trigger; the ChatGPT backend accepts nothing but streams.
         assert compaction_trigger_request?(request)
+        assert request.body["stream"] == true
 
-        {:json, 200,
-         %{
-           "id" => "resp_chatgpt_v2",
-           "object" => "response",
-           "status" => "completed",
-           "output" => [
+        {:sse, 200,
+         openai_compaction_stream_events(
+           "resp_chatgpt_v2",
+           [
              %{
                "id" => "cmp_chatgpt_v2",
                "type" => "compaction",
                "encrypted_content" => "provider-opaque-state"
              }
            ],
-           "usage" => %{"total_tokens" => 41}
-         }}
+           %{"total_tokens" => 41}
+         )}
       end)
 
     assert {:ok, _provider} =
@@ -7606,9 +7605,12 @@ defmodule Ankole.AIGateway.ResponsesDispatchTest do
         assert request.path == "v1/responses"
         assert List.last(request.body["input"]) == %{"type" => "compaction_trigger"}
         assert request.body["model"] == "gpt-5.6"
-        assert request.body["stream"] == false
+        assert request.body["stream"] == true
 
-        {:json, 200, %{"output" => native_output, "usage" => %{"total_tokens" => 42}}}
+        {:sse, 200,
+         openai_compaction_stream_events("resp_native_success", native_output, %{
+           "total_tokens" => 42
+         })}
       end)
 
     configure_openai_responses_provider!(
@@ -7708,7 +7710,10 @@ defmodule Ankole.AIGateway.ResponsesDispatchTest do
     base_url =
       start_recording_upstream(self(), fn request ->
         if compaction_trigger_request?(request) do
-          {:json, 200, %{"output" => native_output, "usage" => %{"total_tokens" => 41}}}
+          {:sse, 200,
+           openai_compaction_stream_events("resp_native_stateful", native_output, %{
+             "total_tokens" => 41
+           })}
         else
           {:sse, 200,
            openai_response_stream_events(
@@ -7790,7 +7795,7 @@ defmodule Ankole.AIGateway.ResponsesDispatchTest do
       start_recording_upstream(self(), fn request ->
         assert request.path == "v1/responses"
         assert List.last(request.body["input"]) == %{"type" => "compaction_trigger"}
-        {:json, 200, %{"output" => native_output}}
+        {:sse, 200, openai_compaction_stream_events("resp_native_manual", native_output)}
       end)
 
     create_openai_compaction_provider!(agent, "openai-native-manual", base_url,
@@ -7890,7 +7895,7 @@ defmodule Ankole.AIGateway.ResponsesDispatchTest do
     assert Agent.get(compact_attempts, & &1) > attempts_after_first_request
   end
 
-  test "standalone opaque history rejects an unavailable local fallback" do
+  test "standalone compact with only opaque provider state reports no candidate" do
     %{principal: agent} = agent_fixture()
 
     configure_openai_responses_provider!(
@@ -7899,13 +7904,75 @@ defmodule Ankole.AIGateway.ResponsesDispatchTest do
       "openai-native-compact-opaque"
     )
 
-    assert {:error, :opaque_compaction_fallback_unavailable} =
+    assert {:error, :no_compaction_candidate} =
              Compaction.compact_response(agent.uid, %{
                "model" => "primary",
                "input" => [
                  %{"type" => "compaction", "encrypted_content" => "provider-opaque-state"}
                ]
              })
+  end
+
+  test "standalone compact preserves opaque provider state through the local fallback" do
+    %{principal: agent} = agent_fixture()
+
+    base_url =
+      start_recording_upstream(self(), fn _request ->
+        {:sse, 200,
+         openai_response_stream_events(
+           "resp_opaque_summary",
+           "gpt-5.6",
+           "## Active Task\nSummary of the work after the provider state"
+         )}
+      end)
+
+    configure_openai_responses_provider!(agent.uid, base_url, "openai-opaque-preserved")
+
+    retained_message = %{
+      "type" => "message",
+      "role" => "user",
+      "content" => "provider-retained"
+    }
+
+    opaque_item = %{"type" => "compaction", "encrypted_content" => "provider-opaque-state"}
+
+    assert {:ok, body} =
+             Compaction.compact_response(agent.uid, %{
+               "model" => "primary",
+               "input" => [
+                 retained_message,
+                 opaque_item,
+                 text_message("user", "post-compaction work to summarize")
+               ]
+             })
+
+    # The reply keeps exactly one compaction item, and the opaque provider
+    # state never leaks into the reply output.
+    assert [%{"type" => "compaction", "encrypted_content" => "ankole:compact:v1:" <> _}] =
+             Enum.filter(body["output"], &(&1["type"] == "compaction"))
+
+    refute Ankole.JSON.encode!(body["output"]) =~ "provider-opaque-state"
+
+    assert [artifact] = Repo.all(CompactionArtifact)
+    assert artifact.content["version"] == 2
+    assert artifact.content["opaque_prefix"] == [retained_message, opaque_item]
+    assert artifact.content["retention"]["opaque_prefix_items"] == 2
+
+    # Handle resolution replays the preserved provider state ahead of the
+    # local checkpoint text.
+    handle = CompactionArtifacts.handle(artifact.id)
+
+    assert {:ok, resolved} =
+             CompactionArtifacts.resolve_input_handles(agent.uid, [
+               %{"type" => "compaction", "encrypted_content" => handle}
+             ])
+
+    assert [^retained_message, ^opaque_item, checkpoint_message] = resolved
+    assert checkpoint_message["type"] == "message"
+    assert checkpoint_message["role"] == "user"
+
+    assert [%{"text" => checkpoint_text}] = checkpoint_message["content"]
+    assert checkpoint_text =~ "Summary of the work after the provider state"
   end
 
   defp start_recording_upstream(test_pid, response_fun) do

--- a/app/control_plane/test/ankole_web/controllers/ai_gateway_controller_test.exs
+++ b/app/control_plane/test/ankole_web/controllers/ai_gateway_controller_test.exs
@@ -2317,9 +2317,10 @@ defmodule AnkoleWeb.AIGatewayControllerTest do
     assert inspect(continuation_request.body) =~ "## Active Task\\nhello from compliance"
   end
 
-  test "compact endpoint rejects opaque history when local fallback is the only path", %{
-    conn: conn
-  } do
+  test "compact endpoint reports no candidate for history that is only opaque provider state",
+       %{
+         conn: conn
+       } do
     %{principal: agent} = agent_fixture()
 
     assert {:ok, _provider} =
@@ -2348,7 +2349,7 @@ defmodule AnkoleWeb.AIGatewayControllerTest do
         ]
       })
 
-    assert {:error, 502, "opaque_compaction_fallback_unavailable"} = conn
+    assert {:error, 400, "no_compaction_candidate"} = conn
   end
 
   test "compact endpoint compacts only items after the previous compaction item", %{conn: conn} do
@@ -2779,9 +2780,6 @@ defmodule AnkoleWeb.AIGatewayControllerTest do
         compaction_trigger_result(
           Enum.map(chunks, fn {:text, chunk} -> Ankole.JSON.decode!(chunk) end)
         )
-
-      {:error, reason} ->
-        {:error, reason}
     end
   end
 

--- a/app/control_plane/test/support/ai_gateway_case.ex
+++ b/app/control_plane/test/support/ai_gateway_case.ex
@@ -221,6 +221,34 @@ defmodule Ankole.AIGatewayCase do
   end
 
   @doc false
+  def openai_compaction_stream_events(response_id, output, usage \\ %{}) do
+    response = %{
+      "id" => response_id,
+      "object" => "response",
+      "created_at" => 1_764_967_971,
+      "completed_at" => nil,
+      "status" => "in_progress",
+      "output" => [],
+      "usage" => %{}
+    }
+
+    [
+      %{"type" => "response.created", "sequence_number" => 0, "response" => response},
+      %{
+        "type" => "response.completed",
+        "sequence_number" => 1,
+        "response" => %{
+          response
+          | "completed_at" => 1_764_967_972,
+            "status" => "completed",
+            "output" => output,
+            "usage" => usage
+        }
+      }
+    ]
+  end
+
+  @doc false
   def openai_response_stream_events(response_id, model, text, usage \\ %{}) do
     response =
       %{

--- a/app/kernel/src/universal_ai_client/api_resolver/core.rs
+++ b/app/kernel/src/universal_ai_client/api_resolver/core.rs
@@ -80,15 +80,11 @@ impl APIResolver {
     pub fn new(kind: APIResolverKind, context: ResponseContext) -> Self {
         let protocol = make_protocol(kind, &context);
         let (opaque_tool_fields, provider_context, opaque_prepare_error) =
-            if kind == APIResolverKind::OpenAIResponsesCompact {
-                (OpaqueToolFields::inactive(), context.clone(), None)
-            } else {
-                match OpaqueToolFields::prepare(kind, &context) {
-                    Ok((opaque_tool_fields, provider_context)) => {
-                        (opaque_tool_fields, provider_context, None)
-                    }
-                    Err(error) => (OpaqueToolFields::inactive(), context.clone(), Some(error)),
+            match OpaqueToolFields::prepare(kind, &context) {
+                Ok((opaque_tool_fields, provider_context)) => {
+                    (opaque_tool_fields, provider_context, None)
                 }
+                Err(error) => (OpaqueToolFields::inactive(), context.clone(), Some(error)),
             };
         let prepare_error = validate_compaction_replay_wire(kind, &provider_context)
             .err()
@@ -159,7 +155,6 @@ impl APIResolver {
 fn make_protocol(kind: APIResolverKind, context: &ResponseContext) -> Box<dyn APIProtocol> {
     match kind {
         APIResolverKind::OpenAIResponses => Box::new(OpenAIResponsesState::default()),
-        APIResolverKind::OpenAIResponsesCompact => Box::new(OpenAIResponsesCompact),
         APIResolverKind::OpenAIChatCompletions => Box::new(ChatState::new(context.model.clone())),
         APIResolverKind::AnthropicMessages => Box::new(AnthropicState::new(context.model.clone())),
         APIResolverKind::GeminiGenerateContent => {
@@ -188,10 +183,7 @@ fn validate_compaction_replay_wire(
     kind: APIResolverKind,
     context: &ResponseContext,
 ) -> Result<(), StreamError> {
-    if matches!(
-        kind,
-        APIResolverKind::OpenAIResponses | APIResolverKind::OpenAIResponsesCompact
-    ) {
+    if kind == APIResolverKind::OpenAIResponses {
         return Ok(());
     }
 

--- a/app/kernel/src/universal_ai_client/api_resolver/opaque_tool_fields.rs
+++ b/app/kernel/src/universal_ai_client/api_resolver/opaque_tool_fields.rs
@@ -513,10 +513,7 @@ impl OpaqueToolFields {
 }
 
 fn openai_responses_wire(kind: APIResolverKind) -> bool {
-    matches!(
-        kind,
-        APIResolverKind::OpenAIResponses | APIResolverKind::OpenAIResponsesCompact
-    )
+    kind == APIResolverKind::OpenAIResponses
 }
 
 impl ToolFieldPlan {

--- a/app/kernel/src/universal_ai_client/api_resolver/openai_responses.rs
+++ b/app/kernel/src/universal_ai_client/api_resolver/openai_responses.rs
@@ -182,21 +182,3 @@ fn classify_stateful_replay_rejection(
         None
     }
 }
-
-#[derive(Debug, Default)]
-pub(super) struct OpenAIResponsesCompact;
-
-impl APIProtocol for OpenAIResponsesCompact {
-    fn on_provider_body(
-        &mut self,
-        _context: &ResponseContext,
-        status: u16,
-        body: Value,
-    ) -> Result<Value, StreamError> {
-        if !(200..300).contains(&status) {
-            return Err(provider_body_error(status, body));
-        }
-        reject_provider_body_error(status, &body)?;
-        provider_object_body(status, body, "OpenAI Responses compact")
-    }
-}

--- a/app/kernel/src/universal_ai_client/api_resolver/tests.rs
+++ b/app/kernel/src/universal_ai_client/api_resolver/tests.rs
@@ -140,42 +140,6 @@ fn non_responses_wire_rejects_provider_native_compaction_input() {
 }
 
 #[test]
-fn responses_compact_preserves_request_and_response_output() {
-    let input = json!([
-        {"type": "compaction", "encrypted_content": "opaque"},
-        {"type": "message", "role": "user", "content": "continue"}
-    ]);
-    let mut resolver = APIResolver::new(
-        APIResolverKind::OpenAIResponsesCompact,
-        ResponseContext {
-            model: "gpt-test".to_string(),
-            request: json!({"input": input.clone(), "stream": true}),
-            provider_options: json!({}),
-            stream: Some(false),
-            include_model: true,
-        },
-    );
-
-    let request = Value::Object(resolver.build_body().unwrap());
-    assert_eq!(request["input"], input);
-    assert_eq!(request["stream"], false);
-
-    let output = json!([
-        {"type": "message", "role": "user", "content": "retained"},
-        {"type": "compaction", "encrypted_content": "new-opaque", "unknown": true}
-    ]);
-    let response = resolver
-        .normalize_body(
-            200,
-            json!({"object": "response.compaction", "output": output.clone(), "extra": 1}),
-        )
-        .unwrap();
-
-    assert_eq!(response["output"], output);
-    assert_eq!(response["extra"], 1);
-}
-
-#[test]
 fn openai_responses_requires_terminal_event_on_finish() {
     let mut resolver =
         APIResolver::new(APIResolverKind::OpenAIResponses, ResponseContext::default());

--- a/app/kernel/src/universal_ai_client/spec.rs
+++ b/app/kernel/src/universal_ai_client/spec.rs
@@ -10,8 +10,6 @@ use crate::common::{KernelError, KernelResult};
 pub enum APIResolverKind {
     #[serde(rename = "openai_responses")]
     OpenAIResponses,
-    #[serde(rename = "openai_responses_compact")]
-    OpenAIResponsesCompact,
     #[serde(rename = "openai_chat_completions")]
     OpenAIChatCompletions,
     AnthropicMessages,
@@ -37,7 +35,6 @@ impl APIResolverKind {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::OpenAIResponses => "openai_responses",
-            Self::OpenAIResponsesCompact => "openai_responses_compact",
             Self::OpenAIChatCompletions => "openai_chat_completions",
             Self::AnthropicMessages => "anthropic_messages",
             Self::GeminiGenerateContent => "gemini_generate_content",

--- a/docs/design-docs/AIGateway.md
+++ b/docs/design-docs/AIGateway.md
@@ -804,13 +804,15 @@ unsupported result is cached. This decision is made per request, not frozen with
 the Job, so a Provider failover cannot leave it pointing at a Provider that
 never made it.
 
-A wrong-shaped Provider reply never reaches the caller. AIGateway collects the
-whole response and requires exactly one `compaction` output item before any of
-it enters the public stream. When that check fails, AIGateway serves the same
-request with its own summary instead. It can only do that while the history
-holds no Provider-owned compaction item, because this summarizer cannot read
-one; a history that already holds one reports the failure rather than inventing
-a summary.
+The pass-through request uses the standard streaming Responses preparation and
+stream owner, because some upstreams accept only streaming requests. A
+wrong-shaped Provider reply never reaches the caller. AIGateway collects the
+stream to its terminal Response and requires exactly one `compaction` output
+item before any of it enters the public stream. When that check fails,
+AIGateway serves the same request with its own summary instead. A history that
+already holds a Provider-owned compaction item keeps that item: the summary
+covers only the items after it, and the checkpoint preserves the Provider item
+verbatim, as described under the stateless trigger below.
 
 Only a stateless caller can be forwarded, because it sends the history the
 Provider must compact. A stateful caller's history lives here, so its
@@ -861,11 +863,17 @@ opaque value that AIGateway cannot project item by item. Reactive replay
 recovery does not replace this check.
 
 A stateless trigger returns version 3 output without an Ankole handle. The
-caller must continue with a compatible Responses provider. If its input already
-contains provider-native compaction state and upstream compaction is disabled or
-fails, AIGateway returns HTTP 502 with
-`opaque_compaction_fallback_unavailable`. It cannot create a correct local
-summary from provider ciphertext.
+caller must continue with a compatible Responses provider. When its input
+already contains provider-native compaction state and upstream compaction is
+disabled or fails, AIGateway cannot read that ciphertext, so it does not fail
+the compaction and does not invent a summary over it. The local summary covers
+only the items after the last Provider compaction item. The artifact stores the
+Provider items through that item verbatim as an opaque prefix, and both replay
+surfaces emit that prefix ahead of the local checkpoint: handle resolution for
+a stateless continuation, and checkpoint materialization for a stored one. The
+reply still carries exactly one compaction item. AIGateway logs a warning when
+it preserves a prefix. Replayed Provider state still reads only on a
+compatible upstream; a Provider change keeps the existing stateless contract.
 
 The kernel preserves provider-native compaction items on the Responses wire.
 It rejects those items on other wires with

--- a/docs/design-docs/AIGateway.md
+++ b/docs/design-docs/AIGateway.md
@@ -867,8 +867,8 @@ fails, AIGateway returns HTTP 502 with
 `opaque_compaction_fallback_unavailable`. It cannot create a correct local
 summary from provider ciphertext.
 
-The kernel preserves provider-native compaction items on the Responses and
-Responses Compact wires. It rejects those items on other wires with
+The kernel preserves provider-native compaction items on the Responses wire.
+It rejects those items on other wires with
 `unsupported_compaction_replay_wire`.
 
 The compaction summarizer uses the shared Responses pair registry for every

--- a/docs/design-docs/BackgroundAgentJob.md
+++ b/docs/design-docs/BackgroundAgentJob.md
@@ -507,12 +507,12 @@ borrows visual capability from a different model.
 
 When the instance leaves compaction to the Provider, AIGateway tries the Job's
 frozen Responses Provider and model before it uses local compaction.
-Unsupported and transient failures use local compaction while the input remains
-readable. A provider-native compact output is opaque. If a later compact
-request cannot use the same upstream path, AIGateway cannot summarize that
-ciphertext and returns HTTP 502 `opaque_compaction_fallback_unavailable`. The
-Job must continue with a compatible Provider, or a caller must start a new Job
-from readable context.
+Unsupported and transient failures use local compaction. A provider-native
+compact output is opaque. If a later compact request cannot use the same
+upstream path, AIGateway keeps the opaque items verbatim, summarizes only the
+readable items after them, and logs a warning, so the Job's compaction
+completes instead of failing. The preserved Provider state still reads only on
+a compatible Provider on later turns.
 
 Worker placement selects the normal owner. The per-Agent `flock` on each
 Worker-local Codex Home is the final same-Worker exclusion boundary. An


### PR DESCRIPTION
## Summary

Two commits, one compaction follow-up to v0.74.0 (dc1dba31). Changelog versions 0.74.1 and 0.74.2, one per commit.

### Commit 1 — remove retired standalone-compaction residue (0.74.1)

v0.74.0 unified compaction on the `compaction_trigger` protocol but left residue: the producer-less `openai_responses_compact` kernel wire (enum variant, dispatch arms, protocol impl, dedicated test), two moduledocs referencing the removed `/responses/compact` endpoint, and a stale design-doc sentence. All removed. Compaction-item preservation on the normal Responses wire and the `unsupported_compaction_replay_wire` rejection stay (version-3 artifacts depend on both). Frozen pre-0.74 Jobs are unaffected: their retired projection block is read and discarded, so every Job already compacts through the unified protocol.

### Commit 2 — stream the pass-through, preserve opaque state (0.74.2)

**Streaming pass-through.** `UpstreamCompaction.execute` now uses the standard streaming Responses preparation and stream owner (the same machinery the local summarizer uses), collects the stream to its terminal Response, and only then runs the exactly-one-compaction-item check. This replaces the non-streaming special case that could never work against the ChatGPT subscription backend, which rejects every non-streaming request with HTTP 400 `"Stream must be set to true"` — matching the official Codex client, which always streams and aggregates (`collect_compaction_output`). The 404/405 negative cache keeps its semantics; failures inside the stream still fall back per attempt without caching.

**Opaque-state preservation.** Compaction over history that already holds Provider-owned compaction ciphertext no longer fails with `opaque_compaction_fallback_unavailable` when the Provider path is off or unavailable. The local checkpoint stores the resolved head through its last surviving compaction item verbatim (`opaque_prefix` on the version-2 artifact), summarizes only the items after it, and logs a warning. Both replay surfaces — stateless handle resolution and stored checkpoint materialization — emit the preserved items ahead of the local checkpoint text, so the reply still carries exactly one compaction item and the caller's next turn replays the Provider state. Readable prior summaries continue to fold into the new summary through `previous_chat_history`. History that is only ciphertext with nothing new reports the existing `no_compaction_candidate`. The retired error code is removed from the socket, the controller, and both design documents.

## Validation

- Control-plane full suite: 2155 passed (one net-new preservation test; upstream fakes now answer SSE and assert `stream == true`).
- Gated real-LLM test (`ANKOLE_AI_ROUTER_KEY`): 2 passed against ai-router over the WebSocket upstream transport.
- Live against chatgpt.com (dev provider): the probe that previously failed with the streaming 400 now completes native compaction; end-to-end stateless trigger returns a provider-native version-3 artifact; the opaque-preservation round trip replays the provider ciphertext byte-identical ahead of the checkpoint text.
- Kernel suite (commit 1): cargo test across 3 feature sets + 14 Bun + 37 Elixir tests, clippy `-D warnings` clean.
- `mix compile --warnings-as-errors` and `mix format --check-formatted` clean on the combined result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compaction now uses standard streaming Responses.
  * Provider-native compaction state is preserved during replay and local fallback.
  * Local fallback summarizes subsequent readable history while retaining compatible provider state.

* **Bug Fixes**
  * Malformed provider responses now fall back to local compaction instead of failing with a gateway-specific error.
  * Histories containing only provider-native state now return a clear no-candidate result.
  * Unsupported compact Responses requests are rejected consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->