### PR TITLE
fix: retry provider turns that end with a server_error code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.0.2-rc.7 (2026-09-07)
+
+- A turn that a provider ends with a `server_error` code, such as a Codex gateway relaying an OpenAI capacity overload, is now retried automatically instead of stopping with "自动重试已停止".
+
 ## Version 1.0.1-rc.7 (2026-09-06)
 
 - Text fields show the full lower strokes of letters such as g, j, p, q, and y with the bundled font.

--- a/app/control_plane/lib/ankole/ai_gateway/failure_diagnostics.ex
+++ b/app/control_plane/lib/ankole/ai_gateway/failure_diagnostics.ex
@@ -21,8 +21,11 @@ defmodule Ankole.AIGateway.FailureDiagnostics do
     websocket_read_failed websocket_send_failed
   )
   @legacy_provider_status_codes ~w(invalid_upstream_response upstream_response_failed)
+  # `server_error` is the code a Codex gateway substitutes for `server_is_overloaded`
+  # on a mid-stream capacity shed, which carries no HTTP status.
   @retryable_provider_codes ~w(
-    rate_limit rate_limited rate_limit_exceeded server_is_overloaded slow_down too_many_requests
+    rate_limit rate_limited rate_limit_exceeded server_error server_is_overloaded slow_down
+    too_many_requests
   )
   # Codex reads only the error code on a terminal Responses failure and treats
   # every code outside this vocabulary as retryable, so a permanent rejection

--- a/app/control_plane/test/ankole/ai_gateway/failure_diagnostics_test.exs
+++ b/app/control_plane/test/ankole/ai_gateway/failure_diagnostics_test.exs
@@ -340,7 +340,7 @@ defmodule Ankole.AIGateway.FailureDiagnosticsTest do
   end
 
   test "classifies Codex overload aliases as retryable provider failures" do
-    for code <- ["server_is_overloaded", "slow_down"] do
+    for code <- ["server_is_overloaded", "slow_down", "server_error"] do
       assert %{
                failure_kind: :provider_response,
                error_code: ^code,


### PR DESCRIPTION
## Summary

- OpenAI is capacity-shedding `gpt-6-astra` high/xhigh turns mid-stream: HTTP 200, then an `error` + `response.failed` frame with `code=server_is_overloaded` and no HTTP status, about one second after first output.
- codex2api (the `agentbull-llm` provider) rewrites that code to `server_error` before relaying, for Codex CLI's benefit. AIGateway's `FailureDiagnostics` lists `server_is_overloaded` as retryable but treated `server_error` without a status as non-retryable, so the worker skipped local retries and the control plane reported "自动重试已停止".
- `server_error` now joins `@retryable_provider_codes`, which also gives it `failure_kind: :provider_response` and warning severity like the other transient codes.

## Test plan

- [x] `mix test test/ankole/ai_gateway/failure_diagnostics_test.exs` (19 passed; overload-alias test now covers `server_error`)
- [x] `mix test test/ankole/ai_gateway test/ankole/signals_gateway` (1230 passed, 16 excluded)
- [x] `MIX_ENV=test mix compile --warnings-as-errors --no-all-warnings`
- [ ] Observe production `ai_gateway_messages` error share after deploy during the next overload window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rKXx5C9mtrn8zXCgpimSd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Automatic retries now continue when a turn ends with a `server_error`, including errors caused by temporary provider capacity limits.
  - These failures are classified as retryable provider responses rather than stopping with an “automatic retry stopped” message.

- **Documentation**
  - Added a changelog entry for Version 1.0.2-rc.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->