### PR TITLE
fix(ai-gateway): support per-model Codex tool configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 0.75.2 (2026-08-19)
+
+- Let an OpenAI-compatible Provider declare pinned Codex model tool configuration by model slug. Background Agent Jobs can now preserve a model's required shell, apply-patch, web-search, and tool-mode declarations instead of forcing every model to the same shell contract. This lets Responses models that require a function shell start normally while AIGateway keeps ownership of instructions, context, capabilities, and output limits.
+- Invalid tool fields or values reject the Provider configuration. When duplicate selectors disagree on one field, AIGateway omits that field from the model card.
+
 ## Version 0.75.1 (2026-08-19)
 
 - Fix DingTalk AI cards to use the platform's native `isFinalize` and `isError` state transitions instead of the unsupported `flowStatus` template variable. A completed interactive card now finishes through the same native protocol. Operators who followed the earlier setup guide must remove `flowStatus` and `flowStatusVar`, bind the `answer` Markdown component in each active state layout, and republish the template.

--- a/app/control_plane/lib/ankole/ai_gateway/codex_model_tool_config.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/codex_model_tool_config.ex
@@ -1,0 +1,109 @@
+defmodule Ankole.AIGateway.CodexModelToolConfig do
+  @moduledoc """
+  Validates Provider-owned Codex model tool configuration and resolves it by model slug.
+
+  AIGateway keeps the rest of the Codex model card under its own ownership.
+  Provider rows can change only fields that describe how the pinned Codex
+  client encodes model-visible tools.
+  """
+
+  alias Ankole.AIGateway.ProviderConfigs.Provider
+
+  @fields ~w(shell_type apply_patch_tool_type web_search_tool_type tool_mode)
+  @shell_types ~w(default local unified_exec disabled shell_command)
+  @apply_patch_tool_types [nil, "freeform"]
+  @web_search_tool_types ~w(text text_and_image)
+  @tool_modes [nil, "direct", "code_mode", "code_mode_only"]
+
+  @doc "Validates the model-slug configuration map stored on one Provider connection."
+  @spec validate_provider_configs(term()) :: :ok | {:error, term()}
+  def validate_provider_configs(configs) when is_map(configs) do
+    configs
+    |> Enum.sort_by(fn {model, _value} -> model end)
+    |> Enum.reduce_while(:ok, fn {model, value}, :ok ->
+      case validate_entry(model, value) do
+        :ok ->
+          {:cont, :ok}
+
+        {:error, reason} ->
+          {:halt, {:error, {:invalid_codex_model_tool_config, {model, reason}}}}
+      end
+    end)
+  end
+
+  def validate_provider_configs(_configs),
+    do: {:error, {:invalid_codex_model_tool_config, :expected_model_map}}
+
+  @doc "Returns the validated tool configuration for one Provider model."
+  @spec for_model(Provider.t(), String.t()) :: map()
+  def for_model(%Provider{connection_options: options}, model)
+      when is_map(options) and is_binary(model) do
+    options
+    |> Map.get("codex_model_tool_configs", %{})
+    |> case do
+      configs when is_map(configs) -> Map.get(configs, model)
+      _value -> nil
+    end
+    |> safe_config()
+  end
+
+  def for_model(_provider, _model), do: %{}
+
+  @doc "Keeps one valid tool configuration and drops every invalid configuration."
+  @spec safe_config(term()) :: map()
+  def safe_config(config) when is_map(config) do
+    case validate_config(config) do
+      :ok -> Map.take(config, @fields)
+      {:error, _reason} -> %{}
+    end
+  end
+
+  def safe_config(_config), do: %{}
+
+  defp validate_entry(model, config)
+       when is_binary(model) and model != "" and byte_size(model) <= 256 and is_map(config),
+       do: validate_config(config)
+
+  defp validate_entry(model, _config) when not is_binary(model) or model == "",
+    do: {:error, :invalid_model_slug}
+
+  defp validate_entry(model, _config) when byte_size(model) > 256,
+    do: {:error, :model_slug_too_long}
+
+  defp validate_entry(_model, _config), do: {:error, :expected_config_map}
+
+  defp validate_config(config) do
+    unknown_fields =
+      config
+      |> Map.keys()
+      |> Enum.reject(&(&1 in @fields))
+      |> Enum.map(fn
+        field when is_binary(field) -> field
+        field -> inspect(field)
+      end)
+      |> Enum.sort()
+
+    with [] <- unknown_fields,
+         :ok <- validate_value(config, "shell_type", @shell_types),
+         :ok <- validate_value(config, "apply_patch_tool_type", @apply_patch_tool_types),
+         :ok <- validate_value(config, "web_search_tool_type", @web_search_tool_types),
+         :ok <- validate_value(config, "tool_mode", @tool_modes) do
+      :ok
+    else
+      [_field | _fields] = fields -> {:error, {:unknown_fields, fields}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp validate_value(config, field, accepted) do
+    case Map.fetch(config, field) do
+      {:ok, value} ->
+        if value in accepted,
+          do: :ok,
+          else: {:error, {:invalid_field, field, value}}
+
+      :error ->
+        :ok
+    end
+  end
+end

--- a/app/control_plane/lib/ankole/ai_gateway/codex_models.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/codex_models.ex
@@ -18,7 +18,9 @@ defmodule Ankole.AIGateway.CodexModels do
   """
 
   alias Ankole.AIAgent.ModelProfiles
+  alias Ankole.AIGateway.CodexModelToolConfig
   alias Ankole.AIGateway.Models
+  alias Ankole.AIGateway.ProviderConfigs
 
   @tool_output_limit_tokens 10_000
 
@@ -49,26 +51,30 @@ defmodule Ankole.AIGateway.CodexModels do
     {:ok, %{"data" => entries}} = Models.list_models(subject_uid, subject_type)
 
     fallback_ref = vision_fallback_ref(subject_uid, subject_type)
+    providers_by_id = Map.new(ProviderConfigs.list_active_providers(), &{&1.provider_id, &1})
 
     candidates =
-      entry_model_candidates(entries, fallback_ref) ++
-        runtime_model_candidates(subject_uid, subject_type)
+      entry_model_candidates(entries, fallback_ref, providers_by_id) ++
+        runtime_model_candidates(subject_uid, subject_type, providers_by_id)
 
     {:ok,
      %{
        "models" =>
          candidates
-         |> intersect_duplicate_modalities()
-         |> Enum.map(fn {slug, modalities} -> card(slug, modalities) end)
+         |> merge_duplicate_candidates()
+         |> Enum.map(fn {slug, modalities, tool_config} ->
+           card(slug, modalities, tool_config)
+         end)
      }}
   end
 
   @doc """
   Builds one full model card for a selector slug.
   """
-  @spec card(String.t(), [String.t()]) :: map()
-  def card(slug, input_modalities) when is_binary(slug) and is_list(input_modalities) do
-    %{
+  @spec card(String.t(), [String.t()], map()) :: map()
+  def card(slug, input_modalities, model_tool_config \\ %{})
+      when is_binary(slug) and is_list(input_modalities) do
+    card = %{
       "slug" => slug,
       "display_name" => slug,
       "description" => nil,
@@ -105,14 +111,20 @@ defmodule Ankole.AIGateway.CodexModels do
       "supports_search_tool" => true,
       "use_responses_lite" => false
     }
+
+    Map.merge(card, CodexModelToolConfig.safe_config(model_tool_config))
   end
 
-  defp entry_model_candidates(entries, fallback_ref) do
+  defp entry_model_candidates(entries, fallback_ref, providers_by_id) do
     Enum.flat_map(entries, fn entry ->
       case Map.get(entry, "id") do
         slug when is_binary(slug) and slug != "" ->
           direct = get_in(entry, ["architecture", "input_modalities"]) || ["text"]
-          [{slug, effective_input_modalities(direct, fallback_ref)}]
+
+          [
+            {slug, effective_input_modalities(direct, fallback_ref),
+             selector_tool_config(Map.get(entry, "canonical_slug", slug), providers_by_id)}
+          ]
 
         _slug ->
           []
@@ -120,7 +132,7 @@ defmodule Ankole.AIGateway.CodexModels do
     end)
   end
 
-  defp runtime_model_candidates(agent_uid, "agent") do
+  defp runtime_model_candidates(agent_uid, "agent", providers_by_id) do
     case ModelProfiles.get_model_profiles(agent_uid) do
       {:ok, profiles} ->
         Enum.flat_map(profiles, fn {profile, attrs} ->
@@ -131,7 +143,8 @@ defmodule Ankole.AIGateway.CodexModels do
                provider_kind when is_binary(provider_kind) <- model_ref["provider_kind"] do
             [
               {codex_model_slug(provider_kind, model),
-               ModelProfiles.effective_input_modalities(model_ref)}
+               ModelProfiles.effective_input_modalities(model_ref),
+               model_ref_tool_config(model_ref, providers_by_id)}
             ]
           else
             _reason -> []
@@ -143,7 +156,7 @@ defmodule Ankole.AIGateway.CodexModels do
     end
   end
 
-  defp runtime_model_candidates(_subject_uid, _subject_type), do: []
+  defp runtime_model_candidates(_subject_uid, _subject_type, _providers_by_id), do: []
 
   defp vision_fallback_ref(agent_uid, "agent") do
     case ModelProfiles.resolve_runtime_model_ref(agent_uid, "vision_fallback") do
@@ -170,23 +183,70 @@ defmodule Ankole.AIGateway.CodexModels do
   defp maybe_put_fallback(model_ref, fallback_ref),
     do: Map.put(model_ref, "vision_fallback_model_ref", fallback_ref)
 
-  defp intersect_duplicate_modalities(candidates) do
-    {order, modalities_by_slug} =
-      Enum.reduce(candidates, {[], %{}}, fn {slug, modalities}, {order, by_slug} ->
-        modalities = MapSet.new(codex_input_modalities(modalities))
+  defp merge_duplicate_candidates(candidates) do
+    candidates
+    |> Enum.map(&elem(&1, 0))
+    |> Enum.uniq()
+    |> Enum.map(fn slug ->
+      duplicates = Enum.filter(candidates, &(elem(&1, 0) == slug))
 
-        case Map.fetch(by_slug, slug) do
-          {:ok, current} ->
-            {order, Map.put(by_slug, slug, MapSet.intersection(current, modalities))}
+      modalities =
+        duplicates
+        |> Enum.map(fn {_slug, modalities, _tool_config} ->
+          MapSet.new(codex_input_modalities(modalities))
+        end)
+        |> Enum.reduce(&MapSet.intersection/2)
+        |> MapSet.to_list()
 
-          :error ->
-            {order ++ [slug], Map.put(by_slug, slug, modalities)}
-        end
-      end)
-
-    Enum.map(order, fn slug ->
-      {slug, Map.fetch!(modalities_by_slug, slug) |> MapSet.to_list()}
+      {slug, modalities, common_tool_config(duplicates)}
     end)
+  end
+
+  defp common_tool_config(candidates) do
+    candidates
+    |> Enum.flat_map(fn {_slug, _modalities, tool_config} -> Map.keys(tool_config) end)
+    |> Enum.uniq()
+    |> Enum.reduce(%{}, fn field, common ->
+      values =
+        candidates
+        |> Enum.flat_map(fn {_slug, _modalities, tool_config} ->
+          if Map.has_key?(tool_config, field), do: [Map.fetch!(tool_config, field)], else: []
+        end)
+        |> Enum.uniq()
+
+      case values do
+        [value] -> Map.put(common, field, value)
+        _conflict -> common
+      end
+    end)
+  end
+
+  defp selector_tool_config(selector, providers_by_id) when is_binary(selector) do
+    case String.split(selector, "/", parts: 2) do
+      [provider_id, model] when provider_id != "" and model != "" ->
+        provider_tool_config(providers_by_id, provider_id, model)
+
+      _selector ->
+        %{}
+    end
+  end
+
+  defp selector_tool_config(_selector, _providers_by_id), do: %{}
+
+  defp model_ref_tool_config(
+         %{"provider_id" => provider_id, "model" => model},
+         providers_by_id
+       )
+       when is_binary(provider_id) and is_binary(model),
+       do: provider_tool_config(providers_by_id, provider_id, model)
+
+  defp model_ref_tool_config(_model_ref, _providers_by_id), do: %{}
+
+  defp provider_tool_config(providers_by_id, provider_id, model) do
+    case Map.fetch(providers_by_id, provider_id) do
+      {:ok, provider} -> CodexModelToolConfig.for_model(provider, model)
+      :error -> %{}
+    end
   end
 
   defp codex_input_modalities(modalities) do

--- a/app/control_plane/lib/ankole/ai_gateway/provider.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/provider.ex
@@ -18,5 +18,10 @@ defmodule Ankole.AIGateway.Provider do
   @callback prepare_connection_check(map()) ::
               {:ok, Ankole.AIGateway.ProviderConnectionCheck.t()} | {:error, term()}
 
-  @optional_callbacks models_metadata_source: 1, prepare_connection_check: 1
+  @doc "Validates semantic constraints across connection settings."
+  @callback validate_connection_options(map()) :: :ok | {:error, term()}
+
+  @optional_callbacks models_metadata_source: 1,
+                      prepare_connection_check: 1,
+                      validate_connection_options: 1
 end

--- a/app/control_plane/lib/ankole/ai_gateway/providers/openai_compatible.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/providers/openai_compatible.ex
@@ -5,6 +5,7 @@ defmodule Ankole.AIGateway.Providers.OpenAICompatible do
 
   use Ankole.AIGateway.ProviderDSL
 
+  alias Ankole.AIGateway.CodexModelToolConfig
   alias Ankole.AIGateway.OpenAIRequestOptions
   alias Ankole.AIGateway.ProviderConnectionCheck
   alias Ankole.AIGateway.Providers
@@ -29,6 +30,8 @@ defmodule Ankole.AIGateway.Providers.OpenAICompatible do
       advanced: true
     )
 
+    setting(:codex_model_tool_configs, type: :map, advanced: true)
+
     setting(:headers, type: :map, advanced: true)
     setting(:query_params, type: :map, advanced: true)
 
@@ -50,6 +53,14 @@ defmodule Ankole.AIGateway.Providers.OpenAICompatible do
       api_resolver(:openai_chat_completions)
       prepare(:prepare_language_model)
     end
+  end
+
+  @doc false
+  @impl true
+  def validate_connection_options(options) when is_map(options) do
+    options
+    |> Map.get("codex_model_tool_configs", %{})
+    |> CodexModelToolConfig.validate_provider_configs()
   end
 
   @doc """

--- a/app/control_plane/test/ankole/ai_gateway/codex_models_test.exs
+++ b/app/control_plane/test/ankole/ai_gateway/codex_models_test.exs
@@ -57,6 +57,24 @@ defmodule Ankole.AIGateway.CodexModelsTest do
              "Model-visible tool output is limited to 10000 tokens."
   end
 
+  test "card applies validated model tool config without replacing AIGateway-owned fields" do
+    card =
+      CodexModels.card("deepseek-v4-flash", ["text"], %{
+        "shell_type" => "shell_command",
+        "apply_patch_tool_type" => "freeform",
+        "web_search_tool_type" => "text",
+        "tool_mode" => "direct"
+      })
+
+    assert card["shell_type"] == "shell_command"
+    assert card["apply_patch_tool_type"] == "freeform"
+    assert card["web_search_tool_type"] == "text"
+    assert Map.has_key?(card, "tool_mode")
+    assert card["tool_mode"] == "direct"
+    assert card["truncation_policy"] == %{"mode" => "tokens", "limit" => 10_000}
+    assert card["model_messages"]["instructions_template"] == card["base_instructions"]
+  end
+
   test "cards keep the configured search tool on standard Responses" do
     for slug <- ~w(gpt-5.6-sol gpt-5.6-terra gpt-5.6-luna) do
       refute CodexModels.card(slug, ["text"])["use_responses_lite"]

--- a/app/control_plane/test/ankole/ai_gateway/provider_runtime_test.exs
+++ b/app/control_plane/test/ankole/ai_gateway/provider_runtime_test.exs
@@ -15,6 +15,7 @@ defmodule Ankole.AIGateway.ProviderRuntimeTest do
 
   alias Ankole.AIAgent.Library
   alias Ankole.AIGateway.CodexModels
+  alias Ankole.AIGateway.CodexModelToolConfig
   alias Ankole.AIGateway.CredentialPool
   alias Ankole.AIGateway.ModelMetadata.Cache, as: ModelMetadataCache
   alias Ankole.AIGateway.ProviderConfigs
@@ -100,6 +101,10 @@ defmodule Ankole.AIGateway.ProviderRuntimeTest do
       assert settings["upstream_transport"]["default"] == "sse"
     end
 
+    compatible_settings = Map.new(openai_compatible["settings"], &{&1["key"], &1})
+    assert compatible_settings["codex_model_tool_configs"]["type"] == "map"
+    assert compatible_settings["codex_model_tool_configs"]["scope"] == "connection"
+
     for provider <- [chatgpt_subscription, azure_openai, openai, openai_compatible] do
       service_tier = Map.new(provider["settings"], &{&1["key"], &1})["serviceTier"]
 
@@ -133,6 +138,82 @@ defmodule Ankole.AIGateway.ProviderRuntimeTest do
              Map.has_key?(label, "default") and Map.has_key?(label, "zh-Hans-CN") and
                not Map.has_key?(label, "en") and not Map.has_key?(label, "zh")
            end)
+  end
+
+  test "OpenAI-compatible provider Codex model tool config reaches the manifest by model slug" do
+    %{principal: agent} = agent_fixture()
+
+    assert {:ok, _provider} =
+             ProviderConfigs.create_provider(%{
+               provider_id: "deepseek-responses",
+               provider_kind: "openai_compatible",
+               base_url: "https://api.deepseek.com/v1",
+               connection_options: %{
+                 "endpoint_kind" => "responses",
+                 "codex_model_tool_configs" => %{
+                   "deepseek-v4-flash" => %{
+                     "shell_type" => "shell_command",
+                     "apply_patch_tool_type" => "freeform",
+                     "web_search_tool_type" => "text",
+                     "tool_mode" => "direct"
+                   }
+                 }
+               },
+               credential_pool: %{
+                 "entries" => [%{"label" => "Default", "api_key" => "sk-test"}]
+               }
+             })
+
+    assert {:ok, _profile} =
+             ModelProfiles.put_model_profile(agent.uid, "coding", %{
+               provider_id: "deepseek-responses",
+               model: "deepseek-v4-flash"
+             })
+
+    assert {:ok, %{"models" => models}} = CodexModels.manifest(agent.uid, "agent")
+    card = Enum.find(models, &(&1["slug"] == "deepseek-v4-flash"))
+
+    assert card["shell_type"] == "shell_command"
+    assert card["apply_patch_tool_type"] == "freeform"
+    assert card["web_search_tool_type"] == "text"
+    assert Map.has_key?(card, "tool_mode")
+    assert card["tool_mode"] == "direct"
+  end
+
+  test "OpenAI-compatible provider rejects unknown Codex model tool config fields" do
+    assert {:error,
+            {:invalid_codex_model_tool_config,
+             {"deepseek-v4-flash", {:unknown_fields, ["base_instructions"]}}}} =
+             ProviderConfigs.create_provider(%{
+               provider_id: "invalid-codex-tool-config",
+               provider_kind: "openai_compatible",
+               connection_options: %{
+                 "codex_model_tool_configs" => %{
+                   "deepseek-v4-flash" => %{"base_instructions" => "replace owner"}
+                 }
+               },
+               credential_pool: %{
+                 "entries" => [%{"label" => "Default", "api_key" => "sk-test"}]
+               }
+             })
+  end
+
+  test "Codex model tool config rejects a non-string model key without raising" do
+    model_key = {:deepseek, "v4-flash"}
+
+    assert {:error, {:invalid_codex_model_tool_config, {^model_key, :invalid_model_slug}}} =
+             CodexModelToolConfig.validate_provider_configs(%{model_key => %{}})
+  end
+
+  test "Codex model tool config rejects a non-string field key without raising" do
+    field_key = {:shell_type, :unexpected}
+
+    assert {:error,
+            {:invalid_codex_model_tool_config,
+             {"deepseek-v4-flash", {:unknown_fields, ["{:shell_type, :unexpected}"]}}}} =
+             CodexModelToolConfig.validate_provider_configs(%{
+               "deepseek-v4-flash" => %{field_key => "shell_command"}
+             })
   end
 
   test "provider kind rejects kebab-case ids" do

--- a/docs/design-docs/AIGateway.md
+++ b/docs/design-docs/AIGateway.md
@@ -113,6 +113,20 @@ the output, but a larger value does not raise the model-visible limit. The card
 instructions state the same limit. Codex processes larger output in code before
 it returns the result, or it writes that output to a Job Workspace file.
 
+The card keeps Provider-declared Codex model tool configuration for the
+selected model. For example, a model that declares
+`shell_type = shell_command` receives the pinned Codex function shell instead
+of the default custom exec grammar. The tool still executes in Agent Computer;
+the field changes only the model-visible declaration. Duplicate selectors keep
+a tool configuration field only when every Provider that declares that field
+agrees on its value.
+
+Agent Computer enables Codex Code Mode by default. A Provider whose endpoint
+does not accept the Code Mode custom `exec` tool also declares
+`tool_mode = direct`; this keeps the function shell model-visible without the
+Code Mode wrapper. Both fields belong to the pinned Codex model tool
+configuration.
+
 The binding also carries the direct modalities and the optional frozen vision
 fallback. AIGateway sends an image directly only when the selected model
 accepts it. For a text-only model, AIGateway makes one stateless request to the
@@ -181,6 +195,16 @@ contains:
 `provider_id` uses a lowercase slug. `provider_kind` uses lowercase snake case.
 The application checks each kind against built-in and active Plugin
 definitions.
+
+An OpenAI-compatible Provider can store `codex_model_tool_configs` in its
+connection options. The value is keyed by the upstream model slug. Each entry
+can declare `shell_type`, `apply_patch_tool_type`, `web_search_tool_type`, and
+`tool_mode` using values accepted by the pinned Codex client. AIGateway applies
+these fields to every matching Codex model card. It continues to own the card's
+instructions, context and output limits, modalities, search capability, and
+parallel-call capability. Unknown fields and invalid pinned values make the
+Provider configuration invalid. This is Codex model tool configuration, not a
+Provider request option, and it never reaches the upstream model endpoint.
 
 The pool has one row-level strategy and an ordered list of entries. Each stored
 entry contains `id`, `label`, `source`, `priority`, optional `disabled_at`, an


### PR DESCRIPTION
## Summary

- add validated `codex_model_tool_configs` to OpenAI-compatible Provider connections, keyed by upstream model slug
- merge only pinned Codex tool fields into AIGateway-owned model cards
- preserve only consistent declarations across duplicate model selectors and reject unknown or invalid configuration

## Why

Ankole currently emits the same default Codex shell contract for every model. Responses providers that require a function shell can therefore reject the first request before any tool runs.

This change keeps the fix provider-neutral: Providers declare model capabilities, while AIGateway continues to own instructions, context/output limits, modalities, and runtime capabilities. It does not add a DeepSeek adapter, request translation, or fallback.

For example, a Responses model that requires a function shell and direct tool mode can declare:

```json
{
  "codex_model_tool_configs": {
    "deepseek-v4-flash": {
      "shell_type": "shell_command",
      "tool_mode": "direct"
    }
  }
}
```

Closes #78

## Validation

- `mix test test/ankole/ai_gateway/codex_models_test.exs test/ankole/ai_gateway/provider_runtime_test.exs` — 35 passed
- `bun run --filter @ankole/control-plane type-check` — exit 0
- `mix format --check-formatted`
- `git diff --check origin/main...HEAD`
- Test environment: an equivalent pre-rename build completed Background Job 1045 on DeepSeek Responses with 195 tool calls; report publishing returned HTTP 200 and the Lark outbox succeeded on its first attempt

## Full-suite note

`bun run control-plane:test` was also attempted. Test-start plugin reconcilers lost the SQL Sandbox/Repo, after which 1,651 tests failed as a cascade (`could not lookup Ecto repo Ankole.Repo because it was not started`). The focused tests above pass independently after the final rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added provider-configurable Codex model tool settings, including shell, patch, web-search, and tool-mode options.
  - Model-specific settings now appear in Codex model listings and background jobs.
  - Duplicate model entries retain only settings consistently supported across providers.

- **Bug Fixes**
  - Invalid or unknown tool configuration values are rejected with validation errors.
  - Unsupported settings are safely excluded from model configurations.

- **Documentation**
  - Documented Codex tool configuration behavior and validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->