### PR TITLE
fix(signals-gateway,worker): retry provider capacity failures on a bounded ladder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 1.1.1-rc.1 (2026-09-10)
+
+- A message whose model call an upstream sheds for capacity now waits 30 seconds and then 2, 5, and 12.5 minutes before the Agent gives up, so a short provider overload no longer stops the message with "自动重试已停止". The Worker also stops repeating that model call three times before the first wait, and the automatic retry strategy never schedules more than 20 minutes of backoff.
+- A credential pool with no usable recovery time counts as an ordinary capacity failure: the Background Agent Job returns to the queue on the fixed Job ladder and the attempt charges the execution-failure budget.
+
 ## Version 1.1.0-rc.1 (2026-09-09)
 
 - An operator can now give each Agent a token quota in the Ankole Console: a period in days, a period start time, and a token limit. The Agent page shows the used tokens as a bar with the share of the limit, and the start and end time of the current period.

--- a/app/agent_computer/src/core/llm-error-classifier.ts
+++ b/app/agent_computer/src/core/llm-error-classifier.ts
@@ -22,6 +22,12 @@ export type LLMErrorKind =
   | 'timeout'
   | 'unknown'
 
+/**
+ * Failure classes whose recovery time is owned by the provider or the gateway, not by a local
+ * re-issue: the control plane schedules those on its capacity ladder.
+ */
+const NO_LOCAL_RETRY_KINDS = new Set<LLMErrorKind>(['rate_limit', 'server'])
+
 export interface LLMErrorClassification {
   kind: LLMErrorKind
   /** Safe to re-issue the same request as-is (transient transport/capacity failures). */
@@ -223,20 +229,22 @@ export function llmErrorCode(error: unknown): string | undefined {
   return findErrorProperty(error, ['code'], value => (typeof value === 'string' && value ? value : undefined))
 }
 
-/** Convenience predicate used on the retry hot path; equivalent to `classifyLLMError(error).retryable`. */
-export function isRetryableLLMError(error: unknown): boolean {
-  return classifyLLMError(error).retryable
-}
-
 /**
- * Local retries re-issue the request from inside the worker. A transport owner can use an explicit
- * local hint when only durable redelivery is safe.
+ * Local retries re-issue the request from inside the worker, at sub-second spacing. A transport
+ * owner can use an explicit local hint when only durable redelivery is safe.
+ *
+ * Provider-capacity failures are never retried here. A saturated upstream or a throttled token
+ * budget needs the control plane's minute-scale ladder, and the local attempts only spend the same
+ * outage window three times before control-plane redelivery even starts.
  */
 export function isLocallyRetryableLLMError(error: unknown): boolean {
-  if (!isRetryableLLMError(error)) return false
+  const { kind, retryable } = classifyLLMError(error)
+  if (!retryable) return false
 
   const hint = localRetryableHint(error)
-  return hint ?? true
+  if (hint !== undefined) return hint
+
+  return !NO_LOCAL_RETRY_KINDS.has(kind)
 }
 
 /**

--- a/app/agent_computer/src/core/pi-loop/stream-fn.ts
+++ b/app/agent_computer/src/core/pi-loop/stream-fn.ts
@@ -52,9 +52,12 @@ import type { PiTurnState, ToolCallWireMeta } from './turn-state'
 const PI_API = 'openai-responses'
 
 /**
- * Local attempts per model call, retried inside this Worker on transient
- * provider errors. The control plane redelivers a failed Turn up to its own
- * dead-letter count (`@worker_turn_error_dead_letter_attempts` in
+ * Local attempts per model call, retried inside this Worker at sub-second
+ * spacing. Only a failure that `isLocallyRetryableLLMError` accepts uses them;
+ * a provider-capacity failure (`server` or `rate_limit`) ends the call after
+ * one attempt and waits on the control plane's capacity ladder. The control
+ * plane redelivers a failed Turn up to its own dead-letter count
+ * (`@worker_turn_error_dead_letter_attempts` in
  * `app/control_plane/lib/ankole/signals_gateway/actor_runtime/turn_lifecycle.ex`),
  * so one actor event can cost this number x that count model calls.
  */

--- a/app/agent_computer/test/llm-error-classifier.test.ts
+++ b/app/agent_computer/test/llm-error-classifier.test.ts
@@ -77,6 +77,48 @@ describe('LLM error classification', () => {
     })
   })
 
+  it('decides local retries by hint, then by kind, and never for a non-retryable failure', () => {
+    expect(isLocallyRetryableLLMError({ code: 'invalid_prompt' })).toBe(false)
+
+    // A transport owner's explicit hint wins in both directions.
+    expect(
+      isLocallyRetryableLLMError(
+        Object.assign(new Error('AIGateway WebSocket closed before response.completed'), {
+          details: { local_retryable: false }
+        })
+      )
+    ).toBe(false)
+
+    expect(
+      isLocallyRetryableLLMError(
+        Object.assign(new Error('AIGateway response failed code=server_error Our servers are currently overloaded.'), {
+          details: { local_retryable: true }
+        })
+      )
+    ).toBe(true)
+
+    // Provider capacity belongs to the control plane's ladder, so the Worker
+    // spends no sub-second local attempts inside the same outage window.
+    for (const error of [
+      { code: 'server_error', message: 'Our servers are currently overloaded. Please try again later.' },
+      { status: 503, message: 'service unavailable' },
+      { status: 429, message: 'rate limited' }
+    ]) {
+      expect(classifyLLMError(error).retryable).toBe(true)
+      expect(isLocallyRetryableLLMError(error)).toBe(false)
+    }
+
+    // Everything else retryable keeps its three local attempts.
+    for (const error of [
+      new Error('stream disconnected before completion'),
+      new Error('read ECONNRESET'),
+      { code: 'upstream_stream_closed_before_terminal_event', message: 'stream closed' }
+    ]) {
+      expect(classifyLLMError(error)).toMatchObject({ kind: 'timeout', retryable: true })
+      expect(isLocallyRetryableLLMError(error)).toBe(true)
+    }
+  })
+
   it('follows wrapped provider cause chains and terminates cyclic graphs', () => {
     const cases: Array<{ error: unknown; kind: LLMErrorKind }> = [
       {

--- a/app/agent_computer/test/llm/websocket-retry.test.ts
+++ b/app/agent_computer/test/llm/websocket-retry.test.ts
@@ -154,8 +154,10 @@ describe('@ankole/agent-computer llm helpers: AIGateway WebSocket retry and over
     expect(sentPayloads).toHaveLength(3)
   })
 
-  it('retries retryable AIGateway WebSocket open errors in the agent loop', async () => {
+  it('hands a provider rate limit to the control plane instead of retrying it locally', async () => {
     const sentPayloads: JSONObject[] = []
+    const logs: Array<{ level: 'info' | 'warning'; event: string; fields?: JSONObject }> = []
+    let caught: unknown
     const model = createModel({
       apiKey: 'unused',
       baseURL: 'http://aigateway.invalid/api/v1/ai-gateway',
@@ -168,37 +170,18 @@ describe('@ankole/agent-computer llm helpers: AIGateway WebSocket retry and over
           fakeResponseSocket(init, data => {
             sentPayloads.push(JSON.parse(data) as JSONObject)
 
-            if (sentPayloads.length === 1) {
-              return [
-                {
-                  type: 'error',
-                  status: 429,
-                  error: {
-                    code: 'upstream_response_failed',
-                    message: 'provider rate limit',
-                    details_json: {
-                      stage: 'socket_open',
-                      upstream_status: 429,
-                      retryable: true
-                    }
-                  }
-                }
-              ]
-            }
-
             return [
               {
-                type: 'response.completed',
-                response: {
-                  id: 'resp_after_429',
-                  status: 'completed',
-                  output: [
-                    {
-                      type: 'message',
-                      role: 'assistant',
-                      content: [{ type: 'output_text', text: 'retried after 429' }]
-                    }
-                  ]
+                type: 'error',
+                status: 429,
+                error: {
+                  code: 'upstream_response_failed',
+                  message: 'provider rate limit',
+                  details_json: {
+                    stage: 'socket_open',
+                    upstream_status: 429,
+                    retryable: true
+                  }
                 }
               }
             ]
@@ -206,27 +189,45 @@ describe('@ankole/agent-computer llm helpers: AIGateway WebSocket retry and over
       }
     })
 
-    const final = await runAgentLoop({
-      model,
-      maxModelIterations: 1,
-      messages: [{ role: 'user', content: 'retry rate limit' }],
-      stateful: {
-        actorEventID: '00000000-0000-0000-0000-000000000006',
-        conversationID: '66666666-6666-6666-6666-666666666666'
-      }
-    })
+    try {
+      await runAgentLoop({
+        model,
+        maxModelIterations: 1,
+        messages: [{ role: 'user', content: 'retry rate limit' }],
+        stateful: {
+          actorEventID: '00000000-0000-0000-0000-000000000006',
+          conversationID: '66666666-6666-6666-6666-666666666666'
+        },
+        logger: {
+          info: (event, _message, fields) => logs.push({ level: 'info', event, fields }),
+          warning: (event, _message, fields) => logs.push({ level: 'warning', event, fields })
+        }
+      })
+    } catch (error) {
+      caught = error
+    }
 
-    expect(final.message.content).toEqual([{ type: 'text', text: 'retried after 429' }])
-    expect(sentPayloads).toHaveLength(2)
+    // AIGateway rotates its credential pool for a 429 and reports the pool as
+    // exhausted only when no usable credential remains, so the Worker issues one
+    // request and leaves the wait to the control plane's capacity ladder.
+    expect(caught).toBeInstanceOf(Error)
+    expect(sentPayloads).toHaveLength(1)
     expect(sentPayloads[0]).toMatchObject({
       store: true,
       conversation: 'conv_66666666-6666-6666-6666-666666666666'
     })
-    expect(sentPayloads[1]).toMatchObject({
-      store: true,
-      conversation: 'conv_66666666-6666-6666-6666-666666666666'
+
+    expect(logs.find(log => log.event === 'worker.model_call_failed')).toMatchObject({
+      level: 'warning',
+      fields: {
+        attempt: 1,
+        error_kind: 'rate_limit',
+        error_code: 'upstream_response_failed',
+        status: 429,
+        retryable: true,
+        will_retry: false
+      }
     })
-    expect(sentPayloads[1]!.previous_response_id).toBeUndefined()
   })
 
   it('retries a structured AIGateway WebSocket stale error in the agent loop', async () => {
@@ -297,6 +298,7 @@ describe('@ankole/agent-computer llm helpers: AIGateway WebSocket retry and over
   it('falls back to terminal status classification when retryable is absent', async () => {
     const sentPayloads: JSONObject[] = []
     const logs: Array<{ level: 'info' | 'warning'; event: string; fields?: JSONObject }> = []
+    let caught: unknown
     const model = createModel({
       apiKey: 'unused',
       baseURL: 'http://aigateway.invalid/api/v1/ai-gateway',
@@ -309,37 +311,18 @@ describe('@ankole/agent-computer llm helpers: AIGateway WebSocket retry and over
           fakeResponseSocket(init, data => {
             sentPayloads.push(JSON.parse(data) as JSONObject)
 
-            if (sentPayloads.length === 1) {
-              return [
-                {
-                  type: 'response.failed',
-                  response: {
-                    id: 'resp_failed_429',
-                    status: 'failed',
-                    error: {
-                      code: 'upstream_response_failed',
-                      provider_status: 429,
-                      message: 'transient upstream response failed'
-                    },
-                    output: []
-                  }
-                }
-              ]
-            }
-
             return [
               {
-                type: 'response.completed',
+                type: 'response.failed',
                 response: {
-                  id: 'resp_after_failed_429',
-                  status: 'completed',
-                  output: [
-                    {
-                      type: 'message',
-                      role: 'assistant',
-                      content: [{ type: 'output_text', text: 'retried after terminal 429' }]
-                    }
-                  ]
+                  id: 'resp_failed_429',
+                  status: 'failed',
+                  error: {
+                    code: 'upstream_response_failed',
+                    provider_status: 429,
+                    message: 'transient upstream response failed'
+                  },
+                  output: []
                 }
               }
             ]
@@ -347,34 +330,35 @@ describe('@ankole/agent-computer llm helpers: AIGateway WebSocket retry and over
       }
     })
 
-    const final = await runAgentLoop({
-      model,
-      maxModelIterations: 90,
-      messages: [{ role: 'user', content: 'retry terminal rate limit' }],
-      stateful: {
-        actorEventID: '00000000-0000-0000-0000-000000000007',
-        conversationID: '77777777-7777-7777-7777-777777777777'
-      },
-      logger: {
-        info: (event, _message, fields) => logs.push({ level: 'info', event, fields }),
-        warning: (event, _message, fields) => logs.push({ level: 'warning', event, fields })
-      }
-    })
+    try {
+      await runAgentLoop({
+        model,
+        maxModelIterations: 90,
+        messages: [{ role: 'user', content: 'retry terminal rate limit' }],
+        stateful: {
+          actorEventID: '00000000-0000-0000-0000-000000000007',
+          conversationID: '77777777-7777-7777-7777-777777777777'
+        },
+        logger: {
+          info: (event, _message, fields) => logs.push({ level: 'info', event, fields }),
+          warning: (event, _message, fields) => logs.push({ level: 'warning', event, fields })
+        }
+      })
+    } catch (error) {
+      caught = error
+    }
 
-    expect(final.message.content).toEqual([{ type: 'text', text: 'retried after terminal 429' }])
-    expect(sentPayloads).toHaveLength(2)
-    expect(sentPayloads[1]).toMatchObject({
+    // The gateway omitted `retryable`, so the Worker falls back to the provider
+    // status class. That class is provider capacity, which the control plane
+    // owns, so the Worker still issues exactly one request.
+    expect(caught).toBeInstanceOf(Error)
+    expect(sentPayloads).toHaveLength(1)
+    expect(sentPayloads[0]).toMatchObject({
       store: true,
       conversation: 'conv_77777777-7777-7777-7777-777777777777'
     })
 
-    expect(logs.map(log => log.event)).toEqual([
-      'worker.model_call_started',
-      'worker.model_call_failed',
-      'worker.model_call_started',
-      'worker.model_call_completed'
-    ])
-    expect(logs[1]).toMatchObject({
+    expect(logs.find(log => log.event === 'worker.model_call_failed')).toMatchObject({
       level: 'warning',
       fields: {
         actor_event_id: '00000000-0000-0000-0000-000000000007',
@@ -383,15 +367,7 @@ describe('@ankole/agent-computer llm helpers: AIGateway WebSocket retry and over
         error_code: 'upstream_response_failed',
         status: 429,
         retryable: true,
-        will_retry: true
-      }
-    })
-    expect(logs[3]).toMatchObject({
-      level: 'info',
-      fields: {
-        attempt: 2,
-        response_id: 'resp_after_failed_429',
-        stop_reason: 'stop'
+        will_retry: false
       }
     })
     expect(JSON.stringify(logs)).not.toContain('transient upstream response failed')

--- a/app/control_plane/lib/ankole/background_agent_jobs.ex
+++ b/app/control_plane/lib/ankole/background_agent_jobs.ex
@@ -19,23 +19,19 @@ defmodule Ankole.BackgroundAgentJobs do
   alias Ankole.BackgroundAgentJobs.TurnEvidence
   alias Ankole.BackgroundAgentJobs.Turns
   alias Ankole.BackgroundAgentJobs.TurnWatchdog
+  alias Ankole.SignalsGateway.ActorRuntime.TurnErrorClassifier
 
   @job_session_prefix "job:"
   @job_session_prefix_size byte_size(@job_session_prefix)
   @minimum_job_id 1000
   @maximum_job_id 9_007_199_254_740_991
-  # Provider-class failures keep the long ladder so the five-failure budget
-  # spans a realistic upstream outage window (about 3.7 hours). Infrastructure
-  # interruptions restart in seconds and never consume that budget, so they
-  # retry on the short ladder instead of holding the Job for hours.
+  # Provider-capacity and execution failures keep the long ladder so the
+  # five-failure budget spans a realistic upstream outage window (about 3.7
+  # hours). Infrastructure interruptions restart in seconds and never consume
+  # that budget, so they retry on the short ladder instead of holding the Job
+  # for hours.
   @turn_error_retry_seconds [60, 600, 1_800, 3_600, 7_200]
   @infrastructure_retry_seconds [15, 30, 60, 120, 300]
-  @infrastructure_error_codes ~w(
-    background_agent_job_runtime_exception
-    agent_codex_runtime_busy
-    background_agent_job_steer_delivery_failed
-    codex_app_server_request_timeout
-  )
 
   @doc """
   Builds the durable actor-session id for one BackgroundAgentJob.
@@ -92,8 +88,12 @@ defmodule Ankole.BackgroundAgentJobs do
   @spec turn_error_retry_at(map(), pos_integer(), DateTime.t()) :: DateTime.t()
   def turn_error_retry_at(reason, delivery_attempt_no, %DateTime{} = now)
       when is_map(reason) and is_integer(delivery_attempt_no) and delivery_attempt_no > 0 do
-    credential_pool_retry_at(reason, now) ||
-      DateTime.add(now, ladder_seconds(turn_error_class(reason), delivery_attempt_no), :second)
+    TurnErrorClassifier.credential_pool_retry_at(reason, now) ||
+      DateTime.add(
+        now,
+        ladder_seconds(TurnErrorClassifier.classify(reason), delivery_attempt_no),
+        :second
+      )
   end
 
   @doc false
@@ -142,29 +142,11 @@ defmodule Ankole.BackgroundAgentJobs do
     )
   end
 
-  defp ladder_seconds(:execution, delivery_attempt_no) do
+  defp ladder_seconds(_class, delivery_attempt_no) do
     Enum.at(
       @turn_error_retry_seconds,
       min(delivery_attempt_no, length(@turn_error_retry_seconds)) - 1
     )
-  end
-
-  # Splits worker turn failures into the two retry accounts. Infrastructure
-  # interruptions (runtime loss, the shared-runtime lock, steer transport) are
-  # not the task failing, so they never consume the execution-failure budget.
-  # Everything else, including provider and model failures, is an execution
-  # failure charged against the bounded budget.
-  @doc false
-  @spec turn_error_class(map()) :: :infrastructure | :execution
-  def turn_error_class(reason) when is_map(reason) do
-    details = reason["details_json"] || %{}
-
-    if reason["code"] in @infrastructure_error_codes or
-         details["error_code"] in @infrastructure_error_codes do
-      :infrastructure
-    else
-      :execution
-    end
   end
 
   @doc "Creates one durable work item and its isolated dispatch event atomically."
@@ -265,19 +247,9 @@ defmodule Ankole.BackgroundAgentJobs do
         } = reason,
         %DateTime{} = now
       ) do
-    with %DateTime{} <- credential_pool_retry_at(reason, now) || :invalid_retry_at,
-         {:ok, job_id} <- parse_job_session_id(session_id),
-         {:ok, job} <-
-           Lifecycle.requeue_credential_pool_exhausted_attempt_in_tx(
-             repo,
-             job_id,
-             agent_uid
-           ) do
-      {:ok, %{kind: :credential_pool_requeued, job: job}}
-    else
-      :invalid_retry_at -> {:ok, nil}
+    case parse_job_session_id(session_id) do
+      {:ok, job_id} -> compensate_credential_pool_exhaustion(repo, job_id, agent_uid, reason, now)
       :error -> {:ok, nil}
-      {:error, _reason} = error -> error
     end
   end
 
@@ -349,20 +321,8 @@ defmodule Ankole.BackgroundAgentJobs do
       )
       when is_map(reason) do
     case parse_job_session_id(session_id) do
-      {:ok, job_id} ->
-        case Lifecycle.requeue_retryable_attempt_in_tx(
-               repo,
-               job_id,
-               agent_uid,
-               charge: charged_turn_error?(reason)
-             ) do
-          {:ok, %Job{} = job} -> {:ok, %{kind: :retryable_requeued, job: job}}
-          {:ok, nil} -> {:ok, nil}
-          {:error, _reason} = error -> error
-        end
-
-      :error ->
-        {:ok, nil}
+      {:ok, job_id} -> requeue_retryable_attempt(repo, job_id, agent_uid, reason)
+      :error -> {:ok, nil}
     end
   end
 
@@ -376,6 +336,36 @@ defmodule Ankole.BackgroundAgentJobs do
          get_in(details, ["aigateway", "code"]) == "agent_token_quota_exceeded",
        do: "agent_token_quota_exceeded",
        else: code
+  end
+
+  # A declared pool recovery time is AIGateway backpressure, so the requeue
+  # keeps the claim and charges no execution-failure budget. A stale or missing
+  # time is an ordinary capacity failure: the Job returns to `queued` and this
+  # attempt charges the budget like any other provider-capacity failure.
+  defp compensate_credential_pool_exhaustion(repo, job_id, agent_uid, reason, now) do
+    case TurnErrorClassifier.credential_pool_retry_at(reason, now) do
+      %DateTime{} ->
+        case Lifecycle.requeue_credential_pool_exhausted_attempt_in_tx(repo, job_id, agent_uid) do
+          {:ok, job} -> {:ok, %{kind: :credential_pool_requeued, job: job}}
+          {:error, _reason} = error -> error
+        end
+
+      nil ->
+        requeue_retryable_attempt(repo, job_id, agent_uid, reason)
+    end
+  end
+
+  defp requeue_retryable_attempt(repo, job_id, agent_uid, reason) do
+    case Lifecycle.requeue_retryable_attempt_in_tx(
+           repo,
+           job_id,
+           agent_uid,
+           charge: charged_turn_error?(reason)
+         ) do
+      {:ok, %Job{} = job} -> {:ok, %{kind: :retryable_requeued, job: job}}
+      {:ok, nil} -> {:ok, nil}
+      {:error, _reason} = error -> error
+    end
   end
 
   defp text_value(value) when is_binary(value) and value != "", do: value
@@ -398,41 +388,11 @@ defmodule Ankole.BackgroundAgentJobs do
   defp successor_notice_line(_successor), do: nil
 
   # Context overflow is an automatic compact-and-retry recovery, not the task
-  # failing, so it consumes no execution-failure budget.
+  # failing, so it consumes no execution-failure budget. Every other
+  # non-infrastructure failure is charged, including a provider-capacity
+  # failure whose credential pool gave no usable recovery time.
   defp charged_turn_error?(%{"code" => "context_overflow"}), do: false
-  defp charged_turn_error?(reason), do: turn_error_class(reason) == :execution
-
-  defp credential_pool_retry_at(%{"details_json" => details}, now) when is_map(details) do
-    if credential_pool_exhausted_details?(details) do
-      details
-      |> pool_retry_at_value()
-      |> parse_pool_retry_at(now)
-    end
-  end
-
-  defp credential_pool_retry_at(_reason, _now), do: nil
-
-  defp credential_pool_exhausted_details?(details) do
-    details["error_code"] == "credential_pool_exhausted" or
-      get_in(details, ["aigateway", "code"]) == "credential_pool_exhausted"
-  end
-
-  defp pool_retry_at_value(details) do
-    details["retry_at"] ||
-      get_in(details, ["aigateway", "details_json", "retry_at"])
-  end
-
-  defp parse_pool_retry_at(retry_at, now) when is_binary(retry_at) do
-    case DateTime.from_iso8601(retry_at) do
-      {:ok, parsed, _offset} ->
-        if DateTime.compare(parsed, now) == :gt, do: parsed
-
-      _error ->
-        nil
-    end
-  end
-
-  defp parse_pool_retry_at(_retry_at, _now), do: nil
+  defp charged_turn_error?(reason), do: TurnErrorClassifier.classify(reason) != :infrastructure
 
   @doc false
   def finalize_turn_error(

--- a/app/control_plane/lib/ankole/signals_gateway/actor_runtime/turn_error_classifier.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/actor_runtime/turn_error_classifier.ex
@@ -1,0 +1,119 @@
+defmodule Ankole.SignalsGateway.ActorRuntime.TurnErrorClassifier do
+  @moduledoc false
+
+  # One Worker turn failure feeds every control-plane retry owner: the ordinary
+  # actor turn and the Background Agent Job. Each owner keeps its own waiting
+  # strategy, but they must agree on what the failure means, so the split lives
+  # here rather than in either owner.
+
+  @infrastructure_error_codes ~w(
+    background_agent_job_runtime_exception
+    agent_codex_runtime_busy
+    background_agent_job_steer_delivery_failed
+    codex_app_server_request_timeout
+  )
+  @provider_capacity_error_kinds ~w(server rate_limit)
+  @credential_pool_exhausted_code "credential_pool_exhausted"
+
+  @type class :: :infrastructure | :provider_capacity | :execution
+
+  @doc """
+  Returns the retry account for one Worker turn failure.
+
+  `:infrastructure` marks an interruption that is not the task failing, so it
+  never consumes a bounded failure budget. `:provider_capacity` marks a
+  retryable provider or credential-pool shortage, which each retry owner
+  schedules on its own capacity ladder. Everything else is an `:execution`
+  failure charged against the owner's failure budget.
+  """
+  @spec classify(map()) :: class()
+  def classify(reason) when is_map(reason) do
+    details = details(reason)
+
+    cond do
+      infrastructure_error?(reason, details) -> :infrastructure
+      provider_capacity?(reason, details) -> :provider_capacity
+      true -> :execution
+    end
+  end
+
+  @doc """
+  Reads the retryable conclusion the Worker recorded for one turn failure.
+
+  `details_json.retryable` is authoritative because the Worker already folds
+  the AIGateway hint into it. The nested AIGateway value is only a fallback for
+  a reason with no top-level field. An explicit `false` always wins, so a
+  failure the Worker called permanent is never scheduled as provider capacity.
+  """
+  @spec retryable?(map()) :: boolean()
+  def retryable?(reason) when is_map(reason) do
+    case details(reason) do
+      %{"retryable" => true} ->
+        true
+
+      %{"retryable" => false} ->
+        false
+
+      details ->
+        get_in(details, ["aigateway", "details_json", "retryable"]) == true
+    end
+  end
+
+  def retryable?(_reason), do: false
+
+  @doc """
+  Returns the credential pool recovery time when the failure carries a valid
+  `retry_at` in the future.
+
+  A missing, unparseable, or already elapsed time returns `nil`, which sends
+  the failure back to the owner's ordinary capacity ladder.
+  """
+  @spec credential_pool_retry_at(map(), DateTime.t()) :: DateTime.t() | nil
+  def credential_pool_retry_at(reason, %DateTime{} = now) when is_map(reason) do
+    details = details(reason)
+
+    if credential_pool_exhausted?(details) do
+      details
+      |> pool_retry_at()
+      |> parse_future_datetime(now)
+    end
+  end
+
+  def credential_pool_retry_at(_reason, %DateTime{}), do: nil
+
+  defp details(%{"details_json" => details}) when is_map(details), do: details
+  defp details(_reason), do: %{}
+
+  defp infrastructure_error?(reason, details) do
+    reason["code"] in @infrastructure_error_codes or
+      details["error_code"] in @infrastructure_error_codes
+  end
+
+  defp provider_capacity?(reason, details) do
+    retryable?(reason) and
+      (details["llm_error_kind"] in @provider_capacity_error_kinds or
+         credential_pool_exhausted?(details))
+  end
+
+  defp credential_pool_exhausted?(details) do
+    details["error_code"] == @credential_pool_exhausted_code or
+      get_in(details, ["aigateway", "code"]) == @credential_pool_exhausted_code
+  end
+
+  defp pool_retry_at(details) do
+    details["retry_at"] ||
+      get_in(details, ["aigateway", "details_json", "retry_at"])
+  end
+
+  defp parse_future_datetime(retry_at, now) when is_binary(retry_at) do
+    case DateTime.from_iso8601(retry_at) do
+      {:ok, parsed, _offset} ->
+        if DateTime.compare(parsed, now) == :gt, do: parsed
+
+      _error ->
+        nil
+    end
+  end
+
+  defp parse_future_datetime(_retry_at, _now), do: nil
+end

--- a/app/control_plane/lib/ankole/signals_gateway/actor_runtime/turn_lifecycle.ex
+++ b/app/control_plane/lib/ankole/signals_gateway/actor_runtime/turn_lifecycle.ex
@@ -19,6 +19,7 @@ defmodule Ankole.SignalsGateway.ActorRuntime.TurnLifecycle do
   alias Ankole.SignalsGateway.ActorRuntime.TurnEnvelope
   alias Ankole.SignalsGateway.ActorRuntime.TurnRuntimeEnv
   alias Ankole.SignalsGateway.ActorRuntime.TurnStartFailure
+  alias Ankole.SignalsGateway.ActorRuntime.TurnErrorClassifier
   alias Ankole.SignalsGateway.ActorRuntime.TurnRef
   alias Ankole.SignalsGateway.ActorRuntime.Transport.Broker
   alias Ankole.SignalsGateway.ActorRuntime.WorkerAdmission
@@ -37,10 +38,10 @@ defmodule Ankole.SignalsGateway.ActorRuntime.TurnLifecycle do
   @activation_progress_lease_seconds 2_100
   # Prevent scheduler delay from expiring an activation at its exact deadline.
   @activation_lease_grace_seconds 120
-  # Stop retry loops after repeated recoverable Worker failures. Each delivery
-  # attempt lets the Worker retry one model call locally
-  # (`app/agent_computer/src/core/pi-loop/stream-fn.ts`), so one actor event
-  # can cost local attempts x this delivery count model calls before it
+  # Stop retry loops after repeated recoverable Worker failures. A non-capacity
+  # delivery attempt also lets the Worker retry one model call locally
+  # (`app/agent_computer/src/core/pi-loop/stream-fn.ts`), so one actor event can
+  # cost local attempts x this delivery count model calls before it
   # dead-letters.
   @worker_turn_error_dead_letter_attempts 5
   # Give a transient Worker failure a short recovery window before redispatch.
@@ -48,6 +49,11 @@ defmodule Ankole.SignalsGateway.ActorRuntime.TurnLifecycle do
   # Prevent repeated Worker failures from increasing one retry delay without
   # limit.
   @worker_turn_error_retry_max_seconds 120
+  # A provider-capacity failure needs a longer window than a transient Worker
+  # failure: the upstream must recover, and the Worker no longer retries this
+  # class locally. Four waits carry the five-delivery budget, so the automatic
+  # retry strategy never schedules more than 20 minutes of backoff.
+  @worker_turn_error_capacity_ladder_seconds [30, 120, 300, 750]
 
   @type actor_key :: %{agent_uid: String.t(), session_id: String.t()}
 
@@ -408,7 +414,7 @@ defmodule Ankole.SignalsGateway.ActorRuntime.TurnLifecycle do
     with :ok <- TurnRef.match(rows, turn_ref, :abort),
          {:ok, event} <- maybe_mark_overflow_retry(repo, event, reason),
          dead_letter? =
-           dead_letter_after_turn_error?(event, deliveries, reason, async_work_unit),
+           dead_letter_after_turn_error?(event, deliveries, reason, now, async_work_unit),
          {:ok, event} <- maybe_mark_event_dead_letter(repo, event, dead_letter?, reason, now),
          {:ok, event} <-
            maybe_delay_retryable_turn_error(
@@ -1001,6 +1007,7 @@ defmodule Ankole.SignalsGateway.ActorRuntime.TurnLifecycle do
          %ActorEvent{} = event,
          _deliveries,
          reason,
+         _now,
          async_work_unit
        )
        when is_atom(async_work_unit) and not is_nil(async_work_unit) do
@@ -1015,14 +1022,16 @@ defmodule Ankole.SignalsGateway.ActorRuntime.TurnLifecycle do
          %ActorEvent{},
          deliveries,
          reason,
+         now,
          nil
        ) do
     not recoverable_turn_error?(reason) or
-      max_delivery_attempt_no(deliveries) >= @worker_turn_error_dead_letter_attempts
+      max_delivery_attempt_no(deliveries) >= @worker_turn_error_dead_letter_attempts or
+      capacity_retry_at_beyond_ladder?(deliveries, reason, now)
   end
 
   defp recoverable_turn_error?(reason),
-    do: retryable_turn_error?(reason) or overflow_turn_error?(reason)
+    do: TurnErrorClassifier.retryable?(reason) or overflow_turn_error?(reason)
 
   defp maybe_mark_event_dead_letter(repo, %ActorEvent{} = event, true, reason, now) do
     Actors.mark_event_dead_letter_in_tx(repo, event, now, reason)
@@ -1137,7 +1146,7 @@ defmodule Ankole.SignalsGateway.ActorRuntime.TurnLifecycle do
          false,
          async_work_unit
        ) do
-    if retryable_turn_error?(reason) do
+    if TurnErrorClassifier.retryable?(reason) do
       retry_available_at =
         turn_error_retry_at(deliveries, reason, now, async_work_unit)
 
@@ -1155,23 +1164,55 @@ defmodule Ankole.SignalsGateway.ActorRuntime.TurnLifecycle do
 
   defp retry_available_at(_event), do: nil
 
-  defp retryable_turn_error?(%{"details_json" => details}) when is_map(details) do
-    details["retryable"] == true or
-      get_in(details, ["aigateway", "details_json", "retryable"]) == true
-  end
-
-  defp retryable_turn_error?(_reason), do: false
-
   defp turn_error_retry_at(deliveries, reason, now, async_work_unit)
        when is_atom(async_work_unit) and not is_nil(async_work_unit) do
     attempt_no = max(max_delivery_attempt_no(deliveries), 1)
     async_work_unit.turn_error_retry_at(reason, attempt_no, now)
   end
 
-  defp turn_error_retry_at(deliveries, _reason, now, nil) do
+  defp turn_error_retry_at(deliveries, reason, now, nil) do
     attempt_no = max(max_delivery_attempt_no(deliveries), 1)
-    exponential = round(@worker_turn_error_retry_base_seconds * :math.pow(2, attempt_no - 1))
-    DateTime.add(now, min(exponential, @worker_turn_error_retry_max_seconds), :second)
+
+    case TurnErrorClassifier.classify(reason) do
+      :provider_capacity ->
+        DateTime.add(now, capacity_ladder_seconds(attempt_no), :second)
+
+      _other_class ->
+        exponential = round(@worker_turn_error_retry_base_seconds * :math.pow(2, attempt_no - 1))
+        DateTime.add(now, min(exponential, @worker_turn_error_retry_max_seconds), :second)
+    end
+  end
+
+  # The class is read again at every delivery, so a failure that changes class
+  # between deliveries uses the current class and the current attempt number
+  # instead of resetting or accumulating an earlier schedule.
+  defp capacity_ladder_seconds(attempt_no) do
+    Enum.at(
+      @worker_turn_error_capacity_ladder_seconds,
+      min(attempt_no, length(@worker_turn_error_capacity_ladder_seconds)) - 1
+    )
+  end
+
+  # A credential pool that names a recovery time past every wait this event has
+  # left cannot be reached inside the delivery budget, so the event dead-letters
+  # now instead of spending its remaining deliveries on a known-failing window.
+  # The pool time never schedules a wait: a short recovery time is covered by
+  # the ordinary ladder, at the cost of at most one wasted delivery.
+  defp capacity_retry_at_beyond_ladder?(deliveries, reason, now) do
+    with :provider_capacity <- TurnErrorClassifier.classify(reason),
+         %DateTime{} = retry_at <- TurnErrorClassifier.credential_pool_retry_at(reason, now) do
+      attempt_no = max(max_delivery_attempt_no(deliveries), 1)
+      remaining = remaining_capacity_ladder_seconds(attempt_no)
+      DateTime.compare(retry_at, DateTime.add(now, remaining, :second)) == :gt
+    else
+      _no_pool_recovery_time -> false
+    end
+  end
+
+  defp remaining_capacity_ladder_seconds(attempt_no) do
+    @worker_turn_error_capacity_ladder_seconds
+    |> Enum.drop(attempt_no - 1)
+    |> Enum.sum()
   end
 
   defp max_delivery_attempt_no(deliveries) do

--- a/app/control_plane/test/ankole/background_agent_jobs_test.exs
+++ b/app/control_plane/test/ankole/background_agent_jobs_test.exs
@@ -13,6 +13,7 @@ defmodule Ankole.BackgroundAgentJobsTest do
   alias Ankole.BackgroundAgentJobs.Schemas.TurnItem
   alias Ankole.BackgroundAgentJobs.Turns
   alias Ankole.Repo
+  alias Ankole.SignalsGateway.ActorRuntime.TurnErrorClassifier
 
   require Ankole.BackgroundAgentJobs
 
@@ -2755,7 +2756,7 @@ defmodule Ankole.BackgroundAgentJobsTest do
   end
 
   describe "turn error accounting" do
-    test "infrastructure failures use the short ladder and provider failures keep the long one" do
+    test "infrastructure failures use the short ladder and capacity failures the long one" do
       now = DateTime.utc_now(:microsecond)
 
       infrastructure = %{
@@ -2767,10 +2768,23 @@ defmodule Ankole.BackgroundAgentJobsTest do
         }
       }
 
-      provider = %{
+      capacity = %{
         "code" => "worker_turn_failed",
-        "message" => "upstream failed",
-        "details_json" => %{"error_code" => "codex_job_transient", "retryable" => true}
+        "message" => "upstream shed the stream",
+        "details_json" => %{
+          "error_code" => "server_error",
+          "llm_error_kind" => "server",
+          "retryable" => true
+        }
+      }
+
+      execution = %{
+        "code" => "worker_turn_failed",
+        "message" => "job turn persistence failed",
+        "details_json" => %{
+          "error_code" => "background_agent_job_turn_persistence_failed",
+          "retryable" => true
+        }
       }
 
       app_server_timeout = %{
@@ -2782,7 +2796,9 @@ defmodule Ankole.BackgroundAgentJobsTest do
         }
       }
 
-      assert BackgroundAgentJobs.turn_error_class(app_server_timeout) == :infrastructure
+      assert TurnErrorClassifier.classify(app_server_timeout) == :infrastructure
+      assert TurnErrorClassifier.classify(capacity) == :provider_capacity
+      assert TurnErrorClassifier.classify(execution) == :execution
 
       assert DateTime.diff(BackgroundAgentJobs.turn_error_retry_at(infrastructure, 1, now), now) ==
                15
@@ -2795,10 +2811,29 @@ defmodule Ankole.BackgroundAgentJobsTest do
       assert DateTime.diff(BackgroundAgentJobs.turn_error_retry_at(infrastructure, 5, now), now) ==
                300
 
-      assert DateTime.diff(BackgroundAgentJobs.turn_error_retry_at(provider, 1, now), now) == 60
+      for reason <- [capacity, execution] do
+        assert DateTime.diff(BackgroundAgentJobs.turn_error_retry_at(reason, 1, now), now) == 60
 
-      assert DateTime.diff(BackgroundAgentJobs.turn_error_retry_at(provider, 5, now), now) ==
-               7_200
+        assert DateTime.diff(BackgroundAgentJobs.turn_error_retry_at(reason, 5, now), now) ==
+                 7_200
+      end
+    end
+
+    test "a credential pool recovery time replaces the Job ladder" do
+      now = DateTime.utc_now(:microsecond)
+      pool_retry_at = DateTime.add(now, 3_600, :second)
+
+      reason = %{
+        "code" => "worker_turn_failed",
+        "message" => "pool exhausted",
+        "details_json" => %{
+          "error_code" => "credential_pool_exhausted",
+          "retryable" => true,
+          "retry_at" => DateTime.to_iso8601(pool_retry_at)
+        }
+      }
+
+      assert BackgroundAgentJobs.turn_error_retry_at(reason, 1, now) == pool_retry_at
     end
   end
 

--- a/app/control_plane/test/ankole/signals_gateway/actor_runtime/actor_turn_completion_test.exs
+++ b/app/control_plane/test/ankole/signals_gateway/actor_runtime/actor_turn_completion_test.exs
@@ -672,6 +672,132 @@ defmodule Ankole.SignalsGateway.ActorRuntime.ActorTurnCompletionTest do
       assert is_nil(Repo.get!(ActorEvent, event.id).completed_at)
     end
 
+    test "schedules the provider capacity ladder across the five-delivery budget" do
+      failure_time = DateTime.utc_now(:microsecond)
+
+      for {attempt_no, expected_delay} <- [{1, 30}, {2, 120}, {3, 300}, {4, 750}] do
+        %{event: event, turn_ref: turn_ref} =
+          start_accepted_turn("capacity-ladder-#{attempt_no}")
+
+        seed_delivery_attempt!(event, attempt_no)
+
+        assert {:ok, result} =
+                 fail_turn(
+                   turn_ref,
+                   "worker_turn_failed",
+                   "AIGateway response failed code=server_error Our servers are currently overloaded.",
+                   %{
+                     "error_code" => "server_error",
+                     "llm_error_kind" => "server",
+                     "retryable" => true
+                   },
+                   now: failure_time
+                 )
+
+        refute result.dead_lettered?
+        assert result.status == :turn_failed
+        assert result.retry_available_at == DateTime.add(failure_time, expected_delay, :second)
+        assert Repo.get!(ActorEvent, event.id).input_state == "open"
+      end
+    end
+
+    test "dead-letters the fifth provider capacity delivery" do
+      %{event: event, turn_ref: turn_ref} = start_accepted_turn("capacity-exhausted")
+      seed_delivery_attempt!(event, 5)
+
+      assert {:ok, result} =
+               fail_turn(
+                 turn_ref,
+                 "worker_turn_failed",
+                 "AIGateway response failed code=server_error Our servers are currently overloaded.",
+                 %{
+                   "error_code" => "server_error",
+                   "llm_error_kind" => "server",
+                   "retryable" => true
+                 },
+                 now: DateTime.utc_now(:microsecond)
+               )
+
+      assert result.dead_lettered?
+      assert result.status == :turn_dead_lettered
+      assert Repo.get!(ActorEvent, event.id).input_state == "dead_letter"
+    end
+
+    test "dead-letters at once when the pool recovery time outlasts the remaining ladder" do
+      %{event: event, turn_ref: turn_ref} = start_accepted_turn("capacity-pool-beyond-ladder")
+      seed_delivery_attempt!(event, 1)
+      failure_time = DateTime.utc_now(:microsecond)
+      beyond_ladder = DateTime.add(failure_time, 1_201, :second)
+
+      assert {:ok, result} =
+               fail_turn(
+                 turn_ref,
+                 "worker_turn_failed",
+                 "AIGateway credential pool exhausted.",
+                 %{
+                   "error_code" => "credential_pool_exhausted",
+                   "retryable" => true,
+                   "retry_at" => DateTime.to_iso8601(beyond_ladder)
+                 },
+                 now: failure_time
+               )
+
+      assert result.dead_lettered?
+      assert result.status == :turn_dead_lettered
+      assert Repo.get!(ActorEvent, event.id).input_state == "dead_letter"
+    end
+
+    test "keeps the ladder wait for a pool recovery time the budget still reaches" do
+      %{event: event, turn_ref: turn_ref} = start_accepted_turn("capacity-pool-within-ladder")
+      seed_delivery_attempt!(event, 1)
+      failure_time = DateTime.utc_now(:microsecond)
+      within_ladder = DateTime.add(failure_time, 1_200, :second)
+
+      assert {:ok, result} =
+               fail_turn(
+                 turn_ref,
+                 "worker_turn_failed",
+                 "AIGateway credential pool exhausted.",
+                 %{
+                   "error_code" => "credential_pool_exhausted",
+                   "retryable" => true,
+                   "retry_at" => DateTime.to_iso8601(within_ladder)
+                 },
+                 now: failure_time
+               )
+
+      refute result.dead_lettered?
+      assert result.retry_available_at == DateTime.add(failure_time, 30, :second)
+      assert Repo.get!(ActorEvent, event.id).input_state == "open"
+    end
+
+    test "keeps the exponential backoff for a retryable non-capacity failure" do
+      failure_time = DateTime.utc_now(:microsecond)
+
+      for {attempt_no, expected_delay} <- [{1, 5}, {2, 10}, {3, 20}, {4, 40}] do
+        %{event: event, turn_ref: turn_ref} =
+          start_accepted_turn("transient-ladder-#{attempt_no}")
+
+        seed_delivery_attempt!(event, attempt_no)
+
+        assert {:ok, result} =
+                 fail_turn(
+                   turn_ref,
+                   "worker_turn_failed",
+                   "AIGateway response failed code=upstream_stream_closed_before_terminal_event",
+                   %{
+                     "error_code" => "upstream_stream_closed_before_terminal_event",
+                     "llm_error_kind" => "timeout",
+                     "retryable" => true
+                   },
+                   now: failure_time
+                 )
+
+        refute result.dead_lettered?
+        assert result.retry_available_at == DateTime.add(failure_time, expected_delay, :second)
+      end
+    end
+
     test "completion RPC subsumes turn acceptance when its task runs first" do
       %{agent: agent, event: event, turn_ref: turn_ref, route: route} =
         start_sent_turn("completion-before-acceptance")
@@ -1355,6 +1481,15 @@ defmodule Ankole.SignalsGateway.ActorRuntime.ActorTurnCompletionTest do
              ActorRuntime.handle_turn_accepted(turn_accepted_payload(result.turn_ref))
 
     result
+  end
+
+  # The delivery ledger compacts to the current row per actor event, so one live
+  # row carrying a seeded attempt number is exactly what the control plane sees
+  # after that many redeliveries.
+  defp seed_delivery_attempt!(event, attempt_no) do
+    Repo.get_by!(ActorEventDelivery, actor_event_id: event.id)
+    |> ActorEventDelivery.changeset(%{attempt_no: attempt_no})
+    |> Repo.update!()
   end
 
   defp start_sent_turn(suffix) do

--- a/app/control_plane/test/ankole/signals_gateway/actor_runtime/background_agent_job_dispatch_test.exs
+++ b/app/control_plane/test/ankole/signals_gateway/actor_runtime/background_agent_job_dispatch_test.exs
@@ -1537,7 +1537,12 @@ defmodule Ankole.SignalsGateway.ActorRuntime.BackgroundAgentJobDispatchTest do
     failure_time = DateTime.add(ready_at, 1, :second)
     expected_retry_at = DateTime.add(failure_time, 60, :second)
 
-    assert {:ok, result} =
+    assert {:ok,
+            %{
+              status: :background_agent_job_requeued,
+              retry_available_at: ^expected_retry_at,
+              background_agent_job_requeue: %{kind: :retryable_requeued, job: requeued}
+            }} =
              fail_turn(
                turn_ref,
                "worker_turn_failed",
@@ -1549,13 +1554,11 @@ defmodule Ankole.SignalsGateway.ActorRuntime.BackgroundAgentJobDispatchTest do
                now: failure_time
              )
 
-    assert result.status == :turn_failed
-    assert result.retry_available_at == expected_retry_at
-    refute Map.has_key?(result, :turn_error_compensation)
-
-    persisted = BackgroundAgentJobs.get_job_for_agent(job.id, agent.uid)
-    assert persisted.status == "running"
-    assert persisted.attempts == 1
+    # Without a recovery time the pool is an ordinary capacity failure: the Job
+    # returns to `queued` and this attempt charges the execution-failure budget.
+    assert requeued.status == "queued"
+    assert requeued.attempts == 1
+    assert requeued.execution_failures == 1
 
     persisted_event = Repo.get!(Ankole.SignalsGateway.ActorEvent, turn_ref.actor_event_id)
     assert persisted_event.input_state == "open"
@@ -1585,7 +1588,12 @@ defmodule Ankole.SignalsGateway.ActorRuntime.BackgroundAgentJobDispatchTest do
     expired_retry_at = DateTime.add(failure_time, -1, :second)
     expected_retry_at = DateTime.add(failure_time, 60, :second)
 
-    assert {:ok, result} =
+    assert {:ok,
+            %{
+              status: :background_agent_job_requeued,
+              retry_available_at: ^expected_retry_at,
+              background_agent_job_requeue: %{kind: :retryable_requeued, job: requeued}
+            }} =
              fail_turn(
                turn_ref,
                "worker_turn_failed",
@@ -1598,13 +1606,9 @@ defmodule Ankole.SignalsGateway.ActorRuntime.BackgroundAgentJobDispatchTest do
                now: failure_time
              )
 
-    assert result.status == :turn_failed
-    assert result.retry_available_at == expected_retry_at
-    refute Map.has_key?(result, :turn_error_compensation)
-
-    persisted = BackgroundAgentJobs.get_job_for_agent(job.id, agent.uid)
-    assert persisted.status == "running"
-    assert persisted.attempts == 1
+    assert requeued.status == "queued"
+    assert requeued.attempts == 1
+    assert requeued.execution_failures == 1
 
     persisted_event = Repo.get!(Ankole.SignalsGateway.ActorEvent, turn_ref.actor_event_id)
     assert persisted_event.input_state == "open"

--- a/app/control_plane/test/ankole/signals_gateway/actor_runtime/turn_error_classifier_test.exs
+++ b/app/control_plane/test/ankole/signals_gateway/actor_runtime/turn_error_classifier_test.exs
@@ -1,0 +1,155 @@
+defmodule Ankole.SignalsGateway.ActorRuntime.TurnErrorClassifierTest do
+  use ExUnit.Case, async: true
+
+  alias Ankole.SignalsGateway.ActorRuntime.TurnErrorClassifier
+
+  @now ~U[2026-09-10 10:00:00.000000Z]
+
+  describe "classify/1" do
+    test "reads infrastructure error codes from the top level and from the details" do
+      for code <- [
+            "background_agent_job_runtime_exception",
+            "agent_codex_runtime_busy",
+            "background_agent_job_steer_delivery_failed",
+            "codex_app_server_request_timeout"
+          ] do
+        assert TurnErrorClassifier.classify(reason(code)) == :infrastructure
+
+        assert TurnErrorClassifier.classify(reason("worker_turn_failed", %{"error_code" => code})) ==
+                 :infrastructure
+      end
+    end
+
+    test "marks a retryable provider or credential pool shortage as provider capacity" do
+      for kind <- ["server", "rate_limit"] do
+        assert TurnErrorClassifier.classify(
+                 reason("worker_turn_failed", %{"llm_error_kind" => kind, "retryable" => true})
+               ) == :provider_capacity
+      end
+
+      assert TurnErrorClassifier.classify(
+               reason("worker_turn_failed", %{
+                 "error_code" => "credential_pool_exhausted",
+                 "retryable" => true
+               })
+             ) == :provider_capacity
+
+      assert TurnErrorClassifier.classify(
+               reason("worker_turn_failed", %{
+                 "retryable" => true,
+                 "aigateway" => %{"code" => "credential_pool_exhausted"}
+               })
+             ) == :provider_capacity
+    end
+
+    test "keeps a permanent failure and every other failure on the execution account" do
+      permanent = %{"llm_error_kind" => "server", "retryable" => false}
+      assert TurnErrorClassifier.classify(reason("worker_turn_failed", permanent)) == :execution
+
+      # A capacity kind without the Worker's retryable conclusion is not enough:
+      # the control plane must not schedule what the Worker called permanent.
+      assert TurnErrorClassifier.classify(
+               reason("worker_turn_failed", %{"llm_error_kind" => "server"})
+             ) == :execution
+
+      for details <- [
+            %{"llm_error_kind" => "overflow"},
+            %{"llm_error_kind" => "auth"},
+            %{"error_code" => "server_error"},
+            %{}
+          ] do
+        assert TurnErrorClassifier.classify(reason("worker_turn_failed", details)) == :execution
+      end
+
+      assert TurnErrorClassifier.classify(%{"code" => "worker_turn_failed"}) == :execution
+    end
+
+    test "puts an infrastructure interruption ahead of a provider capacity signal" do
+      assert TurnErrorClassifier.classify(
+               reason("worker_turn_failed", %{
+                 "error_code" => "codex_app_server_request_timeout",
+                 "llm_error_kind" => "server",
+                 "retryable" => true
+               })
+             ) == :infrastructure
+    end
+  end
+
+  describe "retryable?/1" do
+    test "treats the top-level Worker conclusion as authoritative" do
+      assert TurnErrorClassifier.retryable?(
+               reason("worker_turn_failed", %{
+                 "retryable" => true,
+                 "aigateway" => %{"details_json" => %{"retryable" => false}}
+               })
+             )
+
+      refute TurnErrorClassifier.retryable?(
+               reason("worker_turn_failed", %{
+                 "retryable" => false,
+                 "aigateway" => %{"details_json" => %{"retryable" => true}}
+               })
+             )
+    end
+
+    test "reads the nested AIGateway conclusion only when the top level is missing" do
+      assert TurnErrorClassifier.retryable?(
+               reason("worker_turn_failed", %{
+                 "aigateway" => %{"details_json" => %{"retryable" => true}}
+               })
+             )
+
+      refute TurnErrorClassifier.retryable?(
+               reason("worker_turn_failed", %{"aigateway" => %{"code" => "server_error"}})
+             )
+
+      refute TurnErrorClassifier.retryable?(reason("worker_turn_failed"))
+      refute TurnErrorClassifier.retryable?(%{"code" => "worker_turn_failed"})
+    end
+  end
+
+  describe "credential_pool_retry_at/2" do
+    test "returns only a parseable pool recovery time in the future" do
+      future = DateTime.add(@now, 60, :second)
+
+      assert TurnErrorClassifier.credential_pool_retry_at(pool_reason(future), @now) == future
+
+      assert TurnErrorClassifier.credential_pool_retry_at(
+               pool_reason(DateTime.add(@now, -1, :second)),
+               @now
+             ) == nil
+
+      assert TurnErrorClassifier.credential_pool_retry_at(pool_reason(nil), @now) == nil
+      assert TurnErrorClassifier.credential_pool_retry_at(pool_reason("not-a-time"), @now) == nil
+    end
+
+    test "ignores a recovery time that no pool exhaustion declared" do
+      future = DateTime.add(@now, 60, :second)
+
+      assert TurnErrorClassifier.credential_pool_retry_at(
+               reason("worker_turn_failed", %{
+                 "retryable" => true,
+                 "retry_at" => DateTime.to_iso8601(future)
+               }),
+               @now
+             ) == nil
+    end
+  end
+
+  defp pool_reason(retry_at) do
+    details = %{"error_code" => "credential_pool_exhausted", "retryable" => true}
+
+    details =
+      case retry_at do
+        nil -> details
+        %DateTime{} = value -> Map.put(details, "retry_at", DateTime.to_iso8601(value))
+        value -> Map.put(details, "retry_at", value)
+      end
+
+    reason("worker_turn_failed", details)
+  end
+
+  defp reason(code, details \\ %{}) do
+    %{"code" => code, "message" => "worker turn failed", "details_json" => details}
+  end
+end

--- a/docs/design-docs/BackgroundAgentJob.md
+++ b/docs/design-docs/BackgroundAgentJob.md
@@ -643,9 +643,18 @@ lease.
 A placement failure returns an unstarted attempt to `queued`.
 
 A retryable worker failure waits before the next execution attempt.
-Infrastructure interruptions retry within minutes, while provider-class failures
-use a ladder that spans hours so a Job survives an upstream outage. Other actor
-events keep a short exponential backoff, because a user waits on them.
+Infrastructure interruptions retry within minutes and never consume the
+execution-failure budget, while provider-capacity failures and other execution
+failures use a ladder that spans hours so a Job survives an upstream outage. The
+control plane classifies the failure once for every retry owner. A
+provider-capacity failure is a retryable failure whose kind is `server` or
+`rate_limit`, or a credential pool exhaustion. The `details_json.retryable`
+value is authoritative over the nested AIGateway value, and an explicit `false`
+is never provider capacity. The ordinary actor Turn reads the same
+classification but keeps its own shorter ladder, because a user waits on it.
+
+Context overflow consumes no execution-failure budget, because that path
+compacts the context and retries instead of failing the task.
 
 A Provider status that rejects the request itself is terminal for the Job.
 Agent Computer reads that status before Codex stream-disconnect wording, so a
@@ -661,8 +670,10 @@ the worker and moves the Job only when that worker is gone.
 
 AIGateway quota exhaustion with a known future recovery time returns the Job
 to `queued` and releases its Worker assignment until that time. The acquired
-execution attempt stays consumed. A stale or missing recovery time uses the
-fixed Job retry ladder instead of immediate dispatch.
+execution attempt stays consumed and the attempt charges no execution-failure
+budget. A stale or missing recovery time is an ordinary provider-capacity
+failure: the Job returns to `queued` on the fixed Job retry ladder and the
+attempt charges the execution-failure budget.
 
 An Agent [token quota](AgentTokenQuota.md) rejection is terminal for the Job.
 Creation and admission do not check the quota; the first rejected request ends

--- a/docs/design-docs/SignalsGateway.md
+++ b/docs/design-docs/SignalsGateway.md
@@ -485,6 +485,34 @@ successor under the same session key.
 A Worker `actor_turn.abort` leaves the ActorEvent open. ActorRuntime tries again
 and invalidates the old turn fence.
 
+The failure decides the wait. ActorRuntime reads one shared classification of
+the Worker turn failure: an infrastructure interruption (a lost runtime, the
+shared-runtime lock, or a failed steer delivery) is not the task failing, a
+retryable provider-capacity failure schedules on the capacity ladder, and every
+other failure is an execution failure. A provider-capacity failure is a
+retryable failure whose kind is `server` or `rate_limit`, or a credential pool
+exhaustion. The Worker records the retryable conclusion for a failed turn, and
+that top-level value is authoritative; the nested AIGateway value is only a
+fallback when the top level is absent.
+
+An ordinary Turn waits 30, 120, 300, and then 750 seconds for a
+provider-capacity failure, using the delivery attempt number that the delivery
+ledger keeps across compaction and restarts. The Worker does not retry that
+class locally, because a saturated upstream needs a minute-scale wait rather
+than three sub-second re-issues inside the same outage window. A transient
+Worker failure keeps the shorter exponential wait that starts at 5 seconds and
+stops growing at 120 seconds. A failure that changes class between deliveries
+uses its current class and current attempt number, so no earlier schedule is
+reset or accumulated.
+
+For an ordinary Turn, a credential pool recovery time never schedules a wait.
+When that time is later than every wait this event has left, the Turn
+dead-letters at once instead of spending its remaining deliveries on a
+known-failing window; a shorter time costs at most one wasted delivery. An
+ordinary Turn admits at most five deliveries, so the automatic retry strategy
+schedules no more than 20 minutes of backoff. Execution time, queueing, and
+control-plane downtime are outside that budget.
+
 `/llm` creates `command.llm_help`. ActorRuntime returns localized usage plus
 the current Agent's custom model names and descriptions. This command does not
 start a worker Turn, interrupt live work, or supersede a pending interaction.


### PR DESCRIPTION
A provider capacity failure is retryable, but an ordinary Actor turn waited on a five-second exponential ladder that dies after about 75 seconds, while a Background Agent Job used a ladder that spans hours. One upstream overload therefore dead-lettered user messages, hourly scans, and job completion notices while the Job path rode the same outage out.

One control-plane module now owns the retry class, and provider capacity gets a bounded ladder:

- Add `TurnErrorClassifier` under the actor runtime as the single owner of `:infrastructure`, `:provider_capacity`, and `:execution`. It owns the infrastructure code table, the authoritative `details_json.retryable` read with the nested AIGateway value as a fallback, and the structured credential-pool `retry_at` reader.
- An ordinary Turn waits 30, 120, 300, and then 750 seconds for a provider capacity failure, keyed by the persisted delivery attempt number. The five-delivery budget is unchanged, so the automatic retry strategy schedules at most 20 minutes of backoff. Every other retryable failure keeps the five-second exponential ladder.
- The Worker stops re-issuing `server` and `rate_limit` failures locally, because three sub-second attempts only spend the same outage window. An explicit `local_retryable` hint still wins in both directions, and `timeout` and the other classes keep their three local attempts.
- Background Agent Jobs keep both ladders unchanged. Charging is now anything that is not an infrastructure interruption, with the two existing exceptions: context overflow is not charged, and a credential pool exhaustion with a valid future `retry_at` keeps the claim, releases the Worker assignment, and charges nothing. A stale or missing recovery time becomes an ordinary capacity failure, which is what the Background Agent Job design document already described.
- For an ordinary Turn, a credential pool recovery time never schedules a wait: it dead-letters the event at once when it outlasts the remaining ladder, and a shorter time costs at most one wasted delivery. A Job still schedules its next attempt at that time.

Both design documents and the single `1.1.1-rc.1` changelog entry describe this behavior. The control plane and the Worker are best updated together, because only the new Worker leaves the wait to the control plane ladder; an old Worker keeps its extra local attempts but is not broken.

## Validation

- Control-plane tests for the shared classifier, the ordinary turn ladder, and both Job retry owners: 169 passed. Full `mix test`: 2816/2821.
- Worker `bun run test`: 691 passed, including the local retry decision order.
- `MIX_ENV=test mix compile --warnings-as-errors --no-all-warnings`, `bun run lint` in both packages, and `git diff --check`: passed.
- The full control-plane `bun run lint` still stops on existing formatting errors in five unchanged files: `setup_controller.ex`, `universal_ai_request_test.exs`, `agent_computer_worker_controller_test.exs`, `control_plane_plugin_controller_test.exs`, and `worker_file_controller_test.exs`.
- The five `mix test` failures also fail on a pristine `upstream/main` in this environment, so they are unrelated to this change: a stale row in the local test database (`ConsoleReadinessControllerTest`), a Postgres `item_pointer_is_valid(ctid)` assertion (`RecallRerankTest`), and three schedule-validation tests that upstream added.

One gap stays open on purpose: a capacity failure that arrives only as a `provider_error_type` (`service_unavailable_error`, `server_error`, `overloaded_error`) with no code, no HTTP status, and no capacity wording in the message still classifies as `unknown` in the Worker, so it takes the execution path instead of the capacity ladder.