### PR TITLE
fix(office): stop rejecting the installed OfficeCLI version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.1.2-rc.1 (2026-09-10)
+
+- Word, Excel, and PowerPoint jobs use the OfficeCLI installed in the Worker image. An older version reference in a Skill no longer stops file work when the installed CLI and its format help run successfully.
+
 ## Version 1.1.1-rc.1 (2026-09-10)
 
 - A message whose model call an upstream sheds for capacity now waits 30 seconds and then 2, 5, and 12.5 minutes before the Agent gives up, so a short provider overload no longer stops the message with "自动重试已停止". The Worker also stops repeating that model call three times before the first wait, and the automatic retry strategy never schedules more than 20 minutes of backoff.

--- a/app/library/agent-plugins/office/skills/docx/SKILL.md
+++ b/app/library/agent-plugins/office/skills/docx/SKILL.md
@@ -16,7 +16,7 @@ For visual styling, use `design-md` when the user requests the internal design s
 
 ## Setup
 
-Ankole Agent Computer images install OfficeCLI 1.0.144 at build time. Run `officecli --version` and require the exact output `1.0.144`. A missing command or a different version means the Worker image and this Skill disagree; stop and report that the Worker image must be rebuilt.
+The Worker image build installs OfficeCLI and checks its version. Run `officecli --version` and `officecli help docx`. If both commands succeed, continue with the installed CLI. Version numbers in upstream references and known-issue notes are not runtime requirements. If either command fails, report the command and error as the runtime blocker. Worker image maintenance happens outside the Job.
 
 ## Playbooks
 

--- a/app/library/agent-plugins/office/skills/docx/THIRD-PARTY-NOTICES.txt
+++ b/app/library/agent-plugins/office/skills/docx/THIRD-PARTY-NOTICES.txt
@@ -14,7 +14,7 @@ Imported source files:
 
 Modifications:
 - Copied upstream SKILL.md content first, then changed Ankole-local frontmatter names so the skill name matches its installed directory.
-- Replaced self-install setup instructions with Ankole Agent Computer preinstalled-runtime notes.
+- Replaced self-install setup and exact-version checks with the installed Worker runtime and its help.
 - Added Playbook routing; the upstream scene-layer skills live in ../../playbooks with their own notices.
 - Aligned the adapted guidance with OfficeCLI 1.0.144.
 

--- a/app/library/agent-plugins/office/skills/pptx/SKILL.md
+++ b/app/library/agent-plugins/office/skills/pptx/SKILL.md
@@ -107,13 +107,7 @@ For replication, analyze the reference images to estimate element positions, fon
 
 ## OfficeCLI Runtime
 
-Ankole Agent Computer images install OfficeCLI 1.0.144 at build time. Verify the exact runtime:
-
-```bash
-officecli --version
-```
-
-Require the exact output `1.0.144`. A missing command or a different version means the Worker image and this Skill disagree; a rebuild happens outside this Job, so report the stale runtime as the Job outcome.
+The Worker image build installs OfficeCLI and checks its version. Run `officecli --version` and `officecli help pptx`. If both commands succeed, continue with the installed CLI. Version numbers in upstream references and known-issue notes are not runtime requirements. If either command fails, report the command and error as the runtime blocker. Worker image maintenance happens outside the Job.
 
 ### Gotchas
 

--- a/app/library/agent-plugins/office/skills/pptx/THIRD-PARTY-NOTICES.txt
+++ b/app/library/agent-plugins/office/skills/pptx/THIRD-PARTY-NOTICES.txt
@@ -17,7 +17,7 @@ Imported source files:
 
 Modifications:
 - Kept OfficeCLI as the file-operation runtime.
-- Replaced self-install setup instructions with Ankole Agent Computer runtime notes.
+- Replaced self-install setup and exact-version checks with the installed Worker runtime and its help.
 - Added Playbook routing and Ankole-local frontmatter.
 - Reduced the command catalog to a help-first operating guide.
 - Aligned the adapted guidance with OfficeCLI 1.0.144.

--- a/app/library/agent-plugins/office/skills/xlsx/SKILL.md
+++ b/app/library/agent-plugins/office/skills/xlsx/SKILL.md
@@ -16,7 +16,7 @@ For visual styling, use `design-md` when the user requests the internal design s
 
 ## Setup
 
-Ankole Agent Computer images install OfficeCLI 1.0.144 at build time. Run `officecli --version` and require the exact output `1.0.144`. A missing command or a different version means the Worker image and this Skill disagree; stop and report that the Worker image must be rebuilt.
+The Worker image build installs OfficeCLI and checks its version. Run `officecli --version` and `officecli help xlsx`. If both commands succeed, continue with the installed CLI. Version numbers in upstream references and known-issue notes are not runtime requirements. If either command fails, report the command and error as the runtime blocker. Worker image maintenance happens outside the Job.
 
 ## Playbooks
 

--- a/app/library/agent-plugins/office/skills/xlsx/THIRD-PARTY-NOTICES.txt
+++ b/app/library/agent-plugins/office/skills/xlsx/THIRD-PARTY-NOTICES.txt
@@ -14,7 +14,7 @@ Imported source files:
 
 Modifications:
 - Copied upstream SKILL.md content first, then changed Ankole-local frontmatter names so the skill name matches its installed directory.
-- Replaced self-install setup instructions with Ankole Agent Computer preinstalled-runtime notes.
+- Replaced self-install setup and exact-version checks with the installed Worker runtime and its help.
 - Added Playbook routing; the upstream scene-layer skills live in ../../playbooks with their own notices.
 - Aligned the adapted guidance with OfficeCLI 1.0.144 and added the verified import persistence fence.
 


### PR DESCRIPTION
Office jobs stop before reading or creating files because the DOCX, PPTX, and XLSX Skills require exactly OfficeCLI 1.0.144, while the Worker image installs 1.0.147. The Skills now check that the installed CLI and its format help run successfully, then proceed with file work. The image build still owns the pinned version and its exact check; command failures and artifact validation still block delivery.

Source references and known-issue notes retain their version history. The change adds changelog version 1.1.2-rc.1.

Validation:
- The old Skill instructions reproduced the version refusal. The updated instructions allow 1.0.147 and keep failures for a missing CLI or failed format help.
- The official OfficeCLI 1.0.147 binary in a disposable local Worker container passed DOCX, PPTX, and XLSX creation, close, fresh content reads, and structural validation.
- Skill metadata, changelog parsing, and `git diff --check origin/main...HEAD` passed after rebasing onto current main. The Office Skill changes are identical to the reviewed and smoke-tested version.

The full production BackgroundAgentJob flow has not been tested. Deployment must update the Worker Skill files; a Job with old instructions must load the Skills again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Word, Excel, and PowerPoint jobs now use the OfficeCLI available in the Worker environment without requiring an exact version.
  * File processing continues when the installed CLI and the relevant format help command run successfully.
  * When runtime checks fail, the specific failing command and error are reported as the blocker.

* **Documentation**
  * Updated OfficeCLI setup guidance and third-party notices to reflect the installed runtime workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->