### PR TITLE
fix(schedule): allow Console manual cron runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.76.2 (2026-08-20)
+
+- The Console can run a recurring schedule immediately again. A valid `Idempotency-Key` no longer crashes request validation, and a repeated request still returns the same scheduled event.
+
 ## Version 0.76.1 (2026-08-19)
 
 - No product behavior changes. Agent Computer integration no longer expects the retired standalone compaction endpoint, and Schedule end-to-end coverage no longer declares an unused context, so the current compaction and scheduling contracts run without false failures or warnings.

--- a/app/control_plane/lib/ankole_web/controllers/schedule_controller.ex
+++ b/app/control_plane/lib/ankole_web/controllers/schedule_controller.ex
@@ -109,7 +109,7 @@ defmodule AnkoleWeb.ScheduleController do
           cron_schedule_id: [in: :path, type: :string, required: true],
           idempotency_key: [
             in: :header,
-            name: "Idempotency-Key",
+            name: :"Idempotency-Key",
             type: :string,
             required: true
           ]

--- a/app/control_plane/test/ankole_web/controllers/schedule_controller_test.exs
+++ b/app/control_plane/test/ankole_web/controllers/schedule_controller_test.exs
@@ -149,6 +149,31 @@ defmodule AnkoleWeb.ScheduleControllerTest do
            |> json_response(422)
   end
 
+  test "admin manually runs a cron schedule idempotently", %{conn: conn} do
+    %{principal: agent} = agent_fixture()
+    schedule = cron_schedule!(agent.uid, "session-a", "manual-digest")
+    api_spec = AnkoleWeb.APISpec.spec()
+    conn = bearer_conn(conn)
+
+    first =
+      conn
+      |> put_req_header("idempotency-key", "console-manual-digest")
+      |> post(~p"/api/v1/agents/#{agent.uid}/cron-schedules/#{schedule.id}/runs")
+      |> json_response(200)
+
+    assert_schema(first, "ScheduleEventResponse", api_spec)
+
+    repeated =
+      conn
+      |> recycle_bearer()
+      |> put_req_header("idempotency-key", "console-manual-digest")
+      |> post(~p"/api/v1/agents/#{agent.uid}/cron-schedules/#{schedule.id}/runs")
+      |> json_response(200)
+
+    assert get_in(repeated, ["schedule_event", "id"]) ==
+             get_in(first, ["schedule_event", "id"])
+  end
+
   test "admin lists and cancels checkbacks across every session of one agent", %{conn: conn} do
     %{principal: agent} = agent_fixture()
     %{principal: other_agent} = agent_fixture()


### PR DESCRIPTION
## Summary

- declare the Console manual-run `Idempotency-Key` parameter with the atom name expected by OpenApiSpex
- add a controller regression test that exercises the real HTTP validation path
- verify repeated requests with the same idempotency key return the same schedule event

## Root cause

The operation parameter override used a string for `name`. OpenApiSpex 3.22.3 treats ControllerSpecs parameter names as atoms while casting request parameters, so a valid header reached `Atom.to_string/1` as a string and raised before the schedule domain was called.

## Validation

- `mix test test/ankole_web/controllers/schedule_controller_test.exs` — 5 passed
- full Control Plane suite against a newly migrated isolated database — 2178 passed, 13 excluded
- `bun run type-check`
- `mix format --check-formatted ...`
- `mix ankole.openapi.check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored immediate execution for recurring schedules run from the Console.
  * Fixed validation of valid `Idempotency-Key` headers without causing errors.
  * Repeated requests with the same key continue to return the same result.

* **Documentation**
  * Added release notes for version 0.76.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->